### PR TITLE
Model Preview Fix

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -596,6 +596,10 @@ void IgnRenderer::Render()
     IGN_PROFILE("IgnRenderer::Render Shapes");
     if (this->dataPtr->spawnModel)
     {
+      // Terminate any pre-existing visualized models
+      this->TerminatePreviewModel();
+
+      // Generate preview model
       rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
       rendering::VisualPtr rootVis = scene->RootVisual();
       this->dataPtr->placingModel =


### PR DESCRIPTION
This PR fixes a bug that occurred when the user would select multiple shapes from the qml without clicking the scene or pressing Escape.  The fix simply clears any pre-existing visualized models so they do not persist in the scene after they are done being used.


Signed-off-by: John Shepherd <john@openrobotics.org>