### PR TITLE
Backport support for <uri>s from Fuel

### DIFF
--- a/.github/ci-bionic/after_make.sh
+++ b/.github/ci-bionic/after_make.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -l
+
+set -x
+
+# Install
+make install

--- a/examples/worlds/fuel.sdf
+++ b/examples/worlds/fuel.sdf
@@ -120,19 +120,44 @@
       </link>
     </model>
 
+    <!-- Included model without meshes -->
     <include>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Double pendulum with base</uri>
     </include>
 
+    <!-- Included model with meshes -->
     <include>
       <pose>1 0 0 0 0 0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
     </include>
 
+    <!-- Included model with meshes using relative paths -->
     <include>
       <pose>2 5 0 0 0 0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Gazebo - relative paths</uri>
     </include>
+
+    <!-- Model with meshes -->
+    <model name="Radio">
+      <pose>3 -1.5 0 0 0 0</pose>
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <mesh>
+              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio/4/files/meshes/Radio.dae</uri>
+            </mesh>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <mesh>
+              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio/4/files/meshes/Radio.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+      </link>
+    </model>
 
   </world>
 </sdf>

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -97,6 +97,8 @@ Server::Server(const ServerConfig &_config)
   // Configure SDF to fetch assets from ignition fuel.
   sdf::setFindCallback(std::bind(&ServerPrivate::FetchResource,
         this->dataPtr.get(), std::placeholders::_1));
+  common::addFindFileURICallback(std::bind(&ServerPrivate::FetchResourceUri,
+      this->dataPtr.get(), std::placeholders::_1));
 
   sdf::Errors errors;
 

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -418,3 +418,9 @@ std::string ServerPrivate::FetchResource(const std::string &_uri)
   }
   return path;
 }
+
+//////////////////////////////////////////////////
+std::string ServerPrivate::FetchResourceUri(const common::URI &_uri)
+{
+  return this->FetchResource(_uri.Str());
+}

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -89,6 +89,11 @@ namespace ignition
       /// \return Path to the downloaded resource, empty on error.
       public: std::string FetchResource(const std::string &_uri);
 
+      /// \brief Fetch a resource from Fuel using fuel-tools.
+      /// \param[in] _uri The resource URI to fetch.
+      /// \return Path to the downloaded resource, empty on error.
+      public: std::string FetchResourceUri(const common::URI &_uri);
+
       /// \brief Signal handler callback
       /// \param[in] _sig The signal number
       private: void OnSignal(int _sig);

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -17,6 +17,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
+#include <ignition/fuel_tools/Interface.hh>
 #include <ignition/gui/Application.hh>
 
 // Include all components so they have first-class support
@@ -33,6 +34,11 @@ GuiRunner::GuiRunner(const std::string &_worldName)
 {
   this->setProperty("worldName", QString::fromStdString(_worldName));
   this->stateTopic = "/world/" + _worldName + "/state";
+
+  common::addFindFileURICallback([] (common::URI _uri)
+  {
+    return fuel_tools::fetchResource(_uri.Str());
+  });
 
   igndbg << "Requesting initial state from [" << this->stateTopic << "]..."
          << std::endl;


### PR DESCRIPTION
Backports [this PR](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/532/page/1) (released in Citadel), which allows using Fuel URLs within `<uri>` blocks, among others.

Needs https://github.com/ignitionrobotics/ign-fuel-tools/pull/84