### PR TITLE
add header file for using common::SkeletonPtr

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -32,6 +32,8 @@
 #include <ignition/common/SkeletonAnimation.hh>
 #include <ignition/common/MeshManager.hh>
 
+#include <ignition/rendering/RenderTypes.hh>
+
 #include <ignition/rendering/Geometry.hh>
 #include <ignition/rendering/Light.hh>
 #include <ignition/rendering/Material.hh>


### PR DESCRIPTION
When I include `#include <ignition/gazebo/rendering/SceneManager.hh>` in the plugin, the compile process raised an error like "common::SkeletonPtr is not defined". After searching the package, I found common::SkeletonPtr is defined in `#include <ignition/rendering/RenderTypes.hh>` and this header file is not included in SceneManager.hh.

After adding the header file, the plugin compiled successfully.