### PR TITLE
DetachableJoint system: Add option to suppress warning about missing child model

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 1. Allow battery plugin to work with joint force systems.
     * [Pull Request 120](https://github.com/ignitionrobotics/ign-gazebo/pull/120)
 
+1. DetachableJoint system: Add option to suppress warning about missing child model
+    * [Pull Request 132](https://github.com/ignitionrobotics/ign-gazebo/pull/132)
+
 1. Make breadcrumb static after specified time
     * [Pull Request 90](https://github.com/ignitionrobotics/ign-gazebo/pull/90)
 

--- a/src/systems/detachable_joint/DetachableJoint.cc
+++ b/src/systems/detachable_joint/DetachableJoint.cc
@@ -97,6 +97,10 @@ void DetachableJoint::Configure(const Entity &_entity,
                              "/detachable_joint/detach"};
   this->topic = _sdf->Get<std::string>("topic", defaultTopic).first;
 
+  this->suppressChildWarning =
+      _sdf->Get<bool>("suppress_child_warning", this->suppressChildWarning)
+          .first;
+
   this->validConfig = true;
 }
 
@@ -151,7 +155,7 @@ void DetachableJoint::PreUpdate(
                 << " could not be found.\n";
       }
     }
-    else
+    else if (!this->suppressChildWarning)
     {
       ignwarn << "Child Model " << this->childModelName
               << " could not be found.\n";

--- a/src/systems/detachable_joint/DetachableJoint.hh
+++ b/src/systems/detachable_joint/DetachableJoint.hh
@@ -49,6 +49,10 @@ namespace systems
   /// creating a fixed joint with a link in the parent model.
   ///
   /// <topic> (optional): Topic name to be used for detaching connections
+  ///
+  /// <suppress_child_warning> (optional): If true, the system
+  /// will not print a warning message if a child model does not exist yet.
+  /// Otherwise, a warning message is printed. Defaults to false.
 
   class IGNITION_GAZEBO_VISIBLE DetachableJoint
       : public System,
@@ -83,6 +87,9 @@ namespace systems
 
     /// \brief Topic to be used for detaching connections
     private: std::string topic;
+
+    /// \brief Whether to suppress warning about missing child model.
+    private: bool suppressChildWarning{false};
 
     /// \brief Entity of attachment link in the parent model
     private: Entity parentLinkEntity{kNullEntity};


### PR DESCRIPTION
This is useful for avoiding warning messages when parent and child models are spawned with a delay in between. 