### PR TITLE
Use a custom Fuel cache location for tests

### DIFF
--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -39,6 +39,8 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/test_config.hh"
 
+#include "helpers/UniqueTestDirectoryEnv.hh"
+
 #include "SdfGenerator.hh"
 
 using namespace ignition;
@@ -135,28 +137,6 @@ TEST(CompareElements, CompareWithDuplicateElements)
   EXPECT_FALSE(isSubset(m1CompTest, m1));
 }
 
-
-const char *g_cacheLocation = nullptr;
-class CustomCacheEnv : public ::testing::Environment
-{
-  public: void SetUp() override
-  {
-    this->cacheLoc =
-        common::uniqueDirectoryPath(common::absPath("sdf_gen_test_cache"));
-    g_cacheLocation = this->cacheLoc.c_str();
-    common::createDirectory(g_cacheLocation);
-    ASSERT_TRUE(common::exists(g_cacheLocation));
-  }
-
-  public: void TearDown() override
-  {
-    common::removeAll(g_cacheLocation);
-  }
-
-  // g_cacheLocation will point to this string data.
-  private: std::string cacheLoc;
-};
-
 /////////////////////////////////////////////////
 class ElementUpdateFixture : public ::testing::Test
 {
@@ -165,7 +145,7 @@ class ElementUpdateFixture : public ::testing::Test
     ignition::common::Console::SetVerbosity(4);
 
     fuel_tools::ClientConfig config;
-    config.SetCacheLocation(g_cacheLocation);
+    config.SetCacheLocation(test::UniqueTestDirectoryEnv::Path());
     this->fuelClient = std::make_unique<fuel_tools::FuelClient>(config);
 
     auto fuelCb = [&](const std::string &_uri)
@@ -888,6 +868,7 @@ TEST_F(GenerateWorldFixture, ModelsInline)
 int main(int _argc, char **_argv)
 {
   ::testing::InitGoogleTest(&_argc, _argv);
-  ::testing::AddGlobalTestEnvironment(new CustomCacheEnv);
+  ::testing::AddGlobalTestEnvironment(
+      new test::UniqueTestDirectoryEnv("sdf_gen_test_cache"));
   return RUN_ALL_TESTS();
 }

--- a/test/helpers/UniqueTestDirectoryEnv.hh
+++ b/test/helpers/UniqueTestDirectoryEnv.hh
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_GAZEBO_TEST_HELPERS_CUSTOMCACHEENV_HH_
+#define IGNITION_GAZEBO_TEST_HELPERS_CUSTOMCACHEENV_HH_
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
+#include <ignition/gazebo/test_config.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+namespace test
+{
+/// \brief Helper class to be used in internal tests. It sets up a unique test
+/// directory inside the cmake build directory (PROJECT_BINARY_PATH). The name
+/// of the directory is specified in the constructor argument, but if another
+/// directory with the same name is found, a new one with a numeric suffix will
+/// be created ensuring that the new name is unique. This class can
+/// be used, for example, for setting custom cache locations for tests that
+/// download Fuel models.
+///
+/// An instance of the Environment has to be added to gtest using the
+/// `::testing::AddGlobalTestEnvironment` function.
+///
+/// ## Usage
+///
+///  // In the test file
+///  int main(int _argc, char **_argv)
+///  {
+///    ::testing::InitGoogleTest(&_argc, _argv);
+///    ::testing::AddGlobalTestEnvironment(
+///      new ignition::gazebo::test::UniqueTestDirectoryEnv("custom_dir_name"));
+///     return RUN_ALL_TESTS();
+///  }
+/// gtest is responsible for the instance, so there is no need to delete it.
+class UniqueTestDirectoryEnv : public ::testing::Environment
+{
+  /// \brief Constructor
+  /// \param[in] _dirName Directory name based on which a unique path is created
+  public: explicit UniqueTestDirectoryEnv(const std::string &_dirName)
+  {
+    // We don't assert here because the assertion in the constructor won't be
+    // caught by gtest.
+    if (_dirName.empty())
+    {
+      ignerr << "_dirName cannot be empty\n";
+    }
+    else
+    {
+      UniqueTestDirectoryEnv::Path() = common::uniqueDirectoryPath(
+          common::joinPaths(PROJECT_BINARY_PATH, _dirName));
+    }
+  }
+
+  public: void SetUp() override
+  {
+    ASSERT_FALSE(UniqueTestDirectoryEnv::Path().empty())
+        << "UniqueTestDirectoryEnv is not configured properly";
+
+    common::createDirectory(UniqueTestDirectoryEnv::Path());
+    ASSERT_TRUE(common::exists(UniqueTestDirectoryEnv::Path()));
+  }
+
+  public: void TearDown() override
+  {
+    if (!UniqueTestDirectoryEnv::Path().empty())
+    {
+      common::removeAll(UniqueTestDirectoryEnv::Path());
+      UniqueTestDirectoryEnv::Path() = "";
+    }
+  }
+
+  public: static std::string &Path()
+  {
+    static std::string dirPath = "";
+    return dirPath;
+  }
+};
+}
+}
+}
+#endif
+

