### PR TITLE
Optional physics features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ ign_find_package(ignition-physics1
     mesh
     sdf
   REQUIRED
-  VERSION 1.6)
+  VERSION 1.7)
 set(IGN_PHYSICS_VER ${ignition-physics1_VERSION_MAJOR})
 
 #--------------------------------------

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -293,8 +293,11 @@ void DiffDrivePrivate::UpdateOdometry(const ignition::gazebo::UpdateInfo &_info,
       this->rightJoints[0]);
 
   // Abort if the joints were not found or just created.
-  if (!leftPos || !rightPos)
+  if (!leftPos || !rightPos || leftPos->Data().empty() ||
+      rightPos->Data().empty())
+  {
     return;
+  }
 
   this->odom.Update(leftPos->Data()[0], rightPos->Data()[0],
       std::chrono::steady_clock::time_point(_info.simTime));

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -120,11 +120,11 @@ namespace components = ignition::gazebo::components;
 // Private data class.
 class ignition::gazebo::systems::PhysicsPrivate
 {
+  /// \brief This is the minimum set of features that any physics engine must
+  /// implement to be supported by this system.
+  /// New features can't be added to this list in minor / patch releases, in
+  /// order to maintain backwards compatibility with downstream physics plugins.
   public: using MinimumFeatureList = ignition::physics::FeatureList<
-          ignition::physics::AttachFixedJointFeature,
-          ignition::physics::DetachJointFeature,
-          ignition::physics::SetJointTransformFromParentFeature,
-          // FreeGroup
           ignition::physics::FindFreeGroupFeature,
           ignition::physics::SetFreeGroupWorldPose,
           ignition::physics::FreeGroupFrameSemantics,
@@ -134,12 +134,9 @@ class ignition::gazebo::systems::PhysicsPrivate
           ignition::physics::GetEntities,
           ignition::physics::GetContactsFromLastStepFeature,
           ignition::physics::RemoveEntities,
-          ignition::physics::mesh::AttachMeshShapeFeature,
           ignition::physics::GetBasicJointProperties,
           ignition::physics::GetBasicJointState,
           ignition::physics::SetBasicJointState,
-          ignition::physics::SetJointVelocityCommandFeature,
-          ignition::physics::GetModelBoundingBox,
           ignition::physics::sdf::ConstructSdfCollision,
           ignition::physics::sdf::ConstructSdfJoint,
           ignition::physics::sdf::ConstructSdfLink,
@@ -147,28 +144,35 @@ class ignition::gazebo::systems::PhysicsPrivate
           ignition::physics::sdf::ConstructSdfWorld
           >;
 
-
+  /// \brief Engine type with just the minimum features.
   public: using EnginePtrType = ignition::physics::EnginePtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief World type with just the minimum features. Non-pointer.
   public: using WorldType = ignition::physics::World<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief World type with just the minimum features.
   public: using WorldPtrType = ignition::physics::WorldPtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief Model type with just the minimum features.
   public: using ModelPtrType = ignition::physics::ModelPtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief Link type with just the minimum features.
   public: using LinkPtrType = ignition::physics::LinkPtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief Shape type with just the minimum features.
   public: using ShapePtrType = ignition::physics::ShapePtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief Joint type with just the minimum features.
   public: using JointPtrType = ignition::physics::JointPtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
+  /// \brief Free group type with just the minimum features.
   public: using FreeGroupPtrType = ignition::physics::FreeGroupPtr<
             ignition::physics::FeaturePolicy3d, MinimumFeatureList>;
 
@@ -266,6 +270,95 @@ class ignition::gazebo::systems::PhysicsPrivate
 
   /// \brief Environment variable which holds paths to look for engine plugins
   public: std::string pluginPathEnv = "IGN_GAZEBO_PHYSICS_ENGINE_PATH";
+
+  //////////////////////////////////////////////////
+  // Detachable joints
+
+  /// \brief Feature list to process `DetachableJoint` components.
+  public: using DetachableJointFeatureList = physics::FeatureList<
+            MinimumFeatureList,
+            physics::AttachFixedJointFeature,
+            physics::DetachJointFeature,
+            physics::SetJointTransformFromParentFeature>;
+
+  /// \brief Joint type with detachable joint features.
+  public: using JointDetachableJointPtrType = physics::JointPtr<
+            physics::FeaturePolicy3d, DetachableJointFeatureList>;
+
+  /// \brief Link type with detachable joint features (links to attach to).
+  public: using LinkDetachableJointPtrType = physics::LinkPtr<
+            physics::FeaturePolicy3d, DetachableJointFeatureList>;
+
+  /// \brief A map between joint entity ids in the ECM to Joint Entities in
+  /// ign-physics, with detach feature.
+  /// All joints on this map are also in `entityJointMap`. The difference is
+  /// that here they've been casted for `physics::DetachJointFeature`.
+  public: std::unordered_map<Entity, JointDetachableJointPtrType>
+      entityJointDetachableJointMap;
+
+  /// \brief A map between link entity ids in the ECM to Link Entities in
+  /// ign-physics, with attach feature.
+  /// All links on this map are also in `entityLinkMap`. The difference is
+  /// that here they've been casted for `DetachableJointFeatureList`.
+  public: std::unordered_map<Entity, LinkDetachableJointPtrType>
+      entityLinkDetachableJointMap;
+
+  //////////////////////////////////////////////////
+  // Bounding box
+
+  /// \brief Feature list for model bounding box.
+  public: using BoundingBoxFeatureList = physics::FeatureList<
+            physics::GetModelBoundingBox>;
+
+  /// \brief Model type with bounding box feature.
+  public: using ModelBoundingBoxPtrType = physics::ModelPtr<
+            physics::FeaturePolicy3d, BoundingBoxFeatureList>;
+
+  /// \brief A map between model entity ids in the ECM to Model Entities in
+  /// ign-physics, with bounding box feature.
+  /// All models on this map are also in `entityModelMap`. The difference is
+  /// that here they've been casted for `BoundingBoxFeatureList`.
+  public: std::unordered_map<Entity, ModelBoundingBoxPtrType>
+      entityModelBoundingBoxMap;
+
+  //////////////////////////////////////////////////
+  // Joint velocity command
+
+  /// \brief Feature list for set joint velocity command.
+  public: using JointVelocityCommandFeatureList = physics::FeatureList<
+            physics::SetJointVelocityCommandFeature>;
+
+  /// \brief Joint type with set joint velocity command.
+  public: using JointVelocityCommandPtrType = physics::JointPtr<
+            physics::FeaturePolicy3d, JointVelocityCommandFeatureList>;
+
+  /// \brief A map between joint entity ids in the ECM to Joint Entities in
+  /// ign-physics, with velocity command feature.
+  /// All joints on this map are also in `entityJointMap`. The difference is
+  /// that here they've been casted for `JointVelocityCommandFeatureList`.
+  public: std::unordered_map<Entity, JointVelocityCommandPtrType>
+      entityJointVelocityCommandMap;
+
+  //////////////////////////////////////////////////
+  // Meshes
+
+  /// \brief Feature list for meshes.
+  /// Include MinimumFeatureList so created collision can be automatically
+  /// up-cast.
+  public: using MeshFeatureList = physics::FeatureList<
+            MinimumFeatureList,
+            physics::mesh::AttachMeshShapeFeature>;
+
+  /// \brief Link type with meshes.
+  public: using LinkMeshPtrType = physics::LinkPtr<
+            physics::FeaturePolicy3d, MeshFeatureList>;
+
+  /// \brief A map between link entity ids in the ECM to Link Entities in
+  /// ign-physics, with mesh feature.
+  /// All links on this map are also in `entityLinkMap`. The difference is
+  /// that here they've been casted for `MeshFeatureList`.
+  public: std::unordered_map<Entity, LinkMeshPtrType>
+      entityLinkMeshMap;
 };
 
 //////////////////////////////////////////////////
