### PR TITLE
Properly add new models into the scenegraph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo2 VERSION 2.20.0)
+project(ignition-gazebo2 VERSION 2.20.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ## Ignition Gazebo 2.x
 
 
+### Ignition Gazebo 2.20.1 (2020-06-18)
+
+1. Properly add new models into the scenegraph. With this fix, when a model is spawned it will be added into the graph and resulting calls to the `scene/info` service will return a correct `msgs::Scene`.
+    * [Pull Request 212](https://github.com/ignitionrobotics/ign-gazebo/pull/212)
+
 ### Ignition Gazebo 2.20.0 (2020-06-09)
 
 1. Updated battery model to stop battery drain when there is no joint

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -693,13 +693,18 @@ void SceneBroadcasterPrivate::SceneGraphAddEntities(
     std::lock_guard<std::mutex> lock(this->graphMutex);
     for (const auto &[id, vert] : newGraph.Vertices())
     {
+      // Add the vertex only if it's not already in the graph
       if (!this->sceneGraph.VertexFromId(id).Valid())
         this->sceneGraph.AddVertex(vert.get().Name(), vert.get().Data(), id);
     }
     for (const auto &[id, edge] : newGraph.Edges())
     {
-      if (!this->sceneGraph.EdgeFromId(id).Valid())
+      // Add the edge only if it's not already in the graph
+      if (!this->sceneGraph.EdgeFromVertices(edge.get().Vertices().first,
+            edge.get().Vertices().second).Valid())
+      {
         this->sceneGraph.AddEdge(edge.get().Vertices(), edge.get().Data());
+      }
     }
   }
 


### PR DESCRIPTION
The edge check logic was incorrect because it was checking to see if an edge ID already existed in the `sceneGraph` when it should be checking if a connected between the two vertices already existed.

Without this fix, when a model is spawned it won't be added into the graph properly.

Signed-off-by: Nate Koenig <nate@openrobotics.org>