### PR TITLE
Fix tests on Blueprint

### DIFF
--- a/include/ignition/gazebo/Server.hh
+++ b/include/ignition/gazebo/Server.hh
@@ -148,9 +148,7 @@ namespace ignition
       /// or more simulation worlds, each of which may or may not be
       /// running. See Running(const unsigned int) to get the running status
       /// of a world.
-      /// \param[in] _worldIndex Index of the world to query.
-      /// \return True if the server is running, or std::nullopt
-      ///  if _worldIndex is invalid.
+      /// \return True if the server is running.
       public: bool Running() const;
 
       /// \brief Get whether a world simulation instance is running. When

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -28,7 +28,33 @@
 #include "ServerPrivate.hh"
 #include "SimulationRunner.hh"
 
-using namespace ignition::gazebo;
+using namespace ignition;
+using namespace gazebo;
+
+//////////////////////////////////////////////////
+// Getting the first .sdf file in the path
+std::string findFuelResourceSdf(const std::string &_path)
+{
+  if (!common::exists(_path))
+    return "";
+
+  for (common::DirIter file(_path); file != common::DirIter(); ++file)
+  {
+    std::string current(*file);
+    if (!common::isFile(current))
+      continue;
+
+    auto fileName = common::basename(current);
+    auto fileExtensionIndex = fileName.rfind(".");
+    auto fileExtension = fileName.substr(fileExtensionIndex + 1);
+
+    if (fileExtension == "sdf")
+    {
+      return current;
+    }
+  }
+  return "";
+}
 
 /// \brief This struct provides access to the default world.
 struct DefaultWorld
@@ -123,10 +149,51 @@ Server::Server(const ServerConfig &_config)
   }
   else if (!_config.SdfFile().empty())
   {
-    common::SystemPaths systemPaths;
-    systemPaths.SetFilePathEnv(kResourcePathEnv);
-    systemPaths.AddFilePaths(IGN_GAZEBO_WORLD_INSTALL_DIR);
-    std::string filePath = systemPaths.FindFile(_config.SdfFile());
+    std::string filePath;
+
+    // Check Fuel if it's a URL
+    auto sdfUri = common::URI(_config.SdfFile());
+    if (sdfUri.Scheme() == "http" || sdfUri.Scheme() == "https")
+    {
+      std::string fuelCachePath;
+      if (this->dataPtr->fuelClient->CachedWorld(common::URI(_config.SdfFile()),
+          fuelCachePath))
+      {
+        filePath = findFuelResourceSdf(fuelCachePath);
+      }
+      else if (auto result = this->dataPtr->fuelClient->DownloadWorld(
+          common::URI(_config.SdfFile()), fuelCachePath))
+      {
+        filePath = findFuelResourceSdf(fuelCachePath);
+      }
+      else
+      {
+        ignwarn << "Fuel couldn't download URL [" << _config.SdfFile()
+                << "], error: [" << result.ReadableResult() << "]"
+                << std::endl;
+      }
+    }
+
+    if (filePath.empty())
+    {
+      common::SystemPaths systemPaths;
+
+      // Worlds from environment variable
+      systemPaths.SetFilePathEnv(kResourcePathEnv);
+
+      // Worlds installed with ign-gazebo
+      systemPaths.AddFilePaths(IGN_GAZEBO_WORLD_INSTALL_DIR);
+
+      filePath = systemPaths.FindFile(_config.SdfFile());
+    }
+
+    if (filePath.empty())
+    {
+      ignerr << "Failed to find world [" << _config.SdfFile() << "]"
+             << std::endl;
+      return;
+    }
+
     ignmsg << "Loading SDF world file[" << filePath << "].\n";
 
     // \todo(nkoenig) Async resource download.

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -289,31 +289,6 @@ class ignition::gazebo::ServerConfigPrivate
 };
 
 //////////////////////////////////////////////////