@@ -603,9 +696,19 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
             return true;
           }
 
-          collisionPtrPhys = linkPtrPhys->AttachMeshShape(_name->Data(), *mesh,
-              ignition::math::eigen3::convert(_pose->Data()),
-              ignition::math::eigen3::convert(meshSdf->Scale()));
+          auto linkMeshFeature = entityCast(_parent->Data(),
+              this->entityLinkMap, this->entityLinkMeshMap);
+          if (!linkMeshFeature)
+          {
+            ignwarn << "Can't process Mesh geometry, physics engine "
+                    << "missing AttachMeshShapeFeature" << std::endl;
+            return true;
+          }
+
+          collisionPtrPhys = linkMeshFeature->AttachMeshShape(_name->Data(),
+              *mesh,
+              math::eigen3::convert(_pose->Data()),
+              math::eigen3::convert(meshSdf->Scale()));
         }
         else
         {
@@ -722,25 +825,25 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
           return true;
         }
 
-        auto childLinkPhysIt =
-            this->entityLinkMap.find(_jointInfo->Data().childLink);
-        if (childLinkPhysIt == this->entityLinkMap.end())
+        auto childLinkDetachableJointFeature = entityCast(
+            _jointInfo->Data().childLink, this->entityLinkMap,
+            this->entityLinkDetachableJointMap);
+        if (!childLinkDetachableJointFeature)
         {
-          ignwarn << "DetachableJoint's child link entity ["
-                  << _jointInfo->Data().childLink << "] not found in link map."
-                  << std::endl;
+          ignwarn << "Can't process DetachableJoint component, physics engine "
+                  << "missing AttachFixedJointFeature" << std::endl;
           return true;
         }
 
         const auto poseParent =
             parentLinkPhysIt->second->FrameDataRelativeToWorld().pose;
         const auto poseChild =
