### PR TITLE
Fix non-specified material error

### DIFF
--- a/src/rendering/MarkerManager.cc
+++ b/src/rendering/MarkerManager.cc
@@ -308,11 +308,14 @@ void MarkerManagerPrivate::SetMarker(const ignition::msgs::Marker &_msg,
   _markerPtr->SetType(markerType);
 
   // Set Marker Material
-  rendering::MaterialPtr materialPtr = MsgToMaterial(_msg);
-  _markerPtr->SetMaterial(materialPtr, true /* clone */);
+  if (_msg.has_material())
+  {
+    rendering::MaterialPtr materialPtr = MsgToMaterial(_msg);
+    _markerPtr->SetMaterial(materialPtr, true /* clone */);
 
-  // clean up material after clone
-  this->scene->DestroyMaterial(materialPtr);
+    // clean up material after clone
+    this->scene->DestroyMaterial(materialPtr);
+  }
 
   // Assume the presence of points means we clear old ones
   if (_msg.point().size() > 0)


### PR DESCRIPTION
As found in https://github.com/ignitionrobotics/ign-gazebo/issues/285 , if no material is specified when using `ign service` to spawn a marker, the material defaults to transparent/invisible, this check will set the default material of marker visuals to white if no material is specified.

Signed-off-by: John Shepherd <john@openrobotics.org>