### PR TITLE
Enable alpha based transparency on PBR materials by default

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -476,6 +476,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
       if (!fullPath.empty())
       {
         material->SetTexture(fullPath);
+        // Use alpha channel for transparency
+        material->SetAlphaFromTexture(true);
       }
       else
         ignerr << "Unable to find file [" << albedoMap << "]\n";


### PR DESCRIPTION
This (simple) PR enables transparency on Physically Based Rendering materials. The alpha channel of the diffuse / albedo map is used to set the transparency.

An example way to test it is by using [Pine Tree](https://app.ignitionrobotics.org/OpenRobotics/fuel/models/Pine%20Tree) from Fuel, it will be necessary to update the `model.sdf` file by changing the `<material>` tag of the branch into:

```
        <material>
          <diffuse>1.0 1.0 1.0</diffuse>
          <script>
            <uri>model://Pine Tree/materials/scripts/</uri>
            <uri>model://Pine Tree/materials/textures/</uri>
            <name>PineTree/Branch</name>
          </script>
          <!-- PBR for Ignition, material scripts for gazebo classic-->
          <pbr>
            <metal>
              <albedo_map>model://Pine Tree/materials/textures/branch_2_diffuse.png</albedo_map>
            </metal>
          </pbr>
        </material>
```

Before and after the PR:
![image](https://user-images.githubusercontent.com/9111558/87644932-5c356a80-c77f-11ea-8476-fc1448a11566.png)
![image](https://user-images.githubusercontent.com/9111558/87644938-5fc8f180-c77f-11ea-91cd-cda53b5711d7.png)

Open to feedback! (especially if this PR introduces any regression / change in behavior in preexisting assets / projects).