-            childLinkPhysIt->second->FrameDataRelativeToWorld().pose;
+            childLinkDetachableJointFeature->FrameDataRelativeToWorld().pose;
 
         // Pose of child relative to parent
         auto poseParentChild = poseParent.inverse() * poseChild;
-        auto jointPtrPhys =
-            childLinkPhysIt->second->AttachFixedJoint(parentLinkPhysIt->second);
+        auto jointPtrPhys = childLinkDetachableJointFeature->AttachFixedJoint(
+            parentLinkPhysIt->second);
         if (jointPtrPhys.Valid())
         {
           // We let the joint be at the origin of the child link.
@@ -809,12 +912,17 @@ void PhysicsPrivate::RemovePhysicsEntities(const EntityComponentManager &_ecm)
   _ecm.EachRemoved<components::DetachableJoint>(
       [&](const Entity &_entity, const components::DetachableJoint *) -> bool
       {
-        auto jointIt = this->entityJointMap.find(_entity);
-        if (jointIt != this->entityJointMap.end())
+        auto castEntity = entityCast(_entity, this->entityJointMap,
+            this->entityJointDetachableJointMap);
+        if (!castEntity)
         {
-          igndbg << "Detaching joint [" << _entity << "]" << std::endl;
-          jointIt->second->Detach();
+          ignwarn << "Can't process DetachableJoint component, physics engine "
+                  << "missing DetachJointFeature" << std::endl;
+          return true;
         }
+
+        igndbg << "Detaching joint [" << _entity << "]" << std::endl;
+        castEntity->Detach();
         return true;
       });
 }
@@ -850,9 +958,15 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
           for (std::size_t i = 0; i < nDofs; ++i)
           {
             jointIt->second->SetForce(i, 0);
+
             // TODO(anyone): Only for diff drive, which does not use
             //   JointForceCmd. Remove when it does.
-            jointIt->second->SetVelocityCommand(i, 0);
+            auto jointVelFeature = entityCast(_entity, this->entityJointMap,
+                this->entityJointVelocityCommandMap);
+            if (jointVelFeature)
+            {
+              jointVelFeature->SetVelocityCommand(i, 0);
+            }
           }
           return true;
         }
