### PR TITLE
Names with spaces: add string serializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 ### Ignition Gazebo 4.0.0 (20XX-XX-XX)
 
+1. Names with spaces: add string serializer
+    * [pull request 244](https://github.com/ignitionrobotics/ign-gazebo/pull/244)
+
 1. Filter mesh collision based on `collide_bitmask` property
     * [pull request 160](https://github.com/ignitionrobotics/ign-gazebo/pull/160)
 

--- a/examples/worlds/fuel.sdf
+++ b/examples/worlds/fuel.sdf
@@ -122,6 +122,7 @@
 
     <!-- Included model without meshes -->
     <include>
+      <name>Double pendulum</name>
       <pose>-3 0 0 0 0 0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/nate/models/double_pendulum_with_base/2</uri>
     </include>
@@ -134,12 +135,15 @@
 
     <!-- Included model with meshes using relative paths -->
     <include>
+      <name>Gazebo (relative paths)</name>
       <pose>2 5 0 0 0 0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/chapulina/models/Gazebo - relative paths</uri>
     </include>
 
     <!-- Included actor with meshes using relative paths -->
     <include>
+      <name>Actor Test</name>
+      <pose>0 0 0 0 0 0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/chapulina/models/actor - relative paths</uri>
     </include>
 

--- a/include/ignition/gazebo/components/Actor.hh
+++ b/include/ignition/gazebo/components/Actor.hh
@@ -86,7 +86,8 @@ namespace components
       AnimationTime)
 
   /// \brief Name of animation being currently played.
-  using AnimationName = Component<std::string, class AnimationNameTag>;
+  using AnimationName = Component<std::string, class AnimationNameTag,
+      serializers::StringSerializer>;
   IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.AnimationName",
       AnimationName)
 }

--- a/include/ignition/gazebo/components/ChildLinkName.hh
+++ b/include/ignition/gazebo/components/ChildLinkName.hh
@@ -18,8 +18,9 @@
 #define IGNITION_GAZEBO_COMPONENTS_CHILDLINKNAME_HH_
 
 #include <string>
-#include <ignition/gazebo/components/Factory.hh>
 #include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/components/Serialization.hh>
 #include <ignition/gazebo/config.hh>
 
 namespace ignition
@@ -32,7 +33,8 @@ namespace components
 {
   /// \brief A component used to indicate that a model is childlinkname (i.e.
   /// not moveable).
-  using ChildLinkName = Component<std::string, class ChildLinkNameTag>;
+  using ChildLinkName = Component<std::string, class ChildLinkNameTag,
+      serializers::StringSerializer>;
   IGN_GAZEBO_REGISTER_COMPONENT(
     "ign_gazebo_components.ChildLinkName", ChildLinkName)
 }

--- a/include/ignition/gazebo/components/LevelEntityNames.hh
+++ b/include/ignition/gazebo/components/LevelEntityNames.hh
@@ -43,9 +43,12 @@ namespace serializers
     public: static std::ostream &Serialize(std::ostream &_out,
                                            const std::set<std::string> &_set)
     {
+      // Character to separate level names. It's the "Unit separator".
+      const char sep = 31;
+
       for (const auto &entity : _set)
       {
-        _out << entity << " ";
+        _out << entity << sep;
       }
       return _out;
     }
@@ -57,14 +60,13 @@ namespace serializers
     public: static std::istream &Deserialize(std::istream &_in,
                                              std::set<std::string> &_set)
     {
-      _in.setf(std::ios_base::skipws);
-
       _set.clear();
 
-      for (auto it = std::istream_iterator<std::string>(_in);
-           it != std::istream_iterator<std::string>(); ++it)
+      const char sep = 31;
+      std::string level;
+      while (std::getline(_in, level, sep))
       {
-        _set.insert(*it);
+        _set.insert(level);
       }
       return _in;
     }

--- a/include/ignition/gazebo/components/Name.hh
+++ b/include/ignition/gazebo/components/Name.hh
@@ -20,6 +20,7 @@
 #include <string>
 #include <ignition/gazebo/components/Factory.hh>
 #include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Serialization.hh>
 #include <ignition/gazebo/config.hh>
 
 namespace ignition
