### PR TITLE
Capitalize openrobotics

### DIFF
--- a/examples/worlds/breadcrumbs.sdf
+++ b/examples/worlds/breadcrumbs.sdf
@@ -472,7 +472,7 @@
               <pose>-2 0 0 0 0 0</pose>
               <include>
                 <uri>
-                  https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X2 Config 1
+                  https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1
                 </uri>
               </include>
             </model>

--- a/examples/worlds/camera_sensor.sdf
+++ b/examples/worlds/camera_sensor.sdf
@@ -258,7 +258,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Construction Cone
+      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
     </include>
 

--- a/examples/worlds/depth_camera_sensor.sdf
+++ b/examples/worlds/depth_camera_sensor.sdf
@@ -227,7 +227,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Construction Barrel
+      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Barrel
       </uri>
     </include>
 

--- a/examples/worlds/fuel_textured_mesh.sdf
+++ b/examples/worlds/fuel_textured_mesh.sdf
@@ -169,7 +169,7 @@
       <static>true</static>
       <name>Rescue Randy</name>
       <pose>0 0 0 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Rescue Randy</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Rescue Randy</uri>
     </include>
 
     <model name="ground_plane">

--- a/examples/worlds/gpu_lidar_sensor.sdf
+++ b/examples/worlds/gpu_lidar_sensor.sdf
@@ -235,7 +235,7 @@
     <include>
       <pose>0 0 0 0 0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Playground
+      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Playground
       </uri>
     </include>
 

--- a/examples/worlds/log_record_resources.sdf
+++ b/examples/worlds/log_record_resources.sdf
@@ -121,7 +121,7 @@
       <static>false</static>
       <name>staging_area</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X2 Config 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1</uri>
     </include>
 
     <model name="ground_plane">

--- a/examples/worlds/multicopter_velocity_control.sdf
+++ b/examples/worlds/multicopter_velocity_control.sdf
@@ -155,7 +155,7 @@ You can use the velocity controller and command linear velocity and yaw angular 
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X3 UAV/4
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X3 UAV/4
       </uri>
       <plugin
         filename="libignition-gazebo-multicopter-motor-model-system.so"
@@ -280,7 +280,7 @@ You can use the velocity controller and command linear velocity and yaw angular 
     <include>
       <pose>0 3 1 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X4 UAV Config 1
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X4 UAV Config 1
       </uri>
 
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"

--- a/examples/worlds/quadcopter.sdf
+++ b/examples/worlds/quadcopter.sdf
@@ -144,7 +144,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X3 UAV/4
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X3 UAV/4
       </uri>
       <plugin
         filename="libignition-gazebo-multicopter-motor-model-system.so"

--- a/examples/worlds/sensors_demo.sdf
+++ b/examples/worlds/sensors_demo.sdf
@@ -406,7 +406,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Construction Cone
+      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
     </include>
 

--- a/examples/worlds/tunnel.sdf
+++ b/examples/worlds/tunnel.sdf
@@ -104,181 +104,181 @@
       <static>true</static>
       <name>BaseStation</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/subt_tunnel_staging_area</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/subt_tunnel_staging_area</uri>
     </include>
 
     <!-- Fiducial marking the origin for artifacts reports -->
     <include>
       <name>artifact_origin</name>
       <pose>2 4 0.5 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Fiducial</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fiducial</uri>
     </include>
 
     <!-- Tunnel tiles and artifacts -->
     <include>
       <name>tile_0</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>240.000000 240.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_1</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 240.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_2</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Constrained Tunnel Tile Tall</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Tall</uri>
       <pose>280.000000 240.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_3</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>300.000000 240.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_4</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>160.000000 211.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_5</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 220.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>radio_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Radio
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio
       </uri>
       <pose>241.500000 220.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_6</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>300.000000 220.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_7</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>69.000000 200.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_8</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_9</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>100.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_10</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>120.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_11</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_12</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>160.000000 200.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_13</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>180.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_14</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_15</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_16</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>240.000000 200.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_17</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>300.000000 200.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_18</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>160.000000 180.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>backpack_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack
       </uri>
       <pose>219.000000 202.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_19</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>260.000000 180.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_20</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 180.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_21</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>300.000000 180.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_22</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>320.000000 180.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_23</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>340.000000 180.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_24</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Constrained Tunnel Tile Tall
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Tall
       </uri>
       <pose>160.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