@@ -930,45 +1044,47 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
             jointIt->second->SetForce(i, force->Data()[i]);
           }
         }
-        else
+        // Only set joint velocity if joint force is not set.
+        // If both the cmd and reset components are found, cmd is ignored.
+        else if (velCmd)
         {
-          // Only set joint velocity if joint force is not set.
-          // If both the cmd and reset components are found, cmd is ignored.
-          if (velCmd)
+          auto velocityCmd = velCmd->Data();
+
+          if (velReset)
           {
-              auto velocityCmd = velCmd->Data();
+            ignwarn << "Found both JointVelocityReset and "
+                    << "JointVelocityCmd components for Joint ["
+                    << _name->Data() << "(Entity=" << _entity
+                    << "]). Ignoring JointVelocityCmd component."
+                    << std::endl;
+            return true;
+          }
 
-              if (velReset)
-              {
-                ignwarn << "Found both JointVelocityReset and "
-                        << "JointVelocityCmd components for Joint ["
-                        << _name->Data() << "(Entity=" << _entity
-                        << "]). Ignoring JointVelocityCmd component."
-                        << std::endl;
-              }
-              else
-              {
-                if (velocityCmd.size() !=
-                      jointIt->second->GetDegreesOfFreedom())
-                {
-                  ignwarn << "There is a mismatch in the degrees of freedom"
-                          << " between Joint [" << _name->Data()
-                          << "(Entity=" << _entity<< ")] and its "
-                          << "JointVelocityCmd component. The joint has "
-                          << jointIt->second->GetDegreesOfFreedom()
-                          << " while the component has "
-                          << velocityCmd.size() << ".\n";
-                  }
+          if (velocityCmd.size() != jointIt->second->GetDegreesOfFreedom())
+          {
+            ignwarn << "There is a mismatch in the degrees of freedom"
+                    << " between Joint [" << _name->Data()
+                    << "(Entity=" << _entity<< ")] and its "
+                    << "JointVelocityCmd component. The joint has "
+                    << jointIt->second->GetDegreesOfFreedom()
+                    << " while the component has "
+                    << velocityCmd.size() << ".\n";
+          }
 
-                  std::size_t nDofs = std::min(
-                    velocityCmd.size(),
-                    jointIt->second->GetDegreesOfFreedom());
+          auto jointVelFeature = entityCast(_entity, this->entityJointMap,
+              this->entityJointVelocityCommandMap);
+          if (!jointVelFeature)
+          {
+            return true;
+          }
 
-                  for (std::size_t i = 0; i < nDofs; ++i)
-                  {
-                    jointIt->second->SetVelocityCommand(i, velocityCmd[i]);
-                  }
-              }
+          std::size_t nDofs = std::min(
+            velocityCmd.size(),
+            jointIt->second->GetDegreesOfFreedom());
+
+          for (std::size_t i = 0; i < nDofs; ++i)
+          {
+            jointVelFeature->SetVelocityCommand(i, velocityCmd[i]);
           }
         }
 
