### PR TITLE
Add odom_topic to diff drive

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 ## Ignition Gazebo 2.x
 
+
+### Ignition Gazebo 2.XX.XX (2020-XX-XX)
+
+1. Added an `<odom_topic>` element to the DiffDrive system so that a custom odometry topic can be used.
+    * [Pull Request 179](https://github.com/ignitionrobotics/ign-gazebo/pull/179)
+
 ### Ignition Gazebo 2.19.0 (2020-06-02)
 
 1. Use updated model names for spawned models when generating SDFormat

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -165,6 +165,8 @@ void DiffDrive::Configure(const Entity &_entity,
 
   std::string odomTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
     "/odometry"};
+  if (_sdf->HasElement("odom_topic"))
+    odomTopic = _sdf->Get<std::string>("odom_topic");
   this->dataPtr->odomPub = this->dataPtr->node.Advertise<msgs::Odometry>(
       odomTopic);
 

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -33,6 +33,33 @@ namespace systems
 
   /// \brief Differential drive controller which can be attached to a model
   /// with any number of left and right wheels.
+  ///
+  /// # System Parameters
+  ///
+  /// `<left_joint>`: Name of a joint that controls a left wheel. This
+  /// element can appear multiple times, and must appear at least once.
+  ///
+  /// `<right_joint>`: Name of a joint that controls a right wheel. This
+  /// element can appear multiple times, and must appear at least once.
+  ///
+  /// `<wheel_separation>`: Distance between wheels, in meters. This element
+  /// is optional, although it is recommended to be included with an
+  /// appropriate value. The default value is 1.0m.
+  ///
+  /// `<wheel_radius>`: Wheel radius in meters. This element is optional,
+  /// although it is recommended to be included with an appropriate value. The
+  /// default value is 0.2m.
+  ///
+  /// `<odom_publish_frequency>`: Odometry publication frequency. This
+  /// element is optional, and the default value is 50Hz.
+  ///
+  /// `<topic>`: Custom topic that this system will subscribe to in order to
+  /// receive command velocity messages. This element if optional, and the
+  /// default value is `/model/{name_of_model}/cmd_vel`.
+  ///
+  /// `<odom_topic>`: Custom topic on which this system will publish odometry
+  /// messages. This element if optional, and the default value is
+  /// `/model/{name_of_model}/odometry`.
   class IGNITION_GAZEBO_VISIBLE DiffDrive
       : public System,
         public ISystemConfigure,

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -35,18 +35,6 @@ using namespace ignition;
 using namespace gazebo;
 using namespace std::chrono_literals;
 
-/// \brief Test DiffDrive system
-class DiffDriveTest : public ::testing::TestWithParam<int>
-{
-  // Documentation inherited
-  protected: void SetUp() override
-  {
-    common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
-  }
-};
-
 class Relay
 {
   public: Relay()
@@ -87,141 +75,174 @@ class Relay
   private: MockSystem *mockSystem;
 };
 
+/// \brief Test DiffDrive system
+class DiffDriveTest : public ::testing::TestWithParam<int>
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    common::Console::SetVerbosity(4);
+    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+  }
+
+  /// \param[in] _sdfFile SDF file to load.
+  /// \param[in] _cmdVelTopic Command velocity topic.
+  /// \param[in] _odomTopic Odometry topic.
+  protected: void TestPublishCmd(const std::string &_sdfFile,
+                                 const std::string &_cmdVelTopic,
+                                 const std::string &_odomTopic)
+  {
+    // Start server
+    ServerConfig serverConfig;
+    serverConfig.SetSdfFile(_sdfFile);
+
+    Server server(serverConfig);
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+
+    // Create a system that records the vehicle poses
+    Relay testSystem;
+
+    std::vector<math::Pose3d> poses;
+    testSystem.OnPostUpdate([&poses](const gazebo::UpdateInfo &,
+      const gazebo::EntityComponentManager &_ecm)
+      {
+        auto id = _ecm.EntityByComponents(
+          components::Model(),
+          components::Name("vehicle"));
+        EXPECT_NE(kNullEntity, id);
+
+        auto poseComp = _ecm.Component<components::Pose>(id);
+        ASSERT_NE(nullptr, poseComp);
+
+        poses.push_back(poseComp->Data());
+      });
+    server.AddSystem(testSystem.systemPtr);
+
+    // Run server and check that vehicle didn't move
+    server.Run(true, 1000, false);
+
+    EXPECT_EQ(1000u, poses.size());
+
+    for (const auto &pose : poses)
+    {
+      EXPECT_EQ(poses[0], pose);
+    }
+
+    // Get odometry messages
+    double period{1.0 / 50.0};
+    double lastMsgTime{1.0};
+    std::vector<math::Pose3d> odomPoses;
+    std::function<void(const msgs::Odometry &)> odomCb =
+      [&](const msgs::Odometry &_msg)
+      {
+        ASSERT_TRUE(_msg.has_header());
+        ASSERT_TRUE(_msg.header().has_stamp());
+
+        double msgTime =
+            static_cast<double>(_msg.header().stamp().sec()) +
+            static_cast<double>(_msg.header().stamp().nsec()) * 1e-9;
+
+        EXPECT_DOUBLE_EQ(msgTime, lastMsgTime + period);
+        lastMsgTime = msgTime;
+
+        odomPoses.push_back(msgs::Convert(_msg.pose()));
+      };
+
+    // Publish command and check that vehicle moved
+    transport::Node node;
+    auto pub = node.Advertise<msgs::Twist>(_cmdVelTopic);
+    node.Subscribe(_odomTopic, odomCb);
+
+    msgs::Twist msg;
+
+    // Avoid wheel slip by limiting acceleration
+    Relay velocityRamp;
+    const double desiredLinVel = 0.5;
+    const double desiredAngVel = 0.2;
+    const double linAccel = 1;
+    const double angAccel = 1;
+    velocityRamp.OnPreUpdate(
+        [&](const gazebo::UpdateInfo &_info,
+            const gazebo::EntityComponentManager &)
+        {
+          double dt = std::chrono::duration<double>(_info.dt).count();
+          double nextLinVel = msg.linear().x() + dt * linAccel;
+          double nextAngVel = msg.angular().z() + dt * angAccel;
+          msgs::Set(msg.mutable_linear(),
+              math::Vector3d(std::min(nextLinVel, desiredLinVel), 0, 0));
+          msgs::Set(msg.mutable_angular(),
+              math::Vector3d(0.0, 0, std::min(nextAngVel, desiredAngVel)));
+          pub.Publish(msg);
+        });
+
+    server.AddSystem(velocityRamp.systemPtr);
+
+    server.Run(true, 3000, false);
+
+    // Poses for 4s
+    ASSERT_EQ(4000u, poses.size());
+
+    int sleep = 0;
+    int maxSleep = 30;
+    for (; odomPoses.size() < 150 && sleep < maxSleep; ++sleep)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_NE(maxSleep, sleep);
+
+    // Odometry calculates the pose of a point that is located half way between
+    // the two wheels, not the origin of the model. For example, if the
+    // vehicle is commanded to rotate in place, the vehicle will rotate about
+    // the point half way between the two wheels, thus, the odometry position
+    // will remain zero.
+    // However, since the model origin is offset, the model position will
+    // change. To find the final pose of the model, we have to do the
+    // following similarity transformation
+    math::Pose3d tOdomModel(0.554283, 0, -0.325, 0, 0, 0);
+    auto finalModelFramePose =
+        tOdomModel * odomPoses.back() * tOdomModel.Inverse();
+
+    // Odom for 3s
+    ASSERT_FALSE(odomPoses.empty());
+    EXPECT_EQ(150u, odomPoses.size());
+
+    EXPECT_LT(poses[0].Pos().X(), poses[3999].Pos().X());
+    EXPECT_LT(poses[0].Pos().Y(), poses[3999].Pos().Y());
+    EXPECT_NEAR(poses[0].Pos().Z(), poses[3999].Pos().Z(), tol);
+    EXPECT_NEAR(poses[0].Rot().X(), poses[3999].Rot().X(), tol);
+    EXPECT_NEAR(poses[0].Rot().Y(), poses[3999].Rot().Y(), tol);
+    EXPECT_LT(poses[0].Rot().Z(), poses[3999].Rot().Z());
+
+    // The value from odometry will be close, but not exactly the ground truth
+    // pose of the robot model. This is partially due to throttling the
+    // odometry publisher, partially due to a frame difference between the
+    // odom frame and the model frame, and partially due to wheel slip.
+    EXPECT_NEAR(poses[1020].Pos().X(), odomPoses[0].Pos().X(), 1e-2);
+    EXPECT_NEAR(poses[1020].Pos().Y(), odomPoses[0].Pos().Y(), 1e-2);
+    EXPECT_NEAR(poses.back().Pos().X(), finalModelFramePose.Pos().X(), 1e-2);
+    EXPECT_NEAR(poses.back().Pos().Y(), finalModelFramePose.Pos().Y(), 1e-2);
+  }
+};
 
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, PublishCmd)
 {
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive.sdf");
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // Create a system that records the vehicle poses
-  Relay testSystem;
-
-  std::vector<math::Pose3d> poses;
-  testSystem.OnPostUpdate([&poses](const gazebo::UpdateInfo &,
-    const gazebo::EntityComponentManager &_ecm)
-    {
-      auto id = _ecm.EntityByComponents(
-        components::Model(),
-        components::Name("vehicle"));
-      EXPECT_NE(kNullEntity, id);
-
-      auto poseComp = _ecm.Component<components::Pose>(id);
-      ASSERT_NE(nullptr, poseComp);
-
-      poses.push_back(poseComp->Data());
-    });
-  server.AddSystem(testSystem.systemPtr);
-
-  // Run server and check that vehicle didn't move
-  server.Run(true, 1000, false);
-
-  EXPECT_EQ(1000u, poses.size());
-
-  for (const auto &pose : poses)
-  {
-    EXPECT_EQ(poses[0], pose);
-  }
-
-  // Get odometry messages
-  double period{1.0 / 50.0};
-  double lastMsgTime{1.0};
-  std::vector<math::Pose3d> odomPoses;
-  std::function<void(const msgs::Odometry &)> odomCb =
-    [&](const msgs::Odometry &_msg)
-    {
-      ASSERT_TRUE(_msg.has_header());
-      ASSERT_TRUE(_msg.header().has_stamp());
-
-      double msgTime =
-          static_cast<double>(_msg.header().stamp().sec()) +
-          static_cast<double>(_msg.header().stamp().nsec()) * 1e-9;
-
-      EXPECT_DOUBLE_EQ(msgTime, lastMsgTime + period);
-      lastMsgTime = msgTime;
-
-      odomPoses.push_back(msgs::Convert(_msg.pose()));
-    };
-
-  // Publish command and check that vehicle moved
-  transport::Node node;
-  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/model/vehicle/odometry", odomCb);
-
-  msgs::Twist msg;
-
-  // Avoid wheel slip by limiting acceleration
-  Relay velocityRamp;
-  const double desiredLinVel = 0.5;
-  const double desiredAngVel = 0.2;
-  const double linAccel = 1;
-  const double angAccel = 1;
-  velocityRamp.OnPreUpdate(
-      [&](const gazebo::UpdateInfo &_info,
-          const gazebo::EntityComponentManager &)
-      {
-        double dt = std::chrono::duration<double>(_info.dt).count();
-        double nextLinVel = msg.linear().x() + dt * linAccel;
-        double nextAngVel = msg.angular().z() + dt * angAccel;
-        msgs::Set(msg.mutable_linear(),
-                  math::Vector3d(std::min(nextLinVel, desiredLinVel), 0, 0));
-        msgs::Set(msg.mutable_angular(),
-                  math::Vector3d(0.0, 0, std::min(nextAngVel, desiredAngVel)));
-        pub.Publish(msg);
-      });
-
-  server.AddSystem(velocityRamp.systemPtr);
-
-  server.Run(true, 3000, false);
-
-  // Poses for 4s
-  ASSERT_EQ(4000u, poses.size());
-
-  int sleep = 0;
-  int maxSleep = 30;
-  for (; odomPoses.size() < 150 && sleep < maxSleep; ++sleep)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  EXPECT_NE(maxSleep, sleep);
-
-  // Odometry calculates the pose of a point that is located half way between
-  // the two wheels, not the origin of the model. For example, if the vehicle is
-  // commanded to rotate in place, the vehicle will rotate about the point half
-  // way between the two wheels, thus, the odometry position will remain zero.
-  // However, since the model origin is offset, the model position will change.
-  // To find the final pose of the model, we have to do the following similarity
-  // transformation
-  math::Pose3d tOdomModel(0.554283, 0, -0.325, 0, 0, 0);
-  auto finalModelFramePose =
-      tOdomModel * odomPoses.back() * tOdomModel.Inverse();
-
-  // Odom for 3s
-  ASSERT_FALSE(odomPoses.empty());
-  EXPECT_EQ(150u, odomPoses.size());
-
-  EXPECT_LT(poses[0].Pos().X(), poses[3999].Pos().X());
-  EXPECT_LT(poses[0].Pos().Y(), poses[3999].Pos().Y());
-  EXPECT_NEAR(poses[0].Pos().Z(), poses[3999].Pos().Z(), tol);
-  EXPECT_NEAR(poses[0].Rot().X(), poses[3999].Rot().X(), tol);
-  EXPECT_NEAR(poses[0].Rot().Y(), poses[3999].Rot().Y(), tol);
-  EXPECT_LT(poses[0].Rot().Z(), poses[3999].Rot().Z());
-
-  // The value from odometry will be close, but not exactly the ground truth
-  // pose of the robot model. This is partially due to throttling the
-  // odometry publisher, partially due to a frame difference between the
-  // odom frame and the model frame, and partially due to wheel slip.
-  EXPECT_NEAR(poses[1020].Pos().X(), odomPoses[0].Pos().X(), 1e-2);
-  EXPECT_NEAR(poses[1020].Pos().Y(), odomPoses[0].Pos().Y(), 1e-2);
-  EXPECT_NEAR(poses.back().Pos().X(), finalModelFramePose.Pos().X(), 1e-2);
-  EXPECT_NEAR(poses.back().Pos().Y(), finalModelFramePose.Pos().Y(), 1e-2);
+  TestPublishCmd(
+      std::string(PROJECT_SOURCE_PATH) + "/test/worlds/diff_drive.sdf",
+      "/model/vehicle/cmd_vel", "/model/vehicle/odometry");
 }
