### PR TITLE
Multiple resource paths separated by colon

### DIFF
--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -326,12 +326,19 @@ class Cmd
         # If not, then first check the IGN_GAZEBO_RESOURCE_PATH environment
         # variable, then the configuration path from the launch library.
         else
-          configPathEnv = ENV['IGN_GAZEBO_RESOURCE_PATH']
-          # todo: IGN_GAZEBO_RESOURCE_PATH is colon separated.
-          if !configPathEnv.nil? &&
-              File.exists?(File.join(configPathEnv, options['file']))
-            path = File.join(configPathEnv, options['file'])
-          else
+          resourcePathEnv = ENV['IGN_GAZEBO_RESOURCE_PATH']
+          if !resourcePathEnv.nil?
+            resourcePaths = resourcePathEnv.split(':')
+            for resourcePath in resourcePaths
+              filePath = File.join(resourcePath, options['file'])
+              if File.exists?(filePath)
+                path = filePath
+                break
+              end
+            end
+          end
+
+          if path.nil?
             Importer.extern 'char *worldInstallDir()'
             path = File.join(Importer.worldInstallDir().to_s, options['file'])
             if !File.exists?(path)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -119,6 +119,33 @@ TEST(CmdLine, Gazebo)
         << output;
   }
 }
+
+/////////////////////////////////////////////////
+TEST(CmdLine, ResourcePath)
+{
+  std::string cmd = kIgnCommand + " -s -r -v 4 --iterations 1 plugins.sdf";
+
+  // No path
+  std::string output = customExecStr(cmd);
+  EXPECT_NE(output.find("Unable to find file plugins.sdf"), std::string::npos)
+      << output;
+
+  // Correct path
+  auto path =std::string("IGN_GAZEBO_RESOURCE_PATH=") +
+    PROJECT_SOURCE_PATH + "/test/worlds ";
+
+  output = customExecStr(path + cmd);
+  EXPECT_EQ(output.find("Unable to find file plugins.sdf"), std::string::npos)
+      << output;
+
+  // Several paths
+  path =std::string("IGN_GAZEBO_RESOURCE_PATH=banana:") +
+    PROJECT_SOURCE_PATH + "/test/worlds:orange ";
+
+  output = customExecStr(path + cmd);
+  EXPECT_EQ(output.find("Unable to find file plugins.sdf"), std::string::npos)
+      << output;
+}
 #endif
 
 /////////////////////////////////////////////////

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -131,7 +131,7 @@ TEST(CmdLine, ResourcePath)
       << output;
 
   // Correct path
-  auto path =std::string("IGN_GAZEBO_RESOURCE_PATH=") +
+  auto path = std::string("IGN_GAZEBO_RESOURCE_PATH=") +
     PROJECT_SOURCE_PATH + "/test/worlds ";
 
   output = customExecStr(path + cmd);
@@ -139,7 +139,7 @@ TEST(CmdLine, ResourcePath)
       << output;
 
   // Several paths
-  path =std::string("IGN_GAZEBO_RESOURCE_PATH=banana:") +
+  path = std::string("IGN_GAZEBO_RESOURCE_PATH=banana:") +
     PROJECT_SOURCE_PATH + "/test/worlds:orange ";
 
   output = customExecStr(path + cmd);


### PR DESCRIPTION
Address a TODO and support multiple paths separated by colon. For example:

`IGN_GAZEBO_RESOURCE_PATH=/home/user/my_worlds:/home/user/more_worlds ign gazebo a_world.sdf`

Then Ignition will look for `a_world` on these paths, in order:

* the local directory
* `/home/user/my_worlds`
* `/home/user/more_worlds`
* folder where worlds were installed with `ign-gazebo`