@@ -1063,12 +1179,17 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
       [&](const Entity &_entity, const components::Model *,
           components::AxisAlignedBox *_bbox)
       {
-        auto modelIt = this->entityModelMap.find(_entity);
-        if (modelIt == this->entityModelMap.end())
+        auto bbModel = entityCast(_entity, this->entityModelMap,
+            this->entityModelBoundingBoxMap);
+        if (!bbModel)
+        {
+          ignwarn << "Can't process AxisAlignedBox component, physics engine "
+                  << "missing GetModelBoundingBox" << std::endl;
           return true;
+        }
 
         math::AxisAlignedBox bbox =
-            math::eigen3::convert(modelIt->second->GetAxisAlignedBoundingBox());
+            math::eigen3::convert(bbModel->GetAxisAlignedBoundingBox());
         auto state = _bbox->SetData(bbox, this->axisAlignedBoxEql) ?
             ComponentState::OneTimeChange :
             ComponentState::NoChange;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -832,7 +832,9 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
         {
           ignwarn << "Can't process DetachableJoint component, physics engine "
                   << "missing AttachFixedJointFeature" << std::endl;
-          return true;
+
+          // Break Each call since no DetachableJoints can be processed
+          return false;
         }
 
         const auto poseParent =
@@ -918,7 +920,9 @@ void PhysicsPrivate::RemovePhysicsEntities(const EntityComponentManager &_ecm)
         {
           ignwarn << "Can't process DetachableJoint component, physics engine "
                   << "missing DetachJointFeature" << std::endl;
-          return true;
+
+          // Break Each call since no DetachableJoints can be processed
+          return false;
         }
 
         igndbg << "Detaching joint [" << _entity << "]" << std::endl;
@@ -1185,7 +1189,9 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
         {
           ignwarn << "Can't process AxisAlignedBox component, physics engine "
                   << "missing GetModelBoundingBox" << std::endl;
-          return true;
+
+          // Break Each call since no AxisAlignedBox'es can be processed
+          return false;
         }
 
         math::AxisAlignedBox bbox =

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -18,6 +18,10 @@
 #define IGNITION_GAZEBO_SYSTEMS_PHYSICS_HH_
 
 #include <memory>
+#include <unordered_map>
+#include <utility>
+#include <ignition/physics/RequestFeatures.hh>
+
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Export.hh>
 #include <ignition/gazebo/System.hh>
@@ -59,7 +63,68 @@ namespace systems
     /// \brief Private data pointer.
     private: std::unique_ptr<PhysicsPrivate> dataPtr;
   };
+
+  /// \brief Helper function to cast from an entity type with minimum features
+  /// to an entity with a different set of features. When the entity is cast
+  /// successfully, it is added to _castMap so that subsequent casts will
+  /// use the entity from the map.
+  /// \tparam PolicyT The feature policy, such as
+  /// `ignition::physics::FeaturePolicy3d`.
+  /// \tparam ToFeatureList The list of features of the resulting entity.
+  /// \tparam MinimumFeatureList The minimum list of features.
+  /// \tparam ToEntity Type of entities with ToFeatureList
+  /// \tparam MinimumEntity Type of entities with MinimumFeatureList
+  /// \param[in] _entity Entity ID.
+  /// \param[in] _minimumMap Map with all entities of the given type, having
+  /// minimum features.
+  /// \param[in] _castMap Map to store entities that have already been cast.
+  template <
+      typename PolicyT,
+      typename ToFeatureList,
+      typename MinimumFeatureList,
+      template <typename, typename> class ToEntity,
+      template <typename, typename> class MinimumEntity>
+  physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>> entityCast(
+      Entity _entity,
+      const std::unordered_map<Entity, physics::EntityPtr<
+        MinimumEntity<PolicyT, MinimumFeatureList>>> &_minimumMap,
+      std::unordered_map<Entity, physics::EntityPtr<
+        ToEntity<PolicyT, ToFeatureList>>> &_castMap)
+  {
+    // Has already been cast
+    auto castIt = _castMap.find(_entity);
+    if (castIt != _castMap.end())
+    {
+      return castIt->second;
+    }
+
+    physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>> castEntity;
+
+    // Get from minimum map
+    auto minimumIt = _minimumMap.find(_entity);
+    if (minimumIt == _minimumMap.end())
+    {
+      ignwarn << "Failed to find entity [" << _entity << "] in minimum map."
+              << std::endl;
+      return castEntity;
+    }
+
+    // Cast
+    castEntity =
+        physics::RequestFeatures<ToFeatureList>::From(minimumIt->second);
+
+    if (!castEntity)
+    {
+      ignwarn << "Physics engine missing requested feature." << std::endl;
+    }
+    else
+    {
+      _castMap.insert(std::make_pair(_entity, castEntity));
+    }
+
+    return castEntity;
   }
+}
 }
 }
 }

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -75,8 +75,7 @@ namespace systems
   /// \tparam ToEntity Type of entities with ToFeatureList
   /// \tparam MinimumEntity Type of entities with MinimumFeatureList
   /// \param[in] _entity Entity ID.
