### PR TITLE
Fix: use Marker.ns if provided.

### DIFF
--- a/src/rendering/MarkerManager.cc
+++ b/src/rendering/MarkerManager.cc
@@ -417,7 +417,7 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const ignition::msgs::Marker &_msg)
 {
   // Get the namespace, if it exists. Otherwise, use the global namespace
   std::string ns;
-  if (_msg.ns().empty()) {
+  if (!_msg.ns().empty()) {
     ns = _msg.ns();
   }
 


### PR DESCRIPTION
`Marker.ns` field was ignored.

Note:
I couldn't find existing tests for `MarkerManager.cc`. Let me know how to proceed.