--- a/test/integration/breadcrumbs.cc
+++ b/test/integration/breadcrumbs.cc
@@ -33,31 +33,11 @@
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/test_config.hh"
 
-#include "../helpers/Relay.hh"
+#include "helpers/Relay.hh"
+#include "helpers/UniqueTestDirectoryEnv.hh"
 
 using namespace ignition;
 using namespace gazebo;
-
-const char *g_cacheLocation = nullptr;
-class CustomCacheEnv : public ::testing::Environment
-{
-  public: void SetUp() override
-  {
-    this->cacheLoc =
-        common::uniqueDirectoryPath(common::absPath("breadcrumbs_test_cache"));
-    g_cacheLocation = this->cacheLoc.c_str();
-    common::createDirectory(g_cacheLocation);
-    ASSERT_TRUE(common::exists(g_cacheLocation));
-  }
-
-  public: void TearDown() override
-  {
-    common::removeAll(g_cacheLocation);
-  }
-
-  // g_cacheLocation will point to this string data.
-  private: std::string cacheLoc;
-};
 
 class BreadcrumbsTest : public ::testing::Test
 {
@@ -70,7 +50,7 @@ class BreadcrumbsTest : public ::testing::Test
   }
   public: void LoadWorld(const std::string &_path, bool _useLevels = false)
   {
-    this->serverConfig.SetResourceCache(g_cacheLocation);
+    this->serverConfig.SetResourceCache(test::UniqueTestDirectoryEnv::Path());
     this->serverConfig.SetSdfFile(
         common::joinPaths(PROJECT_SOURCE_PATH, _path));
     this->serverConfig.SetUseLevels(_useLevels);
@@ -505,6 +485,7 @@ TEST_F(BreadcrumbsTest, AllowRenaming)
 int main(int _argc, char **_argv)
 {
   ::testing::InitGoogleTest(&_argc, _argv);
-  ::testing::AddGlobalTestEnvironment(new CustomCacheEnv);
+  ::testing::AddGlobalTestEnvironment(
+      new test::UniqueTestDirectoryEnv("breadcrumbs_test_cache"));
   return RUN_ALL_TESTS();
 }

--- a/test/integration/breadcrumbs.cc
+++ b/test/integration/breadcrumbs.cc
@@ -148,7 +148,7 @@ TEST_F(BreadcrumbsTest, DeployAtOffset)
   });
 
   this->server->AddSystem(testSystem.systemPtr);
-  server->Run(true, iterTestStart + 2001, false);
+  this->server->Run(true, iterTestStart + 2001, false);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/breadcrumbs.cc
+++ b/test/integration/breadcrumbs.cc
@@ -38,6 +38,27 @@
 using namespace ignition;
 using namespace gazebo;
 
+const char *g_cacheLocation = nullptr;
+class CustomCacheEnv : public ::testing::Environment
+{
+  public: void SetUp() override
+  {
+    this->cacheLoc =
+        common::uniqueDirectoryPath(common::absPath("breadcrumbs_test_cache"));
+    g_cacheLocation = this->cacheLoc.c_str();
+    common::createDirectory(g_cacheLocation);
+    ASSERT_TRUE(common::exists(g_cacheLocation));
+  }
+
+  public: void TearDown() override
+  {
+    common::removeAll(g_cacheLocation);
+  }
+
+  // g_cacheLocation will point to this string data.
+  private: std::string cacheLoc;
+};
+
 class BreadcrumbsTest : public ::testing::Test
 {
   // Documentation inherited
@@ -47,6 +68,22 @@ class BreadcrumbsTest : public ::testing::Test
     setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
            (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
   }
+  public: void LoadWorld(const std::string &_path, bool _useLevels = false)
+  {
+    this->serverConfig.SetResourceCache(g_cacheLocation);
+    this->serverConfig.SetSdfFile(
+        common::joinPaths(PROJECT_SOURCE_PATH, _path));
+    this->serverConfig.SetUseLevels(_useLevels);
+
+    this->server = std::make_unique<Server>(this->serverConfig);
+    EXPECT_FALSE(this->server->Running());
+    EXPECT_FALSE(*this->server->Running(0));
+    using namespace std::chrono_literals;
+    this->server->SetUpdatePeriod(1ns);
+  }
+
+  public: ServerConfig serverConfig;
+  public: std::unique_ptr<Server> server;
 };
 
 /////////////////////////////////////////////////
