### PR TITLE
Battery updates - Part 2

### DIFF
--- a/examples/worlds/lift_drag_battery.sdf
+++ b/examples/worlds/lift_drag_battery.sdf
@@ -364,10 +364,9 @@
         <resistance>0.07</resistance>
         <smooth_current_tau>2.0</smooth_current_tau>
         <enable_recharge>true</enable_recharge>
-        <!-- charging I = c / t, discharging I = P / V, 
+        <!-- charging I = c / t, discharging I = P / V,
           charging I should be > discharging I -->
         <charging_time>3.0</charging_time>
-        <soc_threshold>0.51</soc_threshold>
         <!-- Consumer-specific -->
         <power_load>2.1</power_load>
         <start_on_motion>true</start_on_motion>

--- a/examples/worlds/linear_battery_demo.sdf
+++ b/examples/worlds/linear_battery_demo.sdf
@@ -538,7 +538,6 @@
         <!-- charging I = c / t, discharging I = P / V,
           charging I should be > discharging I -->
         <charging_time>3.0</charging_time>
-        <soc_threshold>0.51</soc_threshold>
         <!-- Consumer-specific -->
         <power_load>2.1</power_load>
         <start_on_motion>false</start_on_motion>

--- a/examples/worlds/linear_battery_demo.sdf
+++ b/examples/worlds/linear_battery_demo.sdf
@@ -17,16 +17,16 @@
       ign topic -e -t /model/vehicle_blue/battery/linear_battery/state
 
   Recharge the battery using a service (default):
-      ign service -s /model/vehicle_blue/linear_battery/recharge/start --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Empty --req 'data:true' --timeout 1000
+      ign service -s /model/vehicle_blue/battery/linear_battery/recharge/start --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Empty --req 'data:true' --timeout 1000
 
   Recharge the battery using a topic (optional if <recharge_by_topic> is true):
-      ign topic -t /model/vehicle_blue/linear_battery/recharge/start -m ignition.msgs.Boolean -p 'data:true'
+      ign topic -t /model/vehicle_blue/battery/linear_battery/recharge/start -m ignition.msgs.Boolean -p 'data:true'
 
   Stop recharging the battery using a service (default):
-      ign service -s /model/vehicle_blue/linear_battery/recharge/stop --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Empty --req 'data:true' --timeout 1000
+      ign service -s /model/vehicle_blue/battery/linear_battery/recharge/stop --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Empty --req 'data:true' --timeout 1000
 
   Stop recharging the battery using a topic (optional if <recharge_by_topic> is true):
-      ign topic -t /model/vehicle_blue/linear_battery/recharge/stop -m ignition.msgs.Boolean -p 'data:true'
+      ign topic -t /model/vehicle_blue/battery/linear_battery/recharge/stop -m ignition.msgs.Boolean -p 'data:true'
 
   The blue vehicle should stop when it runs out of battery.
 

--- a/examples/worlds/linear_battery_demo.sdf
+++ b/examples/worlds/linear_battery_demo.sdf
@@ -16,6 +16,18 @@
   Listen to battery state of charge:
       ign topic -e -t /model/vehicle_blue/battery/linear_battery/state
 
+  Recharge the battery using a service (default):
+      ign service -s /model/vehicle_blue/linear_battery/recharge/start --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Empty --req 'data:true' --timeout 1000
+
+  Recharge the battery using a topic (optional if <recharge_by_topic> is true):
+      ign topic -t /model/vehicle_blue/linear_battery/recharge/start -m ignition.msgs.Boolean -p 'data:true'
+
+  Stop recharging the battery using a service (default):
+      ign service -s /model/vehicle_blue/linear_battery/recharge/stop --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Empty --req 'data:true' --timeout 1000
+
+  Stop recharging the battery using a topic (optional if <recharge_by_topic> is true):
+      ign topic -t /model/vehicle_blue/linear_battery/recharge/stop -m ignition.msgs.Boolean -p 'data:true'
+
   The blue vehicle should stop when it runs out of battery.
 
 -->
@@ -530,6 +542,7 @@
         <!-- Consumer-specific -->
         <power_load>2.1</power_load>
         <start_on_motion>false</start_on_motion>
+        <recharge_by_topic>true</recharge_by_topic>
       </plugin>
 
     </model>

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -252,15 +252,24 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
                   "Parameter required to enable recharge.\n";
         return;
       }
-      std::string enableRechargeService = this->dataPtr->modelName +
+
+      std::string enableRechargeTopic = "/model/" + this->dataPtr->modelName +
         "/" + _sdf->Get<std::string>("battery_name") + "/recharge/start";
-      std::string disableRechargeService = this->dataPtr->modelName +
+      std::string disableRechargeTopic = "/model/" + this->dataPtr->modelName +
         "/" + _sdf->Get<std::string>("battery_name") + "/recharge/stop";
 
-      this->dataPtr->node.Advertise(enableRechargeService,
+      this->dataPtr->node.Advertise(enableRechargeTopic,
         &LinearBatteryPluginPrivate::OnEnableRecharge, this->dataPtr.get());
-      this->dataPtr->node.Advertise(disableRechargeService,
+      this->dataPtr->node.Advertise(disableRechargeTopic,
         &LinearBatteryPluginPrivate::OnDisableRecharge, this->dataPtr.get());
+
+      if (_sdf->HasElement("recharge_by_topic"))
+      {
+        this->dataPtr->node.Subscribe(enableRechargeTopic,
+          &LinearBatteryPluginPrivate::OnEnableRecharge, this->dataPtr.get());
+        this->dataPtr->node.Subscribe(disableRechargeTopic,
+          &LinearBatteryPluginPrivate::OnDisableRecharge, this->dataPtr.get());
+      }
     }
   }
 

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -254,9 +254,11 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
       }
 
       std::string enableRechargeTopic = "/model/" + this->dataPtr->modelName +
-        "/" + _sdf->Get<std::string>("battery_name") + "/recharge/start";
+        "/battery/" + _sdf->Get<std::string>("battery_name") +
+        "/recharge/start";
       std::string disableRechargeTopic = "/model/" + this->dataPtr->modelName +
-        "/" + _sdf->Get<std::string>("battery_name") + "/recharge/stop";
+        "/battery/" + _sdf->Get<std::string>("battery_name") +
+        "/recharge/stop";
 
       this->dataPtr->node.Advertise(enableRechargeTopic,
         &LinearBatteryPluginPrivate::OnEnableRecharge, this->dataPtr.get());

--- a/src/systems/battery_plugin/LinearBatteryPlugin.hh
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.hh
@@ -53,6 +53,9 @@ namespace systems
   /// <start_on_motion> if set to true, the battery will start draining
   ///                   only if the robot has started moving
   /// <enable_recharge> If true, the battery can be recharged
+  /// <recharge_by_topic> If true, the start/stop signals for recharging the
+  ///                     battery will also be available via topics. The
+  ///                     regular Ignition services will still be available.
   /// <charging_time> Hours taken to fully charge the battery.
   ///                 (Required if <enable_recharge> is set to true)
   class IGNITION_GAZEBO_VISIBLE LinearBatteryPlugin


### PR DESCRIPTION
Follow-up of https://github.com/ignitionrobotics/ign-gazebo/pull/183

By default the charging control is triggered by services. This patch adds the ability to also do it using topics.

@claireyywang I've updated `linear_battery_demo.sdf` with all the `ign` commands to control the charging process.