### PR TITLE
Units typo in Component Inspector plugin

### DIFF
--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -300,7 +300,7 @@ Rectangle {
         }
 
         Text {
-          text: 'Yaw (m)'
+          text: 'Yaw (rad)'
           leftPadding: 5
           color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
           font.pointSize: 12


### PR DESCRIPTION
Yaw label was specified in meters instead of radians in the `Pose` field of the plugin.