### PR TITLE
Use collision bitmask flag for meshes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ ign_find_package (Qt5
 
 #--------------------------------------
 # Find ignition-physics
-ign_find_package(ignition-physics2
+ign_find_package(ignition-physics2 VERSION 2.1
   COMPONENTS
     mesh
     sdf

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 ### Ignition Gazebo 4.0.0 (20XX-XX-XX)
 
+1. Filter mesh collision based on `collide_bitmask` property
+    * [pull request 160](https://github.com/ignitionrobotics/ign-gazebo/pull/160)
+
 1. Use interpolate\_x sdf parameter for actor animations
     * [BitBucket pull request 536](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/536)
 

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -745,7 +745,7 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
         sdf::Collision collision = _collElement->Data();
         collision.SetRawPose(_pose->Data());
         collision.SetPoseRelativeTo("");
-        uint16_t collideBitmask = collision.Surface()->Contact()->CollideBitmask();
+        auto collideBitmask = collision.Surface()->Contact()->CollideBitmask();
 
         ShapePtrType collisionPtrPhys;
         if (_geom->Data().Type() == sdf::GeometryType::MESH)

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -835,6 +835,17 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
         {
           filterMaskFeature->SetCollisionFilterMask(collideBitmask);
         }
+        else
+        {
+          static bool informed{false};
+          if (!informed)
+          {
+            igndbg << "Attempting to set collision bitmasks, but the physics "
+                   << "engine doesn't support feature [CollisionFilterMask]. "
+                   << "Collision bitmasks will be ignored." << std::endl;
+            informed = true;
+          }
+        }
 
         this->entityCollisionMap.insert(
             std::make_pair(_entity, collisionPtrPhys));

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -66,6 +66,8 @@
 #include <sdf/Link.hh>
 #include <sdf/Mesh.hh>
 #include <sdf/Model.hh>
+#include <sdf/Surface.hh>
+#include <sdf/Visual.hh>
 #include <sdf/World.hh>
 
 #include "ignition/gazebo/EntityComponentManager.hh"
@@ -310,7 +312,8 @@ class ignition::gazebo::systems::PhysicsPrivate
   public: using CollisionFeatureList = ignition::physics::FeatureList<
             MinimumFeatureList,
             ignition::physics::GetContactsFromLastStepFeature,
-            ignition::physics::sdf::ConstructSdfCollision>;
+            ignition::physics::sdf::ConstructSdfCollision,
+            ignition::physics::CollisionFilterMaskFeature>;
 
   /// \brief Collision type with collision features.
   public: using ShapePtrType = ignition::physics::ShapePtr<
@@ -743,6 +746,7 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
         sdf::Collision collision = _collElement->Data();
         collision.SetRawPose(_pose->Data());
         collision.SetPoseRelativeTo("");
+        uint16_t collideBitmask = collision.Surface()->Contact()->CollideBitmask();
 
         ShapePtrType collisionPtrPhys;
         if (_geom->Data().Type() == sdf::GeometryType::MESH)
@@ -807,6 +811,7 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
           collisionPtrPhys =
               linkCollisionFeature->ConstructCollision(collision);
         }
+        collisionPtrPhys->SetCollisionFilterMask(collideBitmask);
 
         this->entityCollisionMap.insert(
             std::make_pair(_entity, collisionPtrPhys));

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -67,7 +67,6 @@
 #include <sdf/Mesh.hh>
 #include <sdf/Model.hh>
 #include <sdf/Surface.hh>
-#include <sdf/Visual.hh>
 #include <sdf/World.hh>
 
 #include "ignition/gazebo/EntityComponentManager.hh"

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -103,11 +103,7 @@ namespace systems
     castEntity =
         physics::RequestFeatures<ToFeatureList>::From(_minimumEntity);
 
-    if (!castEntity)
-    {
-      ignwarn << "Physics engine missing requested feature." << std::endl;
-    }
-    else
+    if (castEntity)
     {
       _castMap.insert(std::make_pair(_entity, castEntity));
     }


### PR DESCRIPTION
Preliminary support for collision bitmask was introduce in ign-physics with [this PR](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-physics/pull-requests/116/page/1).

That introduces filling the bitmask and introducing the filtering in the [ConstructSdfCollision](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/src/SDFFeatures.cc#L499) function. The issue is that the function is called in an [else statement](https://github.com/ignitionrobotics/ign-gazebo/blob/master/src/systems/physics/Physics.cc#L730) only if the object is not a mesh.
This means that before this PR meshes didn't implement the collide_bitmask flag, now they do. This effectively makes the [change in the ConstructSdfCollision](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/src/SDFFeatures.cc#L574-L579) obsolete and it can be removed.

While this is just a few lines and it fixes the problem, it introduces an additional feature to the MinimumFeatureList which is probably not desirable. Also, I guess there should be a discussion about whether more features from the ConstructSdfCollision functions should be ported to make them work with meshes as well, from what I can see in the code there is a whole chunk of SDF [parameters related to friction](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/src/SDFFeatures.cc#L539-L565) that will be applied to primitives but not to meshes, which doesn't sound correct.

Open to ideas on whether this fix is acceptable (and whether we should find a way to port the above) or if I should look at alternative fixes.