### PR TITLE
Fix segfault in the Breadcrumbs system

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Gazebo 2.x
 
+### Ignition Gazebo 2.XX.XX (2020-XX-XX)
+
+1. Fix segfault in the Breadcrumbs system
+    * [Pull Request 180](https://github.com/ignitionrobotics/ign-gazebo/pull/180)
+
 ### Ignition Gazebo 2.19.0 (2020-06-02)
 
 1. Use updated model names for spawned models when generating SDFormat

--- a/src/systems/breadcrumbs/Breadcrumbs.cc
+++ b/src/systems/breadcrumbs/Breadcrumbs.cc
@@ -245,7 +245,8 @@ void Breadcrumbs::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
     }
 
     std::set<Entity> processedEntities;
-    for (const auto &e : this->pendingGeometryUpdate) {
+    for (const auto &e : this->pendingGeometryUpdate)
+    {
       Entity perf = _ecm.EntityByComponents(components::Performer(),
                                             components::ParentEntity(e));
       if (perf == kNullEntity)
@@ -282,16 +283,15 @@ void Breadcrumbs::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
       auto td = _info.simTime - it->second;
       if (td > this->disablePhysicsTime)
       {
-        auto nameComp = _ecm.Component<components::Name>(it->first);
+        auto name = _ecm.Component<components::Name>(it->first)->Data();
         if (!this->MakeStatic(it->first, _ecm))
         {
-          ignerr << "Failed to make breadcrumb '" << nameComp->Data()
+          ignerr << "Failed to make breadcrumb '" << name
                  << "' static." << std::endl;
         }
         else
         {
-          ignmsg << "Breadcrumb '" << nameComp->Data()
-                 << "' is now static." << std::endl;
+          ignmsg << "Breadcrumb '" << name << "' is now static." << std::endl;
         }
         this->autoStaticEntities.erase(it++);
       }


### PR DESCRIPTION
The segfault occurred because a pointer to a component is invalidated by the creation of new components. This doesn't always happen, but if a component type had 99 items, and we take get a pointer to a component, as soon as new components of the same type are created, the underlying `std::vector` containing the component gets expanded invalidating our pointer. The underlying `std::vector` gets expanded every 100 components.

To test, run the attached world (extension is .txt because github doesn't allow .sdf files). It should crash after 2 sim seconds.

[debug_breadcrumbs_crash.txt](https://github.com/ignitionrobotics/ign-gazebo/files/4732600/debug_breadcrumbs_crash.txt)