+
+/////////////////////////////////////////////////
+TEST_P(DiffDriveTest, PublishCmdCustomTopics)
+{
+  TestPublishCmd(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_topics.sdf",
+      "/model/foo/cmdvel", "/model/bar/odom");
+}
+
 
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, SkidPublishCmd)

--- a/test/worlds/diff_drive_custom_topics.sdf
+++ b/test/worlds/diff_drive_custom_topics.sdf
@@ -1,0 +1,238 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="diff_drive">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="libignition-gazebo-physics-system.so"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name='vehicle'>
+      <pose>0 0 0.325 0 -0 0</pose>
+
+      <link name='chassis'>
+        <pose>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1.0 1</ambient>
+            <diffuse>0.5 0.5 1.0 1</diffuse>
+            <specular>0.0 0.0 1.0 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='left_wheel'>
+        <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='right_wheel'>
+        <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='caster'>
+        <pose>-0.957138 -0 -0.125 0 -0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name='left_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='right_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='caster_wheel' type='ball'>
+        <parent>chassis</parent>
+        <child>caster</child>
+      </joint>
+
+      <plugin
+        filename="libignition-gazebo-diff-drive-system.so"
+        name="ignition::gazebo::systems::DiffDrive">
+        <left_joint>left_wheel_joint</left_joint>
+        <right_joint>right_wheel_joint</right_joint>
+        <wheel_separation>1.25</wheel_separation>
+        <wheel_radius>0.3</wheel_radius>
+        <topic>/model/foo/cmdvel</topic>
+        <odom_topic>/model/bar/odom</odom_topic>
+        <!-- no odom_publisher_frequency defaults to 50 Hz -->
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>
+


### PR DESCRIPTION
This adds a `<odom_topic>` element to the DiffDrive system so that a custom odometry topic can be used.

Signed-off-by: Nate Koenig <nate@openrobotics.org>