@@ -286,509 +286,509 @@
     <include>
       <name>phone_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Phone
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Phone
       </uri>
       <pose>260.000000 160.000000 -14.996000 -1.570796 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_25</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_26</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>300.000000 169.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_27</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>toolbox_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Toolbox
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Toolbox
       </uri>
       <pose>342.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_28</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>60.000000 131.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_29</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>80.000000 131.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_30</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>160.000000 140.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>extinguisher_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Extinguisher
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Extinguisher
       </uri>
       <pose>158.000000 140.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_31</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>260.000000 149.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_32</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>340.000000 149.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_33</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>60.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_34</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>80.000000 120.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_35</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>100.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_36</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>120.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_37</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_38</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>160.000000 120.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_39</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 100.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_40</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>200.000000 100.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_41</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 100.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_42</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 100.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_43</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>260.000000 100.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>radio_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Radio
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio
       </uri>
       <pose>260.000000 82.300000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_44</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 80.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_45</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 80.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_46</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>260.000000 80.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_47</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>280.000000 80.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_48</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>80.000000 60.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_49</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 60.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_50</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 60.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>toolbox_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Toolbox
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Toolbox
       </uri>
       <pose>278.000000 60.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_51</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 40.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_52</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_53</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_54</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 20.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_55</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>phone_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Phone
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Phone
       </uri>
       <pose>201.800000 20.000000 -14.996000 -1.570796 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_56</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_57</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>320.000000 20.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_58</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 20.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_59</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>360.000000 20.000000 -20.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>electrical_box_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Electrical Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Electrical Box
       </uri>
       <pose>400.000000 -1.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_60</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>20.000000 0.000000 0.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_61</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>40.000000 0.000000 -5.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_62</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>60.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_63</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>80.000000 0.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_64</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>100.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_65</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>120.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_66</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_67</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>160.000000 0.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_68</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>180.000000 0.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_69</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>200.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_70</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>211.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_71</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>269.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_72</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>280.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_73</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>300.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_74</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>320.000000 0.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_75</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_76</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>360.000000 0.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_77</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>380.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_78</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>400.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_79</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>411.000000 0.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_80</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 7</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 7</uri>
       <pose>80.000000 -20.000000 -10.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_81</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 -20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_82</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_83</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>320.000000 -20.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_84</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 -20.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_85</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>360.000000 -20.000000 -20.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_86</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 -40.000000 -5.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_87</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 -40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_88</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>backpack_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack
       </uri>
       <pose>340.000000 -22.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_89</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 -60.000000 -5.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_90</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>200.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_91</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_92</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_93</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_94</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>280.000000 -60.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_95</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>80.000000 -80.000000 -5.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_96</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 7</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 7</uri>
       <pose>100.000000 -80.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_97</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>120.000000 -80.000000 -10.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>phone_3</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Phone
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Phone
       </uri>
       <pose>120.800000 -98.400000 -9.996000 1.570796 0 0.000000</pose>
     </include>
@@ -796,180 +796,180 @@
     <include>
       <name>valve_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Valve
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Valve
       </uri>
       <pose>240.000000 -58.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_98</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>120.000000 -100.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_99</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>140.000000 -100.000000 -10.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_100</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -120.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>valve_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Valve
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Valve
       </uri>
       <pose>141.750000 -119.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_101</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -140.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_102</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Constrained Tunnel Tile Short
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Short
       </uri>
       <pose>140.000000 -160.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_103</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>280.000000 -169.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>electrical_box_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Electrical Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Electrical Box
       </uri>
       <pose>138.000000 -180.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_104</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -180.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>backpack_3</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack
       </uri>
       <pose>180.000000 -198.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_105</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -180.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_106</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -200.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_107</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>160.000000 -200.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_108</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>180.000000 -200.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_109</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 -200.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_110</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>220.000000 -200.000000 -10.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_111</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -200.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_112</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>140.000000 -220.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_113</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>160.000000 -220.000000 -10.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_114</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 -220.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_115</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -220.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>extinguisher_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Extinguisher
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Extinguisher
       </uri>
       <pose>278.000000 -220.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_116</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>220.000000 -240.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_117</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 -240.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_118</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 -240.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_119</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>280.000000 -240.000000 -10.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>x1</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X1 UGV</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X1 UGV</uri>
       <pose>0 0 .2 0 0 0</pose>
     </include>
 

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -523,17 +523,17 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack/1";
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {
       // Thes following two URIs are valid, but have a trailing '/'
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack/",
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack/1/",
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/",
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1/",
       // Thes following two URIs are invalid, and will not be saved
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack/"
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/"
       "notInt",
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack/"
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/"
       "notInt/",
   };
 
