### PR TITLE
Support joint force commands with the Battery plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Gazebo 2.XX.XX (20XX-XX-XX)
 
+1. Allow joint force commands (JointForceCmd) to dscharge a battery.
+    * [Pull Request XX](https://github.com/ignitionrobotics/ign-gazebo/pull/XX)
+
 1. Allow renaming breadcrumb models if there is a name conflict
     * [Pull Request 155](https://github.com/ignitionrobotics/ign-gazebo/pull/155)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ### Ignition Gazebo 2.XX.XX (20XX-XX-XX)
 
 1. Allow joint force commands (JointForceCmd) to dscharge a battery.
-    * [Pull Request XX](https://github.com/ignitionrobotics/ign-gazebo/pull/XX)
+    * [Pull Request 165](https://github.com/ignitionrobotics/ign-gazebo/pull/165)
 
 1. Allow renaming breadcrumb models if there is a name conflict
     * [Pull Request 155](https://github.com/ignitionrobotics/ign-gazebo/pull/155)

--- a/examples/worlds/lift_drag_battery.sdf
+++ b/examples/worlds/lift_drag_battery.sdf
@@ -1,0 +1,378 @@
+<?xml version="1.0" ?>
+<!--
+  Ignition Gazebo lift-drag system with a battery plugin demo
+
+  This file was adapted from osrf/gazebo/worlds/single_rotor_demo.world
+
+  Try sending commands:
+
+    ign topic -t "/model/lift_drag_demo_model/joint/rod_1_joint/cmd_force" -m ignition.msgs.Double  -p "data: 0.7"
+
+  Listen to joint states:
+
+    ign topic -e -t /world/lift_drag/model/lift_drag_demo_model/joint_state
+
+  Listen to battery state:
+
+    ign topic -et /model/lift_drag_demo_model/battery/linear_batty/state
+-->
+<sdf version="1.6">
+  <world name="lift_drag">
+    <plugin
+      filename="libignition-gazebo-physics-system.so"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-user-commands-system.so"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-scene-broadcaster-system.so"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <gui fullscreen="0">
+
+      <!-- 3D scene -->
+      <plugin filename="GzScene3D" name="3D View">
+        <ignition-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+      </plugin>
+
+      <!-- World control -->
+      <plugin filename="WorldControl" name="World control">
+        <ignition-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <service>/world/lift_drag/control</service>
+        <stats_topic>/world/lift_drag/stats</stats_topic>
+
+      </plugin>
+
+      <!-- World statistics -->
+      <plugin filename="WorldStats" name="World stats">
+        <ignition-gui>
+          <title>World stats</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+
+        <sim_time>true</sim_time>
+        <real_time>true</real_time>
+        <real_time_factor>true</real_time_factor>
+        <iterations>true</iterations>
+        <topic>/world/lift_drag/stats</topic>
+      </plugin>
+    </gui>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            <emissive>0.8 0.8 0.8 1</emissive>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="lift_drag_demo_model">
+      <pose>0 0 0 0 0 0</pose>
+      <link name="body">
+        <pose>0.0 0 0.5 0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>1.8</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>1.8</iyy>
+            <iyz>0.0</iyz>
+            <izz>1.8</izz>
+          </inertia>
+          <mass>10.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.1</mu>
+                <mu2>0.1</mu2>
+              </ode>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="rod_1">
+        <pose>0 0 1.25 0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>0.012</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>0.012</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0012</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.02 0.02 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.02 0.02 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.3 0.3 0.3 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="blade_1">
+        <pose>0 0 1.5 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>0.0000465</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>0.0000006</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0000470</izz>
+          </inertia>
+          <mass>0.01</mass>
+        </inertial>
+        <collision name="collision">
+          <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+          <geometry>
+            <box>
+              <size>0.2 1.0 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+          <geometry>
+            <box>
+              <size>0.2 1.0 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.2 0.2 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="blade_2">
+        <pose>0 0 1.5 0.0 0 3.141593</pose>
+        <inertial>
+          <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>0.0000465</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>0.0000006</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0000470</izz>
+          </inertia>
+          <mass>0.01</mass>
+        </inertial>
+        <collision name="collision">
+          <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+          <geometry>
+            <box>
+              <size>0.2 1.0 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <pose>0.0 0.5 0 0.0 0.0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 1.0 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.2 0.5 0.2 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="rod_1_joint" type="revolute">
+        <parent>body</parent>
+        <child>rod_1</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <axis>
+          <limit>
+            <lower>-1e16</lower>
+            <upper>1e16</upper>
+          </limit>
+          <xyz>0.0 0.0 -1.0</xyz>
+          <dynamics>
+            <damping>0.0001</damping>
+          </dynamics>
+        </axis>
+        <physics>
+          <ode>
+            <cfm_damping>1</cfm_damping>
+          </ode>
+        </physics>
+      </joint>
+      <joint name="blade_1_joint" type="fixed">
+        <parent>rod_1</parent>
+        <child>blade_1</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      </joint>
+      <joint name="blade_2_joint" type="fixed">
+        <parent>rod_1</parent>
+        <child>blade_2</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      </joint>
+
+      <plugin
+        filename="libignition-gazebo-joint-state-publisher-system.so"
+        name="ignition::gazebo::systems::JointStatePublisher"></plugin>
+
+      <plugin
+        filename="libignition-gazebo-lift-drag-system.so"
+        name="ignition::gazebo::systems::LiftDrag">
+        <a0>0.1</a0>
+        <cla>0.1</cla>
+        <cda>0.001</cda>
+        <cma>0.0</cma>
+        <cp>0.0 0.5 0</cp>
+        <area>0.2</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>blade_1</link_name>
+      </plugin>
+      <plugin
+        filename="libignition-gazebo-lift-drag-system.so"
+        name="ignition::gazebo::systems::LiftDrag">
+        <a0>0.1</a0>
+        <cla>0.1</cla>
+        <cda>0.001</cda>
+        <cma>0.0</cma>
+        <cp>0.0 0.5 0</cp>
+        <area>0.2</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>blade_2</link_name>
+      </plugin>
+      <plugin
+        filename="libignition-gazebo-apply-joint-force-system.so"
+        name="ignition::gazebo::systems::ApplyJointForce">
+        <joint_name>rod_1_joint</joint_name>
+      </plugin>
+      <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
+        name="ignition::gazebo::systems::LinearBatteryPlugin">
+        <!--Li-ion battery spec from LIR18650 datasheet-->
+        <battery_name>linear_battery</battery_name>
+        <voltage>4.2</voltage>
+        <open_circuit_voltage_constant_coef>4.2</open_circuit_voltage_constant_coef>
+        <open_circuit_voltage_linear_coef>-2.0</open_circuit_voltage_linear_coef>
+        <initial_charge>2.5</initial_charge>
+        <capacity>2.5 </capacity>
+        <resistance>0.07</resistance>
+        <smooth_current_tau>2.0</smooth_current_tau>
+        <enable_recharge>true</enable_recharge>
+        <!-- charging I = c / t, discharging I = P / V, 
+          charging I should be > discharging I -->
+        <charging_time>3.0</charging_time>
+        <soc_threshold>0.51</soc_threshold>
+        <!-- Consumer-specific -->
+        <power_load>2.1</power_load>
+        <start_on_motion>true</start_on_motion>
+      </plugin>
+
+    </model>
+  </world>
+</sdf>

--- a/examples/worlds/lift_drag_battery.sdf
+++ b/examples/worlds/lift_drag_battery.sdf
@@ -14,7 +14,7 @@
 
   Listen to battery state:
 
-    ign topic -et /model/lift_drag_demo_model/battery/linear_batty/state
+    ign topic -et /model/lift_drag_demo_model/battery/linear_battery/state
 -->
 <sdf version="1.6">
   <world name="lift_drag">

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -36,6 +36,7 @@
 #include "ignition/gazebo/components/BatterySoC.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/components/JointVelocityCmd.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Joint.hh"
@@ -312,7 +313,7 @@ void LinearBatteryPlugin::PreUpdate(
   ignition::gazebo::EntityComponentManager &_ecm)
 {
   IGN_PROFILE("LinearBatteryPlugin::PreUpdate");
-  // // Start draining the battery if the robot has started moving
+  // Start draining the battery if the robot has started moving
   if (!this->dataPtr->startDraining)
   {
     const std::vector<Entity> joints = _ecm.ChildrenByComponents(
@@ -323,10 +324,25 @@ void LinearBatteryPlugin::PreUpdate(
     {
       const auto *jointVelocityCmd =
         _ecm.Component<components::JointVelocityCmd>(jointEntity);
-      if (jointVelocityCmd) {
+      if (jointVelocityCmd)
+      {
         for (double jointVel : jointVelocityCmd->Data())
         {
           if (fabsf(static_cast<float>(jointVel)) > 0)
+          {
+            this->dataPtr->startDraining = true;
+            return;
+          }
+        }
+      }
+
+      const auto *jointForceCmd =
+        _ecm.Component<components::JointForceCmd>(jointEntity);
+      if (jointForceCmd)
+      {
+        for (double jointForce : jointForceCmd->Data())
+        {
+          if (fabsf(static_cast<float>(jointForce)) > 0)
           {
             this->dataPtr->startDraining = true;
             return;


### PR DESCRIPTION
Joint force commands were not checked in the battery plugin.

To test:
1. `ign gazebo -v 4 examples/worlds/lift_drag_battery.sdf`
2. Listen to the battery topic: `ign topic -et /model/lift_drag_demo_model/battery/linear_battery/state`
3. Run simulation.
4. The battery should be full and not discharging.
5. Start the propeller: `ign topic -t "/model/lift_drag_demo_model/joint/rod_1_joint/cmd_force" -m ignition.msgs.Double  -p "data: 0.7"`
6. The battery should start discharging.

Signed-off-by: Nate Koenig <nate@openrobotics.org>