### PR TITLE
Save http URIs (fix tests)

### DIFF
--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -200,9 +200,11 @@ namespace sdf_generator
   /// \brief Recursively go through the child elements of the input element and
   /// update all relative URIs to absolute.
   ///
-  /// The resulting URI will have a "file://" scheme regardless of whether the
-  /// original URI had the scheme. i.e, absolute URIs without the "file://"
-  /// scheme will also be updated by this function.
+  /// URIs with http / https scheme won't be modified.
+  ///
+  /// For all other URIs, the resulting URI will have a "file://" scheme
+  /// regardless of whether the original URI had the scheme. i.e, absolute URIs
+  /// without the "file://" scheme will also be updated by this function.
   /// \param[in] _elem Input element to update
   /// \param[in] _prefixPath Path to be prepended to relative URIs.
   static void relativeToAbsoluteUri(const sdf::ElementPtr &_elem,
@@ -214,7 +216,9 @@ namespace sdf_generator
       auto uriStr = uriElem->Get<std::string>();
       // If the URI starts with "file://", it is assumed to be an
       // absolute path, so there is no need to update it.
-      if (uriStr.find("file://") == std::string::npos)
+      if (uriStr.find("file://") == std::string::npos &&
+          uriStr.find("http://") == std::string::npos &&
+          uriStr.find("https://") == std::string::npos)
       {
         if (uriStr[0] != '/')
         {

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -53,14 +53,11 @@ static bool isSubset(const sdf::ElementPtr &_elemA,
 {
   if (_elemA->GetName() != _elemB->GetName())
   {
-    igndbg << "[" << _elemA->GetName() << "] different from ["
-            << _elemB->GetName() << "]" << std::endl;
     return false;
   }
+
   if (_elemA->GetAttributeCount() != _elemB->GetAttributeCount())
   {
-    igndbg << "[" << _elemA->GetAttributeCount() << "] different from ["
-            << _elemB->GetAttributeCount() << "]" << std::endl;
     return false;
   }
 
@@ -71,14 +68,10 @@ static bool isSubset(const sdf::ElementPtr &_elemA,
     sdf::ParamPtr attrB = _elemB->GetAttribute(attrA->GetKey());
     if (attrA->GetTypeName() != attrB->GetTypeName())
     {
-      igndbg << "[" << attrA->GetTypeName() << "] different from ["
-              << attrB->GetTypeName() << "]" << std::endl;
       return false;
     }
     if (attrA->GetAsString() != attrB->GetAsString())
     {
-      igndbg << "[" << attrA->GetAsString() << "] different from ["
-              << attrB->GetAsString() << "]" << std::endl;
       return false;
     }
   }
@@ -855,8 +848,6 @@ TEST_F(GenerateWorldFixture, ModelsInline)
     const std::optional<std::string> worldStr = sdf_generator::generateWorld(
         this->ecm, worldEntity, this->includeUriMap, this->sdfGenConfig);
     ASSERT_TRUE(worldStr.has_value());
-    // std::cout << "Generated world:" << std::endl;
-    // std::cout << worldStr << std::endl;
     sdf::Root newRoot;
     newRoot.LoadSdfString(*worldStr);
     EXPECT_TRUE(isSubset(newRoot.Element(), this->root.Element()));


### PR DESCRIPTION
The SDF generator was not taking into consideration the case where Fuel URLs are propagated through the ECS, because that was difficult to happen before https://github.com/ignitionrobotics/ign-fuel-tools/pull/85.

This PR just makes it so the full URLs are not completely broken when saving the world. A more complete fix would be to support the [EntityGeneratorConfig](https://github.com/ignitionrobotics/ign-msgs/blob/48536f710161449ac525edf3693e702c5da7a054/proto/ignition/msgs/sdf_generator_config.proto#L34-L46) options.