### PR TITLE
Fixed save world with fuel links

### DIFF
--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -212,9 +212,13 @@ namespace sdf_generator
     {
       auto uriElem = _elem->GetElement("uri");
       auto uriStr = uriElem->Get<std::string>();
-      // If the URI starts with "file://", it is assumed to be an
-      // absolute path, so there is no need to update it.
-      if (uriStr.find("file://") == std::string::npos)
+
+      // If the URI starts with "file://", "http://" or "http://"
+      // it is assumed to be an absolute path or an URL,
+      // so there is no need to update it.
+      if (uriStr.find("file://") == std::string::npos &&
+          !(uriStr.find("http://") == std::string::npos ||
+            uriStr.find("https://") == std::string::npos))
       {
         if (uriStr[0] != '/')
         {


### PR DESCRIPTION
This PR fixes when saving a world file at it contains `uri`s with fuel models. The current behaviour joins the fuel path to the URL. This condition avoids this.

Signed-off-by: ahcorde <ahcorde@gmail.com>