### PR TITLE
Battery updates

### DIFF
--- a/examples/worlds/linear_battery_demo.sdf
+++ b/examples/worlds/linear_battery_demo.sdf
@@ -523,7 +523,7 @@
         <resistance>0.07</resistance>
         <smooth_current_tau>2.0</smooth_current_tau>
         <enable_recharge>true</enable_recharge>
-        <!-- charging I = c / t, discharging I = P / V, 
+        <!-- charging I = c / t, discharging I = P / V,
           charging I should be > discharging I -->
         <charging_time>3.0</charging_time>
         <soc_threshold>0.51</soc_threshold>

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -18,8 +18,8 @@
 #include <ignition/msgs/battery_state.pb.h>
 #include <ignition/msgs/boolean.pb.h>
 
+#include <atomic>
 #include <functional>
-#include <mutex>
 #include <string>
 
 #include <ignition/common/Battery.hh>
@@ -112,7 +112,7 @@ class ignition::gazebo::systems::LinearBatteryPluginPrivate
   public: double soc{1.0};
 
   /// \brief Recharge status
-  public: bool startCharging{false};
+  public: std::atomic_bool startCharging{false};
 
   /// \brief Hours taken to fully charge battery
   public: double tCharge{0.0};
@@ -145,9 +145,6 @@ class ignition::gazebo::systems::LinearBatteryPluginPrivate
 
   /// \brief Battery state of charge message publisher
   public: transport::Node::Publisher statePub;
-
-  /// \brief Mutex to protect "startCharging".
-  public: std::mutex mutex;
 };
 
 /////////////////////////////////////////////////
@@ -327,7 +324,6 @@ void LinearBatteryPluginPrivate::OnEnableRecharge(
   const ignition::msgs::Boolean &/*_req*/)
 {
   igndbg << "Request for start charging received" << std::endl;
-  std::lock_guard<std::mutex> lock(this->mutex);
   this->startCharging = true;
 }
 
@@ -336,7 +332,6 @@ void LinearBatteryPluginPrivate::OnDisableRecharge(
   const ignition::msgs::Boolean &/*_req*/)
 {
   igndbg << "Request for stop charging received" << std::endl;
-  std::lock_guard<std::mutex> lock(this->mutex);
   this->startCharging = false;
 }
 

--- a/src/systems/battery_plugin/LinearBatteryPlugin.hh
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.hh
@@ -40,8 +40,8 @@ namespace systems
   /// \brief A plugin for simulating battery usage
   ///
   /// This system processes the following sdf parameters:
-  /// <battery_name> name of the battery
-  /// <voltage> Initial voltage of the battery
+  /// <battery_name> name of the battery (required)
+  /// <voltage> Initial voltage of the battery (required)
   /// <open_circuit_voltage_constant_coef> Voltage at full charge
   /// <open_circuit_voltage_linear_coef> Amount of voltage decrease when no
   ///                                    charge
@@ -49,9 +49,12 @@ namespace systems
   /// <capacity> Total charge that the battery can hold
   /// <resistance> Internal resistance
   /// <smooth_current_tau> coefficient for smoothing current
-  /// <power_load> power load on battery
+  /// <power_load> power load on battery (required)
   /// <start_on_motion> if set to true, the battery will start draining
-  ///                  only if the robot has started moving
+  ///                   only if the robot has started moving
+  /// <enable_recharge> If true, the battery can be recharged
+  /// <charging_time> Hours taken to fully charge the battery.
+  ///                 (Required if <enable_recharge> is set to true)
   class IGNITION_GAZEBO_VISIBLE LinearBatteryPlugin
       : public System,
         public ISystemConfigure,


### PR DESCRIPTION
This patch introduces the following battery updates:

* The recharging is no longer triggered by the parameter `socThreshold`. The old behavior implies that a battery automatically starts charging when the battery capacity falls below a certain threshold. I think it's more realistic that the recharging can be started or stopped on demand. I took the liberty of removing the `socThreshold` parameter directly because it wasn't documented in the header file.

* If `<enable_recharging>` is present, two new services are available for starting or stopping the battery recharge.

* If there's no joint velocity/force command, the battery doesn't drain anymore. Before, once the battery started draining, it never stopped even if the joints weren't moving.

* I updated the battery status published. It can now be in `CHARGING`, `DISCHARGING`, `FULL` or `NOT_CHARGING` state.

* I documented the SDF charging parameters and added a few minor tweaks.