@@ -54,17 +91,7 @@ class BreadcrumbsTest : public ::testing::Test
 TEST_F(BreadcrumbsTest, DeployAtOffset)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf");
 
   test::Relay testSystem;
   transport::Node node;
@@ -120,8 +147,8 @@ TEST_F(BreadcrumbsTest, DeployAtOffset)
     }
   });
 
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, iterTestStart + 2001, false);
+  this->server->AddSystem(testSystem.systemPtr);
+  server->Run(true, iterTestStart + 2001, false);
 }
 
 /////////////////////////////////////////////////
@@ -129,17 +156,7 @@ TEST_F(BreadcrumbsTest, DeployAtOffset)
 TEST_F(BreadcrumbsTest, MaxDeployments)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf");
 
   test::Relay testSystem;
   transport::Node node;
@@ -184,8 +201,8 @@ TEST_F(BreadcrumbsTest, MaxDeployments)
     }
   });
 
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, iterTestStart + 5001, false);
+  this->server->AddSystem(testSystem.systemPtr);
+  this->server->Run(true, iterTestStart + 5001, false);
 }
 
 /////////////////////////////////////////////////
@@ -194,17 +211,7 @@ TEST_F(BreadcrumbsTest, MaxDeployments)
 TEST_F(BreadcrumbsTest, FuelDeploy)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf");
 
   test::Relay testSystem;
   transport::Node node;
@@ -248,8 +255,8 @@ TEST_F(BreadcrumbsTest, FuelDeploy)
     }
   });
 
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, nIters, false);
+  this->server->AddSystem(testSystem.systemPtr);
+  this->server->Run(true, nIters, false);
 }
 
 /////////////////////////////////////////////////
@@ -257,18 +264,7 @@ TEST_F(BreadcrumbsTest, FuelDeploy)
 TEST_F(BreadcrumbsTest, Performer)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-  serverConfig.SetUseLevels(true);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf");
 
   test::Relay testSystem;
   transport::Node node;
@@ -332,8 +328,8 @@ TEST_F(BreadcrumbsTest, Performer)
     }
   });
 
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, nIters, false);
+  this->server->AddSystem(testSystem.systemPtr);
+  this->server->Run(true, nIters, false);
 }
 
 /////////////////////////////////////////////////
@@ -342,18 +338,7 @@ TEST_F(BreadcrumbsTest, Performer)
 TEST_F(BreadcrumbsTest, PerformerSetVolume)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-  serverConfig.SetUseLevels(true);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf", true);
 
   test::Relay testSystem;
   transport::Node node;
@@ -399,8 +384,8 @@ TEST_F(BreadcrumbsTest, PerformerSetVolume)
     }
   });
 
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, nIters, false);
+  this->server->AddSystem(testSystem.systemPtr);
+  this->server->Run(true, nIters, false);
 }
 
 /////////////////////////////////////////////////
@@ -408,17 +393,7 @@ TEST_F(BreadcrumbsTest, PerformerSetVolume)
 TEST_F(BreadcrumbsTest, DeployDisablePhysics)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf");
 
   test::Relay testSystem;
   transport::Node node;
@@ -476,7 +451,7 @@ TEST_F(BreadcrumbsTest, DeployDisablePhysics)
 
       // Verify that the breadcrumb stopped falling after 0.5s.
       sdf::Root root;
-      root.Load(sdfFile);
+      root.Load(this->serverConfig.SdfFile());
       const sdf::World *world = root.WorldByIndex(0);
       double gz = world->Gravity().Z();
       double z0 = 2.0;
@@ -486,8 +461,8 @@ TEST_F(BreadcrumbsTest, DeployDisablePhysics)
     }
   });
 
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, iterTestStart + 2001, false);
+  this->server->AddSystem(testSystem.systemPtr);
+  this->server->Run(true, iterTestStart + 2001, false);
 }
 
 /////////////////////////////////////////////////
