### PR TITLE
Scene manager losing header file

### DIFF
--- a/include/ignition/gazebo/rendering/SceneManager.hh
+++ b/include/ignition/gazebo/rendering/SceneManager.hh
@@ -32,6 +32,7 @@
 
 #include <ignition/common/KeyFrame.hh>
 #include <ignition/common/Animation.hh>
+#include <ignition/common/graphics/Types.hh>
 
 #include <ignition/rendering/RenderTypes.hh>
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -32,8 +32,6 @@
 #include <ignition/common/SkeletonAnimation.hh>
 #include <ignition/common/MeshManager.hh>
 
-#include <ignition/rendering/RenderTypes.hh>
-
 #include <ignition/rendering/Geometry.hh>
 #include <ignition/rendering/Light.hh>
 #include <ignition/rendering/Material.hh>

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -32,6 +32,8 @@
 #include <ignition/common/SkeletonAnimation.hh>
 #include <ignition/common/MeshManager.hh>
 
+#include <ignition/rendering/RenderTypes.hh>
+
 #include <ignition/rendering/Geometry.hh>
 #include <ignition/rendering/Light.hh>
 #include <ignition/rendering/Material.hh>


### PR DESCRIPTION
Losing this file will result in "common::SkeletonPtr" not defined problem when using SceneManager