@@ -32,7 +33,8 @@ namespace components
 {
   /// \brief This component holds an entity's name. The component has no concept
   /// of scoped names nor does it care about uniqueness.
-  using Name = Component<std::string, class NameTag>;
+  using Name = Component<std::string, class NameTag,
+      serializers::StringSerializer>;
   IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.Name", Name)
 }
 }

--- a/include/ignition/gazebo/components/ParentLinkName.hh
+++ b/include/ignition/gazebo/components/ParentLinkName.hh
@@ -18,8 +18,9 @@
 #define IGNITION_GAZEBO_COMPONENTS_PARENTLINKNAME_HH_
 
 #include <string>
-#include <ignition/gazebo/components/Factory.hh>
 #include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/components/Serialization.hh>
 #include <ignition/gazebo/config.hh>
 
 namespace ignition
@@ -31,7 +32,8 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 namespace components
 {
   /// \brief Holds the name of the entity's parent link.
-  using ParentLinkName = Component<std::string, class ParentLinkNameTag>;
+  using ParentLinkName = Component<std::string, class ParentLinkNameTag,
+      serializers::StringSerializer>;
   IGN_GAZEBO_REGISTER_COMPONENT(
     "ign_gazebo_components.ParentLinkName", ParentLinkName)
 }

--- a/include/ignition/gazebo/components/PerformerAffinity.hh
+++ b/include/ignition/gazebo/components/PerformerAffinity.hh
@@ -22,8 +22,9 @@
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Export.hh>
 
-#include "ignition/gazebo/components/Factory.hh"
 #include "ignition/gazebo/components/Component.hh"
+#include "ignition/gazebo/components/Factory.hh"
+#include "ignition/gazebo/components/Serialization.hh"
 
 namespace ignition
 {
@@ -35,7 +36,8 @@ namespace components
 {
   /// \brief This component holds the address of the distributed secondary that
   /// this performer is associated with.
-  using PerformerAffinity = Component<std::string, class PerformerAffinityTag>;
+  using PerformerAffinity = Component<std::string, class PerformerAffinityTag,
+      serializers::StringSerializer>;
   IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.PerformerAffinity",
       PerformerAffinity)
 }

--- a/include/ignition/gazebo/components/PhysicsEnginePlugin.hh
+++ b/include/ignition/gazebo/components/PhysicsEnginePlugin.hh
@@ -20,6 +20,7 @@
 #include <string>
 #include <ignition/gazebo/components/Factory.hh>
 #include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Serialization.hh>
 #include <ignition/gazebo/config.hh>
 
 namespace ignition
@@ -32,7 +33,7 @@ namespace components
 {
   /// \brief Holds the physics engine shared library.
   using PhysicsEnginePlugin = Component<std::string,
-      class PhysicsEnginePluginTag>;
+      class PhysicsEnginePluginTag, serializers::StringSerializer>;
   IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.PhysicsEnginePlugin",
       PhysicsEnginePlugin)
 }

--- a/include/ignition/gazebo/components/Serialization.hh
+++ b/include/ignition/gazebo/components/Serialization.hh
@@ -20,6 +20,7 @@
 #include <google/protobuf/message_lite.h>
 #include <ignition/msgs/double_v.pb.h>
 
+#include <string>
 #include <vector>
 #include <sdf/Sensor.hh>
 
@@ -153,6 +154,32 @@ namespace serializers
         google::protobuf::Message &_msg)
     {
       _msg.ParseFromIstream(&_in);
+      return _in;
+    }
+  };
+
+  /// \brief Serializer for components that hold std::string.
+  class StringSerializer
+  {
+    /// \brief Serialization
+    /// \param[in] _out Output stream.
+    /// \param[in] _data Data to serialize.
+    /// \return The stream.
+    public: static std::ostream &Serialize(std::ostream &_out,
+        const std::string &_data)
+    {
+      _out << _data;
+      return _out;
+    }
+
+    /// \brief Deserialization
+    /// \param[in] _in Input stream.
+    /// \param[in] _data Data to populate.
+    /// \return The stream.
+    public: static std::istream &Deserialize(std::istream &_in,
+        std::string &_data)
+    {
+      _data = std::string(std::istreambuf_iterator<char>(_in), {});
       return _in;
     }
   };

