### PR TITLE
Move test Relay to its own file

### DIFF
--- a/test/helpers/Relay.hh
+++ b/test/helpers/Relay.hh
@@ -24,9 +24,10 @@
 
 #include "../plugins/MockSystem.hh"
 
-using namespace ignition;
-using namespace gazebo;
-
+namespace ignition
+{
+namespace gazebo
+{
 namespace test
 {
 /// \brief Helper class to be used in internal tests. It allows registering
@@ -97,5 +98,7 @@ class Relay
   /// \brief Used to load the system.
   private: SystemLoader loader;
 };
+}
+}
 }
 #endif

--- a/test/helpers/Relay.hh
+++ b/test/helpers/Relay.hh
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_TEST_HELPERS_RELAY_HH_
+#define IGNITION_GAZEBO_TEST_HELPERS_RELAY_HH_
+
+#include <gtest/gtest.h>
+
+#include <ignition/gazebo/SystemLoader.hh>
+#include <ignition/gazebo/test_config.hh>
+
+#include "../plugins/MockSystem.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+namespace test
+{
+/// \brief Helper class to be used in internal tests. It allows registering
+/// callbacks that will be called during the update cycle. It works as a system
+/// without the need for test writers to do the plugin loading themselves.
+///
+/// ## Usage
+///
+///  // Instantiate a relay system
+///  test::Relay testSystem;
+///
+///  // Register callbacks, for example:
+///  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
+///    const gazebo::EntityComponentManager &_ecm)
+///    {
+///      // Add expectations here
+///    }
+///
+///  // Add the system to a server before running it
+///  server.AddSystem(testSystem.systemPtr);
+///
+class Relay
+{
+  /// \brief Constructor
+  public: Relay()
+  {
+    auto plugin = loader.LoadPlugin("libMockSystem.so",
+        "ignition::gazebo::MockSystem", nullptr);
+
+    EXPECT_TRUE(plugin.has_value());
+    this->systemPtr = plugin.value();
+
+    this->mockSystem = static_cast<MockSystem *>(
+        systemPtr->QueryInterface<System>());
+    EXPECT_NE(nullptr, this->mockSystem);
+  }
+
+  /// \brief Wrapper around system's pre-update callback
+  /// \param[in] _cb Function to be called every pre-update
+  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
+  {
+    this->mockSystem->preUpdateCallback = std::move(_cb);
+    return *this;
+  }
+
+  /// \brief Wrapper around system's update callback
+  /// \param[in] _cb Function to be called every update
+  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
+  {
+    this->mockSystem->updateCallback = std::move(_cb);
+    return *this;
+  }
+
+  /// \brief Wrapper around system's post-update callback
+  /// \param[in] _cb Function to be called every post-update
+  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
+  {
+    this->mockSystem->postUpdateCallback = std::move(_cb);
+    return *this;
+  }
+
+  /// \brief Pointer to underlying syste,
+  public: SystemPluginPtr systemPtr;
+
+  /// \brief Pointer to underlying mock interface
+  public: MockSystem *mockSystem;
+
+  /// \brief Used to load the system.
+  private: SystemLoader loader;
+};
+}
+#endif

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -33,7 +33,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -49,47 +49,6 @@ class AltimeterTest : public ::testing::Test
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
 };
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
-};
-
 
 std::mutex mutex;
 std::vector<msgs::Altimeter> altMsgs;
@@ -119,7 +78,7 @@ TEST_F(AltimeterTest, ModelFalling)
   const std::string sensorName = "altimeter_sensor";
 
   // Create a system that records altimeter data
-  Relay testSystem;
+  test::Relay testSystem;
   std::vector<math::Pose3d> poses;
   std::vector<math::Vector3d> velocities;
   testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,

--- a/test/integration/apply_joint_force_system.cc
+++ b/test/integration/apply_joint_force_system.cc
@@ -30,7 +30,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define TOL 1e-4
 
