### PR TITLE
Use updated model names for spawned models when generating SDFormat

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Gazebo 2.XX.XX (20XX-XX-XX)
 
+1. Use updated model names for spawned models when generating SDFormat
+    * [Pull Request 166](https://github.com/ignitionrobotics/ign-gazebo/pull/166)
+
 1. Allow renaming breadcrumb models if there is a name conflict
     * [Pull Request 155](https://github.com/ignitionrobotics/ign-gazebo/pull/155)
 

--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -376,9 +376,13 @@ namespace sdf_generator
 
     // Update sdf based current components. Here are the list of components to
     // be updated:
+    // - Name
     // - Pose
     // This list is to be updated as other components become updateable during
     // simulation
+    auto *nameComp = _ecm.Component<components::Name>(_entity);
+    _elem->GetAttribute("name")->Set(nameComp->Data());
+
     auto *poseComp = _ecm.Component<components::Pose>(_entity);
 
     auto poseElem = _elem->GetElement("pose");


### PR DESCRIPTION
This fixes an issue with SDFormat generator where it was not using the updated model names of models spawned with a new name or models that get assigned a new name due to a name conflict. The issue only occurred if the generated SDFormat was expanded, i.e, not using `<include>`.