-  /// \param[in] _minimumMap Map with all entities of the given type, having
-  /// minimum features.
+  /// \param[in] _minimumEntity Entity pointer with minimum features.
   /// \param[in] _castMap Map to store entities that have already been cast.
   template <
       typename PolicyT,
@@ -86,8 +85,8 @@ namespace systems
       template <typename, typename> class MinimumEntity>
   physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>> entityCast(
       Entity _entity,
-      const std::unordered_map<Entity, physics::EntityPtr<
-        MinimumEntity<PolicyT, MinimumFeatureList>>> &_minimumMap,
+      const physics::EntityPtr<MinimumEntity<PolicyT, MinimumFeatureList>>
+        &_minimumEntity,
       std::unordered_map<Entity, physics::EntityPtr<
         ToEntity<PolicyT, ToFeatureList>>> &_castMap)
   {
@@ -100,18 +99,9 @@ namespace systems
 
     physics::EntityPtr<ToEntity<PolicyT, ToFeatureList>> castEntity;
 
-    // Get from minimum map
-    auto minimumIt = _minimumMap.find(_entity);
-    if (minimumIt == _minimumMap.end())
-    {
-      ignwarn << "Failed to find entity [" << _entity << "] in minimum map."
-              << std::endl;
-      return castEntity;
-    }
-
     // Cast
     castEntity =
-        physics::RequestFeatures<ToFeatureList>::From(minimumIt->second);
+        physics::RequestFeatures<ToFeatureList>::From(_minimumEntity);
 
     if (!castEntity)
     {

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -65,6 +65,7 @@ class PhysicsSystemFixture : public ::testing::Test
 {
   protected: void SetUp() override
   {
+    common::Console::SetVerbosity(4);
     // Augment the system plugin path.  In SetUp to avoid test order issues.
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
       (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);


### PR DESCRIPTION
Reopening [this BitBucket PR](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/573/page/1), resolves #58.

---

# Overview

Reduce `MinimumFeatureList` so that physics engines are not required to implement all features, and some of them are treated as optional.

# Bullet

This enables running Bullet with Ignition. You must use `ign-physics`' [bullet_chapulina](https://github.com/ignitionrobotics/ign-physics/compare/ign-physics1...bullet_chapulina) branch. :warning:  As of that branch, Bullet is not fully functional yet though. But it loads :slightly_smiling_face: 

# Implementation

This PR makes the following features optional:

* Features for detachable joints:
    * `ignition::physics::AttachFixedJointFeature`
    * `ignition::physics::DetachJointFeature`
    * `ignition::physics::SetJointTransformFromParentFeature`

* Features for bounding box:
    * `ignition::physics::GetModelBoundingBox`

* Features for joint velocity commands:
    * `ignition::physics::SetJointVelocityCommandFeature`

* Features for 3D meshes:
    * `ignition::physics::mesh::AttachMeshShapeFeature`

* For each group of optional features:
    * Create a feature list, i.e. `DetachableJointFeatureList`
    * Create entity types which use that list, i.e. `JointDetachableJointPtrType`
    * Create an entity map that holds the specialized entity type, i.e. `entityJointDetachableJointMap`
    * Use `entityCast` to cast from the original entity, created with `MinimumFeatureList`, to the specialized entity. `entityCast` will also populate the specialized map the first time it's called and get the entity from that map on subsequent calls. This means that `RequestFeature` is only called once for each combination of entity + feature list.

Any engine implementing all the minimum features will be loaded. If, at runtime, there's an attempt to use an unsupported feature, a warning is printed. That is:

* If a `component::DetachableJoint` is created, a warning is printed and the joint isn't attached or detached.
* If a `components::AxisAlignedBox` is created, a warning is printed and the box is not populated.
* If a `components::JointVelocityCmd` is created, a warning is printed and the command has no effect.
* If a collision has a mesh geometry, a warning is printed and the geometry isn't created.

I'll remove features not needed by TPE on a subsequent PR, that's currently on the `chapulina/tpe` branch.