-std::string findResourceSdf(const std::string &_path)
-{
-  if (ignition::common::exists(_path))
-  {
-    for (ignition::common::DirIter file(_path);
-         file != ignition::common::DirIter(); ++file)
-    {
-      std::string current(*file);
-      if (ignition::common::isFile(current))
-      {
-        std::string fileName = ignition::common::basename(current);
-        std::string::size_type fileExtensionIndex = fileName.rfind(".");
-        std::string fileExtension = fileName.substr(fileExtensionIndex + 1);
-
-        if (fileExtension == "sdf")
-        {
-          return current;
-        }
-      }
-    }
-  }
-  return "";
-}
-
-//////////////////////////////////////////////////
 ServerConfig::ServerConfig()
   : dataPtr(new ServerConfigPrivate)
 {
@@ -331,37 +306,9 @@ ServerConfig::~ServerConfig() = default;
 //////////////////////////////////////////////////
 bool ServerConfig::SetSdfFile(const std::string &_file)
 {
-  if (ignition::common::isFile(_file))
-  {
-    this->dataPtr->sdfFile = _file;
-    this->dataPtr->sdfString = "";
-    return true;
-  }
-
-  // The file name does not have a file extension, assume it is a fuel world
-  std::string path;
-  std::string fileName = "";
-  ignition::fuel_tools::FuelClient fuelClient;
-
-  if (fuelClient.CachedWorld(ignition::common::URI(_file), path))
-  {
-    this->dataPtr->sdfFile = findResourceSdf(path);
-    this->dataPtr->sdfString = "";
-    return true;
-  }
-  else if (ignition::fuel_tools::Result result =
-      fuelClient.DownloadWorld(ignition::common::URI(_file), path); result)
-  {
-    this->dataPtr->sdfFile = findResourceSdf(path);
-    this->dataPtr->sdfString = "";
-    return true;
-  }
-  else
-  {
-    ignwarn << "Fuel world download failed because " <<
-      result.ReadableResult() << std::endl;
-  }
-  return false;
+  this->dataPtr->sdfFile = _file;
+  this->dataPtr->sdfString = "";
+  return true;
 }
 
 /////////////////////////////////////////////////

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -762,21 +762,27 @@ TEST_P(ServerFixture, GetResourcePaths)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, CachedFuelWorld)
 {
-  auto logPath = common::joinPaths(
-      std::string(PROJECT_BINARY_PATH), "test_log_path");
   auto cachedWorldPath =
     common::joinPaths(std::string(PROJECT_SOURCE_PATH), "test", "worlds");
-  auto cachedWorldFilePath = common::joinPaths(cachedWorldPath,
-    "fuel.ignitionrobotics.org", "OpenRobotics", "worlds",
-    "Test%20world", "2", "test.sdf");
-  auto fuelWorldURL =
-    "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Test%20world";
   setenv("IGN_FUEL_CACHE_PATH", cachedWorldPath.c_str(), 1);
 
   ServerConfig serverConfig;
-
+  auto fuelWorldURL =
+    "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Test%20world";
   EXPECT_TRUE(serverConfig.SetSdfFile(fuelWorldURL));
-  EXPECT_EQ(cachedWorldFilePath, serverConfig.SdfFile());
+
+  EXPECT_EQ(fuelWorldURL, serverConfig.SdfFile());
+  EXPECT_TRUE(serverConfig.SdfString().empty());
+
+  // Check that world was loaded
+  auto server = Server(serverConfig);
+  EXPECT_NE(std::nullopt, server.Running(0));
+  EXPECT_FALSE(*server.Running(0));
+
+  server.Run(true /*blocking*/, 1, false/*paused*/);
+
+  EXPECT_NE(std::nullopt, server.Running(0));
+  EXPECT_FALSE(*server.Running(0));
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
We let some test failures slip in after #274. In particular, the support for finding worlds with the `IGN_GAZEBO_RESOURCE_PATH` was broken (`ServerFixture.ResourcePath`).

So here I moved the logic that finds worlds all to the same place inside `Server`. Having this search done as the server is instantiated also makes sure that all paths and callbacks needed have already been set. Searching for resources inside `ServerConfig.SetSdfPath` offers us less control about when that is checked, and kept it separate from the rest of the world finding logic.