### PR TITLE
[Blueprint] Add force focus when mouse enters render window

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 1. Add ability to save worlds to SDFormat
     * [BitBucket pull request 545](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/545)
 
+1. Add window focus upon mouse entering the render window
+    * [Github pull request 95](https://github.com/ignitionrobotics/ign-gazebo/pull/95)
+
 ### Ignition Gazebo 2.16.0 (2020-03-24)
 
 1. Add support for computing model bounding box in physics system

--- a/src/gui/plugins/scene3d/GzScene3D.qml
+++ b/src/gui/plugins/scene3d/GzScene3D.qml
@@ -37,15 +37,15 @@ Rectangle {
     anchors.fill: parent
     hoverEnabled: true
     acceptedButtons: Qt.NoButton
+    onEntered: {
+      GzScene3D.OnFocusWindow()
+    }
   }
 
   RenderWindow {
     id: renderWindow
     objectName: "renderWindow"
     anchors.fill: parent
-    onEntered: {
-      GzScene3D.OnFocusWindow()
-    }
 
     /**
      * Message to be displayed over the render window

--- a/src/gui/plugins/scene3d/GzScene3D.qml
+++ b/src/gui/plugins/scene3d/GzScene3D.qml
@@ -43,6 +43,9 @@ Rectangle {
     id: renderWindow
     objectName: "renderWindow"
     anchors.fill: parent
+    onEntered: {
+      GzScene3D.OnFocusWindow()
+    }
 
     /**
      * Message to be displayed over the render window

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2048,6 +2048,13 @@ void Scene3D::OnDropped(const QString &_drop, int _mouseX, int _mouseY)
 }
 
 /////////////////////////////////////////////////
+void Scene3D::OnFocusWindow()
+{
+  auto renderWindow = this->PluginItem()->findChild<RenderWindowItem *>();
+  renderWindow->forceActiveFocus();
+}
+
+/////////////////////////////////////////////////
 void RenderWindowItem::SetXYZSnap(const math::Vector3d &_xyz)
 {
   this->dataPtr->renderThread->ignRenderer.SetXYZSnap(_xyz);

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2227,6 +2227,8 @@ void RenderWindowItem::SetWorldName(const std::string &_name)
 /////////////////////////////////////////////////
 void RenderWindowItem::mousePressEvent(QMouseEvent *_e)
 {
+  this->forceActiveFocus();
+
   auto event = ignition::gui::convert(*_e);
   event.SetPressPos(event.Pos());
   this->dataPtr->mouseEvent = event;
@@ -2275,6 +2277,8 @@ void RenderWindowItem::mouseMoveEvent(QMouseEvent *_e)
 ////////////////////////////////////////////////
 void RenderWindowItem::wheelEvent(QWheelEvent *_e)
 {
+  this->forceActiveFocus();
+
   this->dataPtr->mouseEvent.SetType(common::MouseEvent::SCROLL);
   this->dataPtr->mouseEvent.SetPos(_e->x(), _e->y());
   double scroll = (_e->angleDelta().y() > 0) ? -1.0 : 1.0;

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2227,8 +2227,6 @@ void RenderWindowItem::SetWorldName(const std::string &_name)
 /////////////////////////////////////////////////
 void RenderWindowItem::mousePressEvent(QMouseEvent *_e)
 {
-  this->forceActiveFocus();
-
   auto event = ignition::gui::convert(*_e);
   event.SetPressPos(event.Pos());
   this->dataPtr->mouseEvent = event;
@@ -2277,8 +2275,6 @@ void RenderWindowItem::mouseMoveEvent(QMouseEvent *_e)
 ////////////////////////////////////////////////
 void RenderWindowItem::wheelEvent(QWheelEvent *_e)
 {
-  this->forceActiveFocus();
-
   this->dataPtr->mouseEvent.SetType(common::MouseEvent::SCROLL);
   this->dataPtr->mouseEvent.SetPos(_e->x(), _e->y());
   double scroll = (_e->angleDelta().y() > 0) ? -1.0 : 1.0;

--- a/src/gui/plugins/scene3d/Scene3D.hh
+++ b/src/gui/plugins/scene3d/Scene3D.hh
@@ -96,6 +96,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     public slots: void OnDropped(const QString &_drop,
         int _mouseX, int _mouseY);
 
+    /// \brief Callback when the mouse enters the render window to
+    /// focus the window for mouse/key events
+    public slots: void OnFocusWindow();
+
     // Documentation inherited
     protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
 


### PR DESCRIPTION
Solves issue mentioned [here](https://github.com/ignitionrobotics/ign-gazebo/pull/60#discussion_r414903153).

This PR focuses the render window if the mouse enters it.  Previously, the render window was only focused if the user clicked it, introducing a slightly annoying behavior where the user had to click twice in order to use the snapping behavior given the `CTRL` press wouldn't be registered until after the window was focused.

Signed-off-by: John Shepherd <john@openrobotics.org>