### PR TITLE
Sync components removal

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -534,6 +534,10 @@ namespace ignition
       /// is protected to facilitate testing.
       protected: void ClearNewlyCreatedEntities();
 
+      /// \brief Clear the list of removed components so that a call to
+      /// RemoveComponent doesn't make the list grow indefinitely.
+      protected: void ClearRemovedComponents();
+
       /// \brief Process all entity remove requests. This will remove
       /// entities and their components. This function is protected to
       /// facilitate testing.

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -860,7 +860,6 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedState &_msg,
 
   // Add a component to the message and set it to be removed if the component
   // exists in the removedComponents map.
-  // TODO(anyone) Set component being removed once we have a way to queue it
   this->dataPtr->SetRemovedComponentsMsgs(_entity, entityMsg);
 }
 
@@ -948,7 +947,6 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
 
   // Add a component to the message and set it to be removed if the component
   // exists in the removedComponents map.
-  // TODO(anyone) Set component being removed once we have a way to queue it
   this->dataPtr->SetRemovedComponentsMsgs(_entity, _msg);
 
   // Remove the entity from the message if a component for the entity was

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -110,10 +110,9 @@ class ignition::gazebo::EntityComponentManagerPrivate
   /// \brief Keep track of entities already used to ensure uniqueness.
   public: uint64_t entityCount{0};
 
-  /// \brief Map of removed components. The key is the entity to
+  /// \brief Unordered multimap of removed components. The key is the entity to
   /// which belongs the component, and the value is the component being
-  /// removed. This is set when RemoveComponent() is called, so we assume
-  /// only one removed component per entity.
+  /// removed.
   std::unordered_multimap<Entity, ComponentKey> removedComponents;
 };
 
@@ -791,9 +790,6 @@ void EntityComponentManagerPrivate::SetRemovedComponentsMsgs(Entity &_entity,
 
     it++;
   }
-
-  // Remove entity from map
-  this->removedComponents.erase(_entity);
 }
 
 //////////////////////////////////////////////////
@@ -825,9 +821,6 @@ void EntityComponentManagerPrivate::SetRemovedComponentsMsgs(Entity &_entity,
 
     it++;
   }
-
-  // Remove entity from map
-  this->removedComponents.erase(_entity);
 }
 
 //////////////////////////////////////////////////

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -97,7 +97,8 @@ class ignition::gazebo::EntityComponentManagerPrivate
 
   /// \brief Map of removed components. The key is the entity to
   /// which belongs the component, and the value is the component being
-  /// removed.
+  /// removed. This is set when RemoveComponent() is called, so we assume
+  /// only one removed component per entity.
   std::map<Entity, ComponentKey> removedComponents;
 };
 
@@ -862,7 +863,7 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
 
     // TODO(anyone) Set component being removed once we have a way to queue it
 
-    // Add a component to the message and set it to be removed if the entity
+    // Add a component to the message and set it to be removed if the component
     // exists in the removedComponents map.
 
     bool entityHasRemovedComponent =
@@ -872,8 +873,12 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
     {
       auto removedComponent = this->dataPtr->removedComponents[_entity];
       msgs::SerializedComponent cmp;
+
       cmp.set_type(removedComponent.first);
       cmp.set_remove(true);
+      // Empty data is needed for the component to be processed afterwards
+      cmp.set_component(" ");
+
       (*(entIter->second.mutable_components()))[
         static_cast<int64_t>(removedComponent.first)] = cmp;
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2172,7 +2172,14 @@ TEST_P(EntityComponentManagerFixture, RemovedComponentsSyncBetweenServerAndGUI)
   msgs::SerializedStateMap newStateMsg;
   manager.State(newStateMsg);
 
+  EXPECT_TRUE(nullptr != guiManager.Component<IntComponent>(e1));
+  EXPECT_TRUE(nullptr != guiManager.Component<DoubleComponent>(e1));
+  EXPECT_TRUE(nullptr != guiManager.Component<StringComponent>(e1));
   guiManager.SetState(newStateMsg);
+  EXPECT_TRUE(nullptr != guiManager.Component<IntComponent>(e1));
+  EXPECT_TRUE(nullptr == guiManager.Component<DoubleComponent>(e1));
+  EXPECT_TRUE(nullptr == guiManager.Component<StringComponent>(e1));
+
   msgs::SerializedStateMap newGuiStateMsg;
   guiManager.State(newGuiStateMsg);
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -716,6 +716,9 @@ void SimulationRunner::Step(const UpdateInfo &_info)
   // Process entity removals.
   this->entityCompMgr.ProcessRemoveEntityRequests();
 
+  // Process components removals
+  this->entityCompMgr.ClearRemovedComponents();
+
   // Each network manager takes care of marking its components as unchanged
   if (!this->networkMgr)
     this->entityCompMgr.SetAllComponentsUnchanged();

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -101,6 +101,7 @@ void GuiRunner::OnState(const msgs::SerializedStepMap &_msg)
     plugin->Update(this->updateInfo, this->ecm);
   }
   this->ecm.ClearNewlyCreatedEntities();
+  this->ecm.ClearRemovedComponents();
   this->ecm.ProcessRemoveEntityRequests();
 }
 

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -101,7 +101,7 @@ void GuiRunner::OnState(const msgs::SerializedStepMap &_msg)
     plugin->Update(this->updateInfo, this->ecm);
   }
   this->ecm.ClearNewlyCreatedEntities();
-  this->ecm.ClearRemovedComponents();
   this->ecm.ProcessRemoveEntityRequests();
+  this->ecm.ClearRemovedComponents();
 }
 


### PR DESCRIPTION
It sets the `SerializedStateMap` and `SerializedState` messages when a component is removed after `EntityComponentManager::RemoveComponent` is called. This allows a more precise synchronization between the server and GUI `EntityComponentManager`.

This PR is made in order to solve an issue in #234 already described [here](https://github.com/ignitionrobotics/ign-gazebo/pull/234#issuecomment-664414267) (no. 3).

A couple of comments about the PR:

- [This](https://github.com/ignitionrobotics/ign-gazebo/compare/master...mcres:sync_components_removal?expand=1#diff-f62ca607b3aece56b7217a0fb98c1253R864) TODO comment wasn't removed, given that the PR doesn't do any queuing.
- I think the PR should have 2 tests: one that checks the `SerializedStateMap` message after calling `RemoveComponent`, and another one that checks that a component is actually removed when its `remove` flag in the message is set to true. I've implemented the first one and the second should be already done [here](https://github.com/mcres/ign-gazebo/blob/61841ca5548145e364c8aeb832950289ac6b121c/src/EntityComponentManager_TEST.cc#L1628-L1693).