@@ -588,7 +588,7 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithNonFuelUris)
 {
   const std::vector<std::string> includeUris = {
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack",
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack",
       std::string("file://") + PROJECT_SOURCE_PATH +
           "/test/worlds/models/sphere"};
 

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -1702,7 +1702,7 @@ TEST_F(LogSystemTest, LogResources)
   // Recorded models should exist
   EXPECT_GT(entryCount(recordPath), 2);
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      ".ignition", "fuel", "fuel.ignitionrobotics.org", "OpenRobotics",
       "models", "X2 Config 1")));
 
   // Remove artifacts. Recreate new directory
@@ -1737,7 +1737,7 @@ TEST_F(LogSystemTest, LogResources)
   EXPECT_GT(entryCount(recordPath), 1);
 #endif
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      ".ignition", "fuel", "fuel.ignitionrobotics.org", "OpenRobotics",
       "models", "X2 Config 1")));
 
   // Revert environment variable after test is done

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -95,7 +95,7 @@ TEST_F(SdfGeneratorFixture, WorldWithModelsSpawnedAfterLoad)
   // This has to be different from the backpack in order to test SDFormat
   // generation for a Fuel URI that was not known when simulation started.
   const std::string groundPlaneUri =
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/ground plane";
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/ground plane";
 
   transport::Node node;
   {

--- a/test/integration/sdf_include.cc
+++ b/test/integration/sdf_include.cc
@@ -38,6 +38,6 @@ TEST(SdfInclude, DownloadFromFuel)
   gazebo::Server server(serverConfig);
 
   EXPECT_TRUE(common::exists(path +
-        "/fuel.ignitionrobotics.org/openrobotics/models/ground plane" +
+        "/fuel.ignitionrobotics.org/OpenRobotics/models/ground plane" +
         "/1/model.sdf"));
 }

--- a/test/worlds/breadcrumbs.sdf
+++ b/test/worlds/breadcrumbs.sdf
@@ -549,7 +549,7 @@
               <pose>-2.2 0 5 0 0 0</pose>
               <include>
                 <uri>
-                    https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Cardboard box
+                    https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cardboard box
                 </uri>
               </include>
             </model>

--- a/test/worlds/include.sdf
+++ b/test/worlds/include.sdf
@@ -2,7 +2,7 @@
 <sdf version="1.6">
   <world name="default">
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/ground plane/1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/ground plane/1</uri>
     </include>
   </world>
 </sdf>

--- a/test/worlds/log_record_resources.sdf
+++ b/test/worlds/log_record_resources.sdf
@@ -121,7 +121,7 @@
       <static>false</static>
       <name>staging_area</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/X2 Config 1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1</uri>
     </include>
 
     <model name="ground_plane">

--- a/test/worlds/save_world.sdf
+++ b/test/worlds/save_world.sdf
@@ -20,17 +20,17 @@
     </model>
 
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
       <name>backpack1</name>
       <pose>1 0 0 0 0 0</pose>
     </include>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
       <name>backpack2</name>
       <pose>1 2 3 0.1 0.2 0.3</pose>
     </include>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Backpack/1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1</uri>
       <name>backpack3</name>
       <pose>2 0 0 0.1 0.2 0.3</pose>
     </include>


### PR DESCRIPTION
This changes "openrobotics" to "OpenRobotics".

Signed-off-by: Nate Koenig <nate@openrobotics.org>