@@ -47,45 +47,6 @@ class ApplyJointForceTestFixture : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                    "ignition::gazebo::MockSystem", nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -110,7 +71,7 @@ TEST_F(ApplyJointForceTestFixture, JointVelocityCommand)
 
   const std::string jointName = "j1";
 
-  Relay testSystem;
+  test::Relay testSystem;
   std::vector<double> jointForceCmd;
   testSystem.OnPreUpdate(
       [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)

--- a/test/integration/breadcrumbs.cc
+++ b/test/integration/breadcrumbs.cc
@@ -33,7 +33,7 @@
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -47,46 +47,6 @@ class BreadcrumbsTest : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -106,7 +66,7 @@ TEST_F(BreadcrumbsTest, DeployAtOffset)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/model/vehicle_blue/cmd_vel");
   auto deployB1 =
@@ -181,7 +141,7 @@ TEST_F(BreadcrumbsTest, MaxDeployments)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/model/vehicle_blue/cmd_vel");
   auto deployB1 =
@@ -246,7 +206,7 @@ TEST_F(BreadcrumbsTest, FuelDeploy)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/model/vehicle_blue/cmd_vel");
   auto deploy = node.Advertise<msgs::Empty>("/fuel_deploy");
@@ -310,7 +270,7 @@ TEST_F(BreadcrumbsTest, Performer)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/model/vehicle_blue/cmd_vel");
   auto deploy = node.Advertise<msgs::Empty>(
@@ -395,7 +355,7 @@ TEST_F(BreadcrumbsTest, PerformerSetVolume)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto deploy = node.Advertise<msgs::Empty>(
       "/model/vehicle_blue/breadcrumbs/B1_perf_large_volume/deploy");
@@ -460,7 +420,7 @@ TEST_F(BreadcrumbsTest, DeployDisablePhysics)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/model/vehicle_blue/cmd_vel");
   auto deployB2 =

--- a/test/integration/detachable_joint.cc
+++ b/test/integration/detachable_joint.cc
@@ -33,7 +33,7 @@
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/WindMode.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -60,47 +60,6 @@ class DetachableJointTest : public ::testing::Test
   }
 
   public: std::unique_ptr<Server> server;
-};
-
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem = static_cast<MockSystem *>(
-        systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -135,9 +94,9 @@ TEST_F(DetachableJointTest, StartConnected)
   };
 
   std::vector<math::Pose3d> m1Poses, m2Poses;
-  Relay testSystem1;
+  test::Relay testSystem1;
   testSystem1.OnPostUpdate(poseRecorder("M1", m1Poses));
-  Relay testSystem2;
+  test::Relay testSystem2;
   testSystem2.OnPostUpdate(poseRecorder("M2", m2Poses));
 
   this->server->AddSystem(testSystem1.systemPtr);
@@ -213,9 +172,9 @@ TEST_F(DetachableJointTest, LinksInSameModel)
   };
 
   std::vector<math::Pose3d> b1Poses, b2Poses;
-  Relay testSystem1;
+  test::Relay testSystem1;
   testSystem1.OnPostUpdate(poseRecorder("body1", b1Poses));
-  Relay testSystem2;
+  test::Relay testSystem2;
   testSystem2.OnPostUpdate(poseRecorder("body2", b2Poses));
 
   this->server->AddSystem(testSystem1.systemPtr);

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -27,7 +27,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define tol 10e-4
 

--- a/test/integration/each_new_removed.cc
+++ b/test/integration/each_new_removed.cc
@@ -67,7 +67,7 @@ TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
   gazebo::Entity e1 = gazebo::kNullEntity;
   gazebo::Entity e2 = gazebo::kNullEntity;
 
-  test::Relay entityCreator;
+  gazebo::test::Relay entityCreator;
   entityCreator.OnPreUpdate(
     [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)
     {
@@ -82,7 +82,7 @@ TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
       }
   });
 
