### PR TITLE
Test collection labeler fix

### DIFF
--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
     - name: Add collection labels
       if: github.event.action == 'opened'
-      uses: ignition-tooling/pr-collection-labeler@v1
+      uses: ignition-tooling/pr-collection-labeler@token_var
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed on #166 that the PR labeler failed with:

`##[warning]Unexpected input 'github-token', valid inputs are ['github_token']`

https://github.com/ignitionrobotics/ign-gazebo/pull/166/checks?check_run_id=728171194

Then I checked on the [action code](https://github.com/ignition-tooling/pr-collection-labeler/blob/1eca396fa6c1aa78a430741177999eabac9839ee/action.yml#L5) that indeed the token variable is `github_token`.

The weird part is that this hadn't failed before :thinking: 

So with this PR I'm testing a fix upstream: https://github.com/ignition-tooling/pr-collection-labeler/compare/token_var