### PR TITLE
Qt auto scale factor for HiDPI displays

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -53,6 +53,9 @@ std::unique_ptr<ignition::gui::Application> createGui(
   ignmsg << "Ignition Gazebo GUI    v" << IGNITION_GAZEBO_VERSION_FULL
          << std::endl;
 
+  // Set auto scaling factor for HiDPI displays
+  qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+
   // Initialize Qt app
   auto app = std::make_unique<ignition::gui::Application>(_argc, _argv);
   app->AddPluginPath(IGN_GAZEBO_GUI_PLUGIN_INSTALL_DIR);

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -54,7 +54,10 @@ std::unique_ptr<ignition::gui::Application> createGui(
          << std::endl;
 
   // Set auto scaling factor for HiDPI displays
-  qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+  if (QString::fromLocal8Bit(qgetenv("QT_AUTO_SCREEN_SCALE_FACTOR")).isEmpty())
+  {
+    qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+  }
 
   // Initialize Qt app
   auto app = std::make_unique<ignition::gui::Application>(_argc, _argv);


### PR DESCRIPTION
On HiDPI displays, Ignition menus, fonts, and buttons don't appear correctly.
I don't have a non-HiDPI display to test whether this change messes it up for non-HiDPI displays. Can someone test this?

This PR is the equivalent of setting this on the command line:
```
export QT_AUTO_SCREEN_SCALE_FACTOR=1
```
I'm putting this line in `ign-gazebo` as opposed to `ign-gui`, because this environment variable needs to be set before `ignition::gui::Application` is called. I tried setting it in `Application()` constructor in `ign-gui`, and that did not have an effect.

Test simply with
```
ign gazebo
```

What I did test was whether this flag needs a guard, i.e. getting the value before setting it, then restoring it afterwards. It seems a guard is not needed, because after I terminate `ign gazebo`, then I launch another app in the same terminal that usually doesn't do auto-scale adjustment, and it still doesn't. So seems the flag is not propagated beyond program termination.

If this gets merged, then I can also add the same line before every `Application()` call in `ign-gui` entry point https://github.com/ignitionrobotics/ign-gui/blob/master/src/ign.cc It seems to work there from brief testing.

### Before the fix

For example, on such a display with Gnome auto-scaling set to 200%, Ignition menu font sizes are inconsistent. Compare the font sizes of "Show/Hide Grid" and "Cell Count", which are the same size on non-HiDPI displays.
The mouse cursor takes on the wrong shape on the run button, making it difficult to unpause physics:
![Screenshot from 2020-08-12 22-53-42_beforeFix](https://user-images.githubusercontent.com/7608908/90089281-e9bc9980-dcee-11ea-9881-2352afd46f82.png)

When a second panel is added, the cursor is always in double-arrow for the entire length of the panel title bar, which makes  closing the second panel impossible:
![Screenshot from 2020-08-12 22-54-56_beforeFix](https://user-images.githubusercontent.com/7608908/90089289-f640f200-dcee-11ea-9068-df0e42ad4abd.png)

### After the fix

Font sizes are consistent, cursor size and behavior are correct:

![Screenshot from 2020-08-12 23-00-37](https://user-images.githubusercontent.com/7608908/90089682-fa214400-dcef-11ea-8519-c268983f2091.png)

Signed-off-by: Mabel Zhang <mabel@openrobotics.org>