### PR TITLE
Allow zero or more key/value pairs to be added to detection header information

### DIFF
--- a/src/systems/performer_detector/PerformerDetector.cc
+++ b/src/systems/performer_detector/PerformerDetector.cc
@@ -90,10 +90,27 @@ void PerformerDetector::Configure(const Entity &_entity,
     {
       std::string key = headerElem->Get<std::string>("key", "").first;
       std::string value = headerElem->Get<std::string>("value", "").first;
-      if (!key.empty() || !value.empty())
-      {
+      if (!key.empty() && !value.empty())
         this->extraHeaderData[key] = value;
+      else if (key.empty() && !value.empty())
+      {
+        ignerr << "Performer detector[" << this->detectorName << "] has an "
+          << "empty <key> with an associated <value> of [" << value << "]. "
+          << "This <header_data> will be ignored.\n";
       }
+      else if (value.empty() && !key.empty())
+      {
+        ignerr << "Performer detector[" << this->detectorName << "] has an "
+          << "empty <value> with an associated <key> of [" << key << "]. "
+          << "This <header_data> will be ignored.\n";
+      }
+      else
+      {
+        ignerr << "Performer detector[" << this->detectorName << "] has an "
+          << "empty <header_data> element. This <header_data> will be "
+          << "ignored\n";
+      }
+
       headerElem = headerElem->GetNextElement("header_data");
     }
   }

--- a/src/systems/performer_detector/PerformerDetector.hh
+++ b/src/systems/performer_detector/PerformerDetector.hh
@@ -18,6 +18,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_PERFORMERDETECTOR_HH_
 #define IGNITION_GAZEBO_SYSTEMS_PERFORMERDETECTOR_HH_
 
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -70,6 +71,11 @@ namespace systems
   /// `<pose>`: Additional pose offset relative to the parent model's pose.
   /// This pose is added to the parent model pose when computing the
   /// detection region. Only the position component of the `<pose>` is used.
+  /// `<header_data>`: Zero or more key-value pairs that will be
+  /// included in the header of the detection messages. A `<header_data>`
+  /// element should have child `<key>` and/or `<value>` elements whose
+  /// contents are interpreted as strings. Keys value pairs are stored in a
+  /// map, which means the keys are unique.
 
   class IGNITION_GAZEBO_VISIBLE PerformerDetector
       : public System,
@@ -134,6 +140,9 @@ namespace systems
 
     /// \brief Additional pose offset for the plugin.
     private: math::Pose3d poseOffset;
+
+    /// \brief Optional extra header data.
+    private: std::map<std::string, std::string> extraHeaderData;
   };
 
   }

--- a/src/systems/performer_detector/PerformerDetector.hh
+++ b/src/systems/performer_detector/PerformerDetector.hh
@@ -73,7 +73,7 @@ namespace systems
   /// detection region. Only the position component of the `<pose>` is used.
   /// `<header_data>`: Zero or more key-value pairs that will be
   /// included in the header of the detection messages. A `<header_data>`
-  /// element should have child `<key>` and/or `<value>` elements whose
+  /// element should have child `<key>` and `<value>` elements whose
   /// contents are interpreted as strings. Keys value pairs are stored in a
   /// map, which means the keys are unique.
 

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -73,6 +73,44 @@ TEST_F(PerformerDetectorTest, MovingPerformer)
       {
         std::lock_guard<std::mutex> lock(this->poseMsgsMutex);
         this->poseMsgs.push_back(_msg);
+
+        std::string detectorName;
+        for (int i = 0; i < _msg.header().data_size(); ++i)
+        {
+          if (_msg.header().data(i).key() == "frame_id")
+            detectorName = _msg.header().data(i).value(0);
+        }
+
+        bool hasUniqueKey = false;
+        bool hasDuplicateKey = false;
+        for (int i = 0; i < _msg.header().data_size(); ++i)
+        {
+          EXPECT_NE(_msg.header().data(i).key(), "no_value");
+          EXPECT_NE(_msg.header().data(i).value(0), "no_key");
+          EXPECT_NE(_msg.header().data(i).value(0), "first_value");
+          if (_msg.header().data(i).key() == "unique_key")
+          {
+            EXPECT_EQ(_msg.header().data(i).value(0), "unique_value");
+            hasUniqueKey  = true;
+          }
+          else if (_msg.header().data(i).key() == "duplicate_key")
+          {
+            EXPECT_EQ(_msg.header().data(i).value(0), "second_value");
+            hasDuplicateKey  = true;
+          }
+        }
+        if (detectorName == "detector1")
+        {
+          EXPECT_EQ(4, _msg.header().data_size());
+          EXPECT_TRUE(hasDuplicateKey);
+          EXPECT_TRUE(hasUniqueKey);
+        }
+        else
+        {
+          EXPECT_EQ(2, _msg.header().data_size());
+          EXPECT_FALSE(hasDuplicateKey);
+          EXPECT_FALSE(hasUniqueKey);
+        }
       });
 
   node.Subscribe("/performer_detector", detectorCb);

--- a/test/worlds/performer_detector.sdf
+++ b/test/worlds/performer_detector.sdf
@@ -322,6 +322,25 @@
       <plugin filename="libignition-gazebo-performer-detector-system.so"
         name="ignition::gazebo::systems::PerformerDetector">
         <topic>/performer_detector</topic>
+      <header_data>
+        <key>no_value</key>
+      </header_data>
+      <header_data>
+        <value>no_key</value>
+      </header_data>
+      <header_data>
+        <key>unique_key</key>
+        <value>unique_value</value>
+      </header_data>
+      <header_data>
+        <key>duplicate_key</key>
+        <value>first_value</value>
+      </header_data>
+      <header_data>
+        <key>duplicate_key</key>
+        <value>second_value</value>
+      </header_data>
+
         <geometry>
           <box>
             <size>4 4 5</size>


### PR DESCRIPTION
Add support for zero or more

```
<header_data>
  <key>some key</key>
  <value>some_value</value>
</header_data>
```

in the performer detector.