--- a/include/ignition/gazebo/components/SourceFilePath.hh
+++ b/include/ignition/gazebo/components/SourceFilePath.hh
@@ -20,6 +20,7 @@
 #include <string>
 #include <ignition/gazebo/components/Factory.hh>
 #include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Serialization.hh>
 #include <ignition/gazebo/config.hh>
 
 namespace ignition
@@ -33,7 +34,8 @@ namespace components
   /// \brief This component holds the filepath to the source from which an
   /// entity is created. For example, it can be used to store the file path of a
   /// model's SDFormat file.
-  using SourceFilePath = Component<std::string, class SourceFilePathTag>;
+  using SourceFilePath = Component<std::string, class SourceFilePathTag,
+      serializers::StringSerializer>;
 
   IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.SourceFilePath",
                                 SourceFilePath)

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -300,7 +300,7 @@ Rectangle {
         }
 
         Text {
-          text: 'Yaw (m)'
+          text: 'Yaw (rad)'
           leftPadding: 5
           color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
           font.pointSize: 12

--- a/test/integration/components.cc
+++ b/test/integration/components.cc
@@ -60,10 +60,13 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/ParentLinkName.hh"
 #include "ignition/gazebo/components/Performer.hh"
+#include "ignition/gazebo/components/PerformerAffinity.hh"
 #include "ignition/gazebo/components/PerformerLevels.hh"
+#include "ignition/gazebo/components/PhysicsEnginePlugin.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/Scene.hh"
 #include "ignition/gazebo/components/Sensor.hh"
+#include "ignition/gazebo/components/SourceFilePath.hh"
 #include "ignition/gazebo/components/Static.hh"
 #include "ignition/gazebo/components/ThreadPitch.hh"
 #include "ignition/gazebo/components/Visual.hh"
@@ -108,6 +111,33 @@ TEST_F(ComponentsTest, Actor)
   EXPECT_EQ("abc", comp3.Data().Name());
   EXPECT_EQ("def", comp3.Data().SkinFilename());
   EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, 0, 0), comp3.Data().RawPose());
+}
+
+/////////////////////////////////////////////////
+TEST_F(ComponentsTest, AnimationName)
+{
+  // Create components
+  auto comp11 = components::AnimationName("comp1");
+  auto comp12 = components::AnimationName("comp1");
+  auto comp2 = components::AnimationName("comp2");
+
+  // Equality operators
+  EXPECT_EQ(comp11, comp12);
+  EXPECT_NE(comp11, comp2);
+  EXPECT_TRUE(comp11 == comp12);
+  EXPECT_TRUE(comp11 != comp2);
+  EXPECT_FALSE(comp11 == comp2);
+  EXPECT_FALSE(comp11 != comp12);
+
+  // Stream operators
+  std::ostringstream ostr;
+  comp11.Serialize(ostr);
+  EXPECT_EQ("comp1", ostr.str());
+
+  std::istringstream istr("comp3");
+  components::AnimationName comp3;
+  comp3.Deserialize(istr);
+  EXPECT_EQ("comp3", comp3.Data());
 }
 
 /////////////////////////////////////////////////
@@ -664,9 +694,9 @@ TEST_F(ComponentsTest, LevelEntityNames)
   // Stream operators
   std::ostringstream ostr;
   comp11.Serialize(ostr);
-  EXPECT_EQ("level1 level2 ", ostr.str());
+  EXPECT_EQ("level1\x1Flevel2\x1F", ostr.str());
 
-  std::istringstream istr("level3 level4");
+  std::istringstream istr("level3\x1Flevel4");
   components::LevelEntityNames comp3;
   comp3.Deserialize(istr);
 
@@ -945,14 +975,26 @@ TEST_F(ComponentsTest, Name)
   EXPECT_FALSE(comp11 != comp12);
 
   // Stream operators
-  std::ostringstream ostr;
-  comp11.Serialize(ostr);
-  EXPECT_EQ("comp1", ostr.str());
+  for (auto str : {
+      "boring",
+      "snake_case",
+      "camelCase",
+      "with s p a c e s 123",
+      "with/slash",
+      "tópico",
+      "トピック"
+    })
+  {
+    auto compA = components::Name(str);
+    std::ostringstream ostr;
+    compA.Serialize(ostr);
+    EXPECT_EQ(str, ostr.str());
 
-  std::istringstream istr("comp3");
-  components::Name comp3;
-  comp3.Deserialize(istr);
-  EXPECT_EQ("comp3", comp3.Data());
+    std::istringstream istr(str);
+    components::Name compB;
+    compB.Deserialize(istr);
+    EXPECT_EQ(str, compB.Data());
+  }
 }
 
 /////////////////////////////////////////////////
@@ -1032,6 +1074,33 @@ TEST_F(ComponentsTest, Performer)
 }
 
 /////////////////////////////////////////////////
+TEST_F(ComponentsTest, PerformerAffinity)
+{
+  // Create components
+  auto comp11 = components::PerformerAffinity("comp1");
+  auto comp12 = components::PerformerAffinity("comp1");
+  auto comp2 = components::PerformerAffinity("comp2");
+
+  // Equality operators
+  EXPECT_EQ(comp11, comp12);
+  EXPECT_NE(comp11, comp2);
+  EXPECT_TRUE(comp11 == comp12);
+  EXPECT_TRUE(comp11 != comp2);
+  EXPECT_FALSE(comp11 == comp2);
+  EXPECT_FALSE(comp11 != comp12);
+
+  // Stream operators
+  std::ostringstream ostr;
+  comp11.Serialize(ostr);
+  EXPECT_EQ("comp1", ostr.str());
+
+  std::istringstream istr("comp3");
+  components::PerformerAffinity comp3;
+  comp3.Deserialize(istr);
+  EXPECT_EQ("comp3", comp3.Data());
+}
+
+/////////////////////////////////////////////////
 TEST_F(ComponentsTest, PerformerLevels)
 {
   // Create components
@@ -1055,6 +1124,27 @@ TEST_F(ComponentsTest, PerformerLevels)
   EXPECT_EQ(1u, comp3.Data().count(9));
   EXPECT_EQ(1u, comp3.Data().count(10));
   EXPECT_EQ(0u, comp3.Data().count(1));
+}
+
+/////////////////////////////////////////////////
+TEST_F(ComponentsTest, PhysicsEnginePlugin)
+{
+  // Create components
+  auto comp11 = components::PhysicsEnginePlugin("engine-plugin");
+  auto comp12 = components::PhysicsEnginePlugin("engine-plugin");
+  auto comp2 = components::PhysicsEnginePlugin("another-engine-plugin");
+
+  // TODO(anyone) Equality operators
+
+  // Stream operators
+  std::ostringstream ostr;
+  comp11.Serialize(ostr);
+  EXPECT_EQ("engine-plugin", ostr.str());
+
+  std::istringstream istr("libengine-plugin.so");
+  components::PhysicsEnginePlugin comp3;
+  comp3.Deserialize(istr);
+  EXPECT_EQ("libengine-plugin.so", comp3.Data());
 }
 
 /////////////////////////////////////////////////
@@ -1104,6 +1194,33 @@ TEST_F(ComponentsTest, Sensor)
   std::istringstream istr("ignored");
   components::Sensor comp3;
   comp3.Deserialize(istr);
+}
+
+/////////////////////////////////////////////////
+TEST_F(ComponentsTest, SourceFilePath)
+{
+  // Create components
+  auto comp11 = components::SourceFilePath("comp1");
+  auto comp12 = components::SourceFilePath("comp1");
+  auto comp2 = components::SourceFilePath("comp2");
+
+  // Equality operators
+  EXPECT_EQ(comp11, comp12);
+  EXPECT_NE(comp11, comp2);
+  EXPECT_TRUE(comp11 == comp12);
+  EXPECT_TRUE(comp11 != comp2);
+  EXPECT_FALSE(comp11 == comp2);
+  EXPECT_FALSE(comp11 != comp12);
+
+  // Stream operators
+  std::ostringstream ostr;
+  comp11.Serialize(ostr);
+  EXPECT_EQ("comp1", ostr.str());
+
+  std::istringstream istr("comp3");
+  components::SourceFilePath comp3;
+  comp3.Deserialize(istr);
+  EXPECT_EQ("comp3", comp3.Data());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Addresses issue #239 .

This needs to target Dome because changing the serializer from default to a custom string serializer breaks ABI.

Added some names with spaces and special characters to `fuel.sdf` and everything seems to be in place:

![names_spaces](https://user-images.githubusercontent.com/5751272/87494079-050a8b00-c603-11ea-8f07-5c53e1cce597.png)