@@ -496,17 +471,7 @@ TEST_F(BreadcrumbsTest, DeployDisablePhysics)
 TEST_F(BreadcrumbsTest, AllowRenaming)
 {
   // Start server
-  ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/breadcrumbs.sdf";
-  serverConfig.SetSdfFile(sdfFile);
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  using namespace std::chrono_literals;
-  server.SetUpdatePeriod(1ns);
+  this->LoadWorld("test/worlds/breadcrumbs.sdf");
 
   transport::Node node;
   auto deployB1 =
@@ -516,21 +481,30 @@ TEST_F(BreadcrumbsTest, AllowRenaming)
   auto renameDeploy =
       node.Advertise<msgs::Empty>("/rename_deploy");
 
-  server.Run(true, 1, false);
+  this->server->Run(true, 1, false);
   deployB1.Publish(msgs::Empty());
-  server.Run(true, 100, false);
-  EXPECT_TRUE(server.HasEntity("B1_0"));
+  this->server->Run(true, 100, false);
+  EXPECT_TRUE(this->server->HasEntity("B1_0"));
 
   // Deploying via "/no_rename_deploy" will try to spawn B1_0, but since the
   // model already exists, the spawn should fail.
-  auto curEntityCount = server.EntityCount().value();
+  auto curEntityCount = this->server->EntityCount().value();
   noRenameDeploy.Publish(msgs::Empty());
-  server.Run(true, 100, false);
-  EXPECT_EQ(curEntityCount, server.EntityCount().value());
+  this->server->Run(true, 100, false);
+  EXPECT_EQ(curEntityCount, this->server->EntityCount().value());
 
   // Deploying via "/rename_deploy" will try to spawn B1_0, but since the
   // model already exists, it will spawn B1_0_1 instead.
   renameDeploy.Publish(msgs::Empty());
-  server.Run(true, 100, false);
-  EXPECT_TRUE(server.HasEntity("B1_0_1"));
+  this->server->Run(true, 100, false);
+  EXPECT_TRUE(this->server->HasEntity("B1_0_1"));
+}
+
+/////////////////////////////////////////////////
+/// Main
+int main(int _argc, char **_argv)
+{
+  ::testing::InitGoogleTest(&_argc, _argv);
+  ::testing::AddGlobalTestEnvironment(new CustomCacheEnv);
+  return RUN_ALL_TESTS();
 }

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -30,31 +30,11 @@
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
 
+#include "helpers/UniqueTestDirectoryEnv.hh"
 #include "plugins/MockSystem.hh"
 
 using namespace ignition;
 using namespace gazebo;
-
-const char *g_cacheLocation = nullptr;
-class CustomCacheEnv : public ::testing::Environment
-{
-  public: void SetUp() override
-  {
-    this->cacheLoc =
-        common::uniqueDirectoryPath(common::absPath("save_world_test_cache"));
-    g_cacheLocation = this->cacheLoc.c_str();
-    common::createDirectory(g_cacheLocation);
-    ASSERT_TRUE(common::exists(g_cacheLocation));
-  }
-
-  public: void TearDown() override
-  {
-    common::removeAll(g_cacheLocation);
-  }
-
-  // g_cacheLocation will point to this string data.
-  private: std::string cacheLoc;
-};
 
 /////////////////////////////////////////////////
 class SdfGeneratorFixture : public ::testing::Test
@@ -67,7 +47,7 @@ class SdfGeneratorFixture : public ::testing::Test
   public: void LoadWorld(const std::string &_path)
   {
     ServerConfig serverConfig;
-    serverConfig.SetResourceCache(g_cacheLocation);
+    serverConfig.SetResourceCache(test::UniqueTestDirectoryEnv::Path());
     serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH, _path));
 
     std::cout << "Loading: " << serverConfig.SdfFile() << std::endl;
@@ -262,6 +242,7 @@ TEST_F(SdfGeneratorFixture, ModelSpawnedWithNewName)
 int main(int _argc, char **_argv)
 {
   ::testing::InitGoogleTest(&_argc, _argv);
-  ::testing::AddGlobalTestEnvironment(new CustomCacheEnv);
+  ::testing::AddGlobalTestEnvironment(
+      new test::UniqueTestDirectoryEnv("save_world_test_cache"));
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This ensures that tests are repeatable and are not affected by preexisting
models in the regular user's cache.

Related issue ignitionrobotics/ign-fuel-tools#80