-  test::Relay entityRemover;
+  gazebo::test::Relay entityRemover;
   entityRemover.OnPreUpdate(
     [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)
     {
@@ -127,7 +127,7 @@ TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
     return counterImpl;
   };
 
-  test::Relay entityCounter;
+  gazebo::test::Relay entityCounter;
   entityCounter.OnPreUpdate(counterFunc(preCount));
   entityCounter.OnUpdate(counterFunc(updateCount));
   entityCounter.OnPostUpdate(counterFunc(postCount));

--- a/test/integration/each_new_removed.cc
+++ b/test/integration/each_new_removed.cc
@@ -28,7 +28,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace std::chrono_literals;
@@ -45,42 +45,6 @@ class EachNewRemovedFixture : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
       (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = this->systemLoader.LoadPlugin(
-        "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-    EXPECT_TRUE(plugin.has_value());
-    this->systemPtr = plugin.value();
-    this->mockSystem = static_cast<gazebo::MockSystem *>(
-        systemPtr->QueryInterface<gazebo::System>());
-  }
-
-  public: Relay &OnPreUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(gazebo::MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: ignition::gazebo::SystemPluginPtr systemPtr;
-
-  private: gazebo::SystemLoader systemLoader;
-  private: gazebo::MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -103,7 +67,7 @@ TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
   gazebo::Entity e1 = gazebo::kNullEntity;
   gazebo::Entity e2 = gazebo::kNullEntity;
 
-  Relay entityCreator;
+  test::Relay entityCreator;
   entityCreator.OnPreUpdate(
     [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)
     {
@@ -118,7 +82,7 @@ TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
       }
   });
 
-  Relay entityRemover;
+  test::Relay entityRemover;
   entityRemover.OnPreUpdate(
     [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)
     {
@@ -163,7 +127,7 @@ TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
     return counterImpl;
   };
 
-  Relay entityCounter;
+  test::Relay entityCounter;
   entityCounter.OnPreUpdate(counterFunc(preCount));
   entityCounter.OnUpdate(counterFunc(updateCount));
   entityCounter.OnPostUpdate(counterFunc(postCount));

--- a/test/integration/imu_system.cc
+++ b/test/integration/imu_system.cc
@@ -34,7 +34,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define TOL 1e-4
 
@@ -51,46 +51,6 @@ class ImuTest : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 std::mutex mutex;
@@ -125,7 +85,7 @@ TEST_F(ImuTest, ModelFalling)
   const std::string sensorName = "imu_sensor";
 
   // Create a system that records imu data
-  Relay testSystem;
+  test::Relay testSystem;
   math::Vector3d worldGravity;
   std::vector<math::Pose3d> poses;
   std::vector<math::Vector3d> accelerations;

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -30,7 +30,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define TOL 1e-4
 
@@ -47,45 +47,6 @@ class JointControllerTestFixture : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                    "ignition::gazebo::MockSystem", nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -108,7 +69,7 @@ TEST_F(JointControllerTestFixture, JointVelocityCommand)
 
   const std::string linkName = "rotor";
 
-  Relay testSystem;
+  test::Relay testSystem;
   std::vector<math::Vector3d> angularVelocities;
   testSystem.OnPreUpdate(
       [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -44,57 +44,18 @@
 #include "ignition/gazebo/components/PerformerLevels.hh"
 #include "ignition/gazebo/components/Pose.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
 using namespace std::chrono_literals;
 
 //////////////////////////////////////////////////
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = sm.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-    this->systemPtr = plugin.value();
-    this->mockSystem = static_cast<gazebo::MockSystem *>(
-        systemPtr->QueryInterface<gazebo::System>());
-  }
-
-  public: Relay &OnPreUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(
-              gazebo::MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: ignition::gazebo::SystemPluginPtr systemPtr;
-
-  protected: gazebo::SystemLoader sm;
-  protected: gazebo::MockSystem *mockSystem;
-};
-
-//////////////////////////////////////////////////
 /// \brief A system to move models to arbitrary poses. Note that this does not
 /// work if the physics system is running.
-class ModelMover: public Relay
+class ModelMover: public test::Relay
 {
-  public: explicit ModelMover(Entity _entity): Relay(), entity(_entity)
+  public: explicit ModelMover(Entity _entity): test::Relay(), entity(_entity)
   {
     using namespace std::placeholders;
     this->mockSystem->preUpdateCallback =
@@ -155,7 +116,7 @@ class LevelManagerFixture : public ::testing::Test
 
     server = std::make_unique<gazebo::Server>(serverConfig);
 
-    Relay testSystem;
+    test::Relay testSystem;
     // Check entities loaded on the default level
     testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
                             const gazebo::EntityComponentManager &_ecm)
@@ -220,7 +181,7 @@ TEST_F(LevelManagerFixture, DefaultLevel)
 {
   std::vector<std::set<std::string>> levelEntityNamesList;
 
-  Relay recorder;
+  test::Relay recorder;
   // Check entities loaded on the default level
   recorder.OnPostUpdate([&](const gazebo::UpdateInfo &,
                             const gazebo::EntityComponentManager &_ecm)

--- a/test/integration/level_manager_runtime_performers.cc
+++ b/test/integration/level_manager_runtime_performers.cc
@@ -41,56 +41,18 @@
 #include "ignition/gazebo/components/Pose.hh"
 
 #include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
 using namespace std::chrono_literals;
 
 //////////////////////////////////////////////////
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = sm.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-    this->systemPtr = plugin.value();
-    this->mockSystem = static_cast<gazebo::MockSystem *>(
-        systemPtr->QueryInterface<gazebo::System>());
-  }
-
-  public: Relay &OnPreUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(
-              gazebo::MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: ignition::gazebo::SystemPluginPtr systemPtr;
-
-  protected: gazebo::SystemLoader sm;
-  protected: gazebo::MockSystem *mockSystem;
-};
-
-//////////////////////////////////////////////////
 /// \brief A system to move models to arbitrary poses. Note that this does not
 /// work if the physics system is running.
-class ModelMover: public Relay
+class ModelMover: public test::Relay
 {
-  public: explicit ModelMover(Entity _entity): Relay(), entity(_entity)
+  public: explicit ModelMover(Entity _entity): test::Relay(), entity(_entity)
   {
     using namespace std::placeholders;
     this->mockSystem->preUpdateCallback =
@@ -180,7 +142,7 @@ class LevelManagerFixture : public ::testing::Test
     EXPECT_TRUE(result);
     EXPECT_TRUE(rep.data());
 
-    Relay testSystem;
+    test::Relay testSystem;
     // Check entities loaded on the default level
     testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
                             const gazebo::EntityComponentManager &_ecm)
@@ -248,7 +210,7 @@ TEST_F(LevelManagerFixture, DefaultLevel)
 {
   std::vector<std::set<std::string>> levelEntityNamesList;
 
-  Relay recorder;
+  test::Relay recorder;
   // Check entities loaded on the default level
   recorder.OnPostUpdate([&](const gazebo::UpdateInfo &,
                             const gazebo::EntityComponentManager &_ecm)

--- a/test/integration/lift_drag_system.cc
+++ b/test/integration/lift_drag_system.cc
@@ -37,7 +37,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define TOL 1e-4
 
@@ -54,45 +54,6 @@ class LiftDragTestFixture : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                    "ignition::gazebo::MockSystem", nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -118,7 +79,7 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
   const std::string jointName = "body_joint";
   const double desiredVel = -0.2;
 
-  Relay testSystem;
+  test::Relay testSystem;
   std::vector<math::Vector3d> linearVelocities;
   std::vector<math::Vector3d> forces;
   testSystem.OnPreUpdate(
@@ -185,7 +146,7 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
   // \todo(addisu) This assumes that the this system will run after the lift
   // drag system. This is needed to capture the wrench set by the lift drag
   // system. This assumption may not hold when systems are run in parallel.
-  Relay wrenchRecorder;
+  test::Relay wrenchRecorder;
   wrenchRecorder.OnPreUpdate([&](const gazebo::UpdateInfo &,
                               const gazebo::EntityComponentManager &_ecm)
       {

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -47,7 +47,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -149,46 +149,6 @@ void entryDiff(std::vector<std::string> &_paths1,
   _diff.resize(diffIt - _diff.begin());
 }
 #endif
-
-/////////////////////////////////////////////////
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                    "ignition::gazebo::MockSystem", nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
-};
 
 //////////////////////////////////////////////////
 class LogSystemTest : public ::testing::Test
@@ -917,7 +877,7 @@ TEST_F(LogSystemTest, LogControl)
 
   Server server(config);
 
-  Relay testSystem;
+  test::Relay testSystem;
   math::Pose3d spherePose;
   bool sphereFound{false};
   testSystem.OnPostUpdate(
@@ -1317,7 +1277,7 @@ TEST_F(LogSystemTest, LogControlLevels)
 
   Server server(config);
 
-  Relay testSystem;
+  test::Relay testSystem;
 
   EntityGraph entityGraph;
 

--- a/test/integration/magnetometer_system.cc
+++ b/test/integration/magnetometer_system.cc
@@ -32,7 +32,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define TOL 1e-4
 
@@ -49,45 +49,6 @@ class MagnetometerTest : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 std::mutex mutex;
@@ -118,7 +79,7 @@ TEST_F(MagnetometerTest, RotatedMagnetometer)
   const std::string sensorName = "magnetometer_sensor";
 
   // Create a system that records magnetometer data
-  Relay testSystem;
+  test::Relay testSystem;
 
   std::vector<math::Pose3d> poses;
   testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,

--- a/test/integration/multicopter.cc
+++ b/test/integration/multicopter.cc
@@ -36,7 +36,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -68,46 +68,6 @@ class MulticopterTest : public ::testing::Test
   }
 };
 
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem = static_cast<MockSystem *>(
-        systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
-};
-
 /////////////////////////////////////////////////
 // Test that commanded motor speed is applied
 TEST_F(MulticopterTest, CommandedMotorSpeed)
@@ -115,7 +75,7 @@ TEST_F(MulticopterTest, CommandedMotorSpeed)
   // Start server
   auto server = this->StartServer("/test/worlds/quadcopter.sdf");
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdMotorSpeed =
       node.Advertise<msgs::Actuators>("/X3/gazebo/command/motor_speed");
@@ -182,7 +142,7 @@ TEST_F(MulticopterTest, MulticopterVelocityControl)
   auto server =
       this->StartServer("/test/worlds/quadcopter_velocity_control.sdf");
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/X3/gazebo/command/twist");
 
@@ -290,7 +250,7 @@ TEST_F(MulticopterTest, ModelAndVelocityControlInteraction)
   auto server =
       this->StartServer("/test/worlds/quadcopter_velocity_control.sdf");
 
-  Relay testSystem;
+  test::Relay testSystem;
   transport::Node node;
   auto cmdVel = node.Advertise<msgs::Twist>("/X3/gazebo/command/twist");
 

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -55,7 +55,7 @@
 #include "ignition/gazebo/components/Visual.hh"
 #include "ignition/gazebo/components/World.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -71,44 +71,6 @@ class PhysicsSystemFixture : public ::testing::Test
       (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
 };
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = sm.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-    this->systemPtr = plugin.value();
-    this->mockSystem = static_cast<gazebo::MockSystem *>(
-        systemPtr->QueryInterface<gazebo::System>());
-  }
-
-  public: Relay & OnPreUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay & OnUpdate(gazebo::MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay & OnPostUpdate(gazebo::MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: ignition::gazebo::SystemPluginPtr systemPtr;
-
-  private: gazebo::SystemLoader sm;
-  private: gazebo::MockSystem *mockSystem;
-};
-
 
 /////////////////////////////////////////////////
 TEST_F(PhysicsSystemFixture, CreatePhysicsWorld)
@@ -153,7 +115,7 @@ TEST_F(PhysicsSystemFixture, FallingObject)
   std::vector<ignition::math::Pose3d> spherePoses;
 
   // Create a system that records the poses of the sphere
-  Relay testSystem;
+  test::Relay testSystem;
 
   testSystem.OnPostUpdate(
     [modelName, &spherePoses](const gazebo::UpdateInfo &,
@@ -230,7 +192,7 @@ TEST_F(PhysicsSystemFixture, CanonicalLink)
   ASSERT_EQ(3u, expectedLinPoses.size());
 
   // Create a system that records the poses of the links after physics
-  Relay testSystem;
+  test::Relay testSystem;
 
   std::unordered_map<std::string, ignition::math::Pose3d> postUpLinkPoses;
   testSystem.OnPostUpdate(
@@ -293,7 +255,7 @@ TEST_F(PhysicsSystemFixture, RevoluteJoint)
   const std::string modelName{"revolute_demo"};
   const std::string rotatingLinkName{"link2"};
 
-  Relay testSystem;
+  test::Relay testSystem;
 
   std::vector<double> armDistances;
 
@@ -363,7 +325,7 @@ TEST_F(PhysicsSystemFixture, CreateRuntime)
   // create `Relay` systems in the first place. Consider keeping the ECM in a
   // shared pointer owned by the SimulationRunner.
   EntityComponentManager *ecm{nullptr};
-  Relay testSystem;
+  test::Relay testSystem;
   testSystem.OnPreUpdate([&](const gazebo::UpdateInfo &,
                              gazebo::EntityComponentManager &_ecm)
       {
@@ -450,7 +412,7 @@ TEST_F(PhysicsSystemFixture, SetFrictionCoefficient)
   std::map<std::string, std::vector<ignition::math::Pose3d>> poses;
 
   // Create a system that records the poses of the 3 boxes
-  Relay testSystem;
+  test::Relay testSystem;
   double dt = 0.0;
 
   testSystem.OnPostUpdate(
@@ -532,7 +494,7 @@ TEST_F(PhysicsSystemFixture, MultiAxisJointPosition)
 
   server.SetUpdatePeriod(0ns);
 
-  Relay testSystem;
+  test::Relay testSystem;
   // Create JointPosition components if they don't already exist
   testSystem.OnPreUpdate(
       [&](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)
@@ -619,7 +581,7 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
 
   const std::string rotatingJointName{"j2"};
 
-  Relay testSystem;
+  test::Relay testSystem;
 
   double pos0 = 0.42;
 
@@ -714,7 +676,7 @@ TEST_F(PhysicsSystemFixture, ResetVelocityComponent)
 
   const std::string rotatingJointName{"j2"};
 
-  Relay testSystem;
+  test::Relay testSystem;
 
   double vel0 = 3.0;
 
@@ -807,7 +769,7 @@ TEST_F(PhysicsSystemFixture, GetBoundingBox)
   std::map<std::string, ignition::math::AxisAlignedBox> bbox;
 
   // Create a system that records the bounding box of a model
-  Relay testSystem;
+  test::Relay testSystem;
 
   testSystem.OnPreUpdate(
     [&](const gazebo::UpdateInfo &,

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -31,7 +31,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 #define tol 10e-4
 
@@ -48,46 +48,6 @@ class PosePublisherTest : public ::testing::TestWithParam<int>
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                "ignition::gazebo::MockSystem",
-                                nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem = static_cast<MockSystem *>(
-        systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 std::mutex mutex;
@@ -155,7 +115,7 @@ TEST_F(PosePublisherTest, PublishCmd)
   EXPECT_FALSE(*server.Running(0));
 
   // Create a system that records the model's link poses
-  Relay testSystem;
+  test::Relay testSystem;
 
   // The delimiter is hard coded in PosePublisher. If it changes there, it needs
   // to be changed here as well
@@ -366,7 +326,7 @@ TEST_F(PosePublisherTest, UpdateFrequency)
   EXPECT_FALSE(*server.Running(0));
 
   // Create a system that records the model's link poses
-  Relay testSystem;
+  test::Relay testSystem;
 
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -431,7 +391,7 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
   EXPECT_FALSE(*server.Running(0));
 
   // Create a system that records the model's link poses
-  Relay testSystem;
+  test::Relay testSystem;
 
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -683,7 +643,7 @@ TEST_F(PosePublisherTest, StaticPoseUpdateFrequency)
   EXPECT_FALSE(*server.Running(0));
 
   // Create a system that records the model's link poses
-  Relay testSystem;
+  test::Relay testSystem;
 
   {
     std::lock_guard<std::mutex> lock(mutex);

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -32,7 +32,7 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "plugins/MockSystem.hh"
+#include "../helpers/Relay.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -47,47 +47,6 @@ class UserCommandsTest : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
-};
-
-//////////////////////////////////////////////////
-class Relay
-{
-  public: Relay()
-  {
-    auto plugin = loader.LoadPlugin("libMockSystem.so",
-                                    "ignition::gazebo::MockSystem",
-                                    nullptr);
-    EXPECT_TRUE(plugin.has_value());
-
-    this->systemPtr = plugin.value();
-
-    this->mockSystem =
-        dynamic_cast<MockSystem *>(systemPtr->QueryInterface<System>());
-    EXPECT_NE(nullptr, this->mockSystem);
-  }
-
-  public: Relay &OnPreUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->preUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnUpdate(MockSystem::CallbackType _cb)
-  {
-    this->mockSystem->updateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: Relay &OnPostUpdate(MockSystem::CallbackTypeConst _cb)
-  {
-    this->mockSystem->postUpdateCallback = std::move(_cb);
-    return *this;
-  }
-
-  public: SystemPluginPtr systemPtr;
-
-  private: SystemLoader loader;
-  private: MockSystem *mockSystem;
 };
 
 /////////////////////////////////////////////////
@@ -109,7 +68,7 @@ TEST_F(UserCommandsTest, Create)
   // create `Relay` systems in the first place. Consider keeping the ECM in a
   // shared pointer owned by the SimulationRunner.
   EntityComponentManager *ecm{nullptr};
-  Relay testSystem;
+  test::Relay testSystem;
   testSystem.OnPreUpdate([&](const gazebo::UpdateInfo &,
                              gazebo::EntityComponentManager &_ecm)
       {
@@ -371,7 +330,7 @@ TEST_F(UserCommandsTest, Remove)
   // create `Relay` systems in the first place. Consider keeping the ECM in a
   // shared pointer owned by the SimulationRunner.
   EntityComponentManager *ecm{nullptr};
-  Relay testSystem;
+  test::Relay testSystem;
   testSystem.OnPreUpdate([&](const gazebo::UpdateInfo &,
                              gazebo::EntityComponentManager &_ecm)
       {
@@ -555,7 +514,7 @@ TEST_F(UserCommandsTest, Pose)
 
   // Create a system just to get the ECM
   EntityComponentManager *ecm{nullptr};
-  Relay testSystem;
+  test::Relay testSystem;
   testSystem.OnPreUpdate([&](const gazebo::UpdateInfo &,
                              gazebo::EntityComponentManager &_ecm)
       {


### PR DESCRIPTION
This reduces a lot of code duplication that we currently have in tests.

:sparkles: ` 170 additions and 740 deletions. ` :sparkles: 