### PR TITLE
Allow executing a blocking single Server run in both paused and unpaused states

### DIFF
--- a/include/ignition/gazebo/Server.hh
+++ b/include/ignition/gazebo/Server.hh
@@ -144,6 +144,15 @@ namespace ignition
                        const uint64_t _iterations = 0,
                        const bool _paused = true);
 
+      /// \brief Run the server once, all systems will be updated once and
+      /// then this returns. This is a blocking call.
+      /// \param[in] _paused True to run the simulation in a paused state,
+      /// false to run simulation unpaused. The simulation iterations will
+      /// be increased by 1.
+      /// \return False if the server was terminated before completing,
+      /// not being initialized, or if the server is already running.
+      public: bool RunOnce(const bool _paused = true);
+
       /// \brief Get whether the server is running. The server can have zero
       /// or more simulation worlds, each of which may or may not be
       /// running. See Running(const unsigned int) to get the running status

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -290,12 +290,12 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
 /////////////////////////////////////////////////
 bool Server::RunOnce(const bool _paused)
 {
-    if (_paused) {
-      for (auto &runner : this->dataPtr->simRunners)
-        runner->blockingPausedStepPending = true;
-    }
+  if (_paused) {
+    for (auto &runner : this->dataPtr->simRunners)
+      runner->blockingPausedStepPending = true;
+  }
 
-    return this->Run(true, 1, _paused);
+  return this->Run(true, 1, _paused);
 }
 
 /////////////////////////////////////////////////

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -292,7 +292,7 @@ bool Server::RunOnce(const bool _paused)
 {
   if (_paused) {
     for (auto &runner : this->dataPtr->simRunners)
-      runner->blockingPausedStepPending = true;
+      runner->SetNextStepAsBlockingPaused(true);
   }
 
   return this->Run(true, 1, _paused);

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -288,6 +288,17 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
 }
 
 /////////////////////////////////////////////////
+bool Server::RunOnce(const bool _paused)
+{
+    if (_paused) {
+      for (auto &runner : this->dataPtr->simRunners)
+        runner->blockingPausedStepPending = true;
+    }
+
+    return this->Run(true, 1, _paused);
+}
+
+/////////////////////////////////////////////////
 void Server::SetUpdatePeriod(
     const std::chrono::steady_clock::duration &_updatePeriod,
     const unsigned int _worldIndex)

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -290,7 +290,8 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
 /////////////////////////////////////////////////
 bool Server::RunOnce(const bool _paused)
 {
-  if (_paused) {
+  if (_paused)
+  {
     for (auto &runner : this->dataPtr->simRunners)
       runner->SetNextStepAsBlockingPaused(true);
   }
@@ -434,4 +435,3 @@ bool Server::RequestRemoveEntity(const Entity _entity,
 
   return false;
 }
-

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -478,95 +478,95 @@ TEST_P(ServerFixture, RunNonBlocking)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, RunOnceUnpaused)
 {
-    gazebo::Server server;
-    EXPECT_FALSE(server.Running());
-    EXPECT_FALSE(*server.Running(0));
-    EXPECT_EQ(0u, *server.IterationCount());
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(0u, *server.IterationCount());
 
-    // Load a system
-    gazebo::SystemLoader systemLoader;
-    auto mockSystemPlugin = systemLoader.LoadPlugin(
-        "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-    ASSERT_TRUE(mockSystemPlugin.has_value());
+  // Load a system
+  gazebo::SystemLoader systemLoader;
+  auto mockSystemPlugin = systemLoader.LoadPlugin(
+      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
+  ASSERT_TRUE(mockSystemPlugin.has_value());
 
-    // Check that it was loaded
-    const size_t systemCount = *server.SystemCount();
-    EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-    EXPECT_EQ(systemCount + 1, *server.SystemCount());
+  // Check that it was loaded
+  const size_t systemCount = *server.SystemCount();
+  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+  EXPECT_EQ(systemCount + 1, *server.SystemCount());
 
-    // Query the interface from the plugin
-    auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-    EXPECT_NE(system, nullptr);
-    auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-    EXPECT_NE(mockSystem, nullptr);
+  // Query the interface from the plugin
+  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+  EXPECT_NE(system, nullptr);
+  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+  EXPECT_NE(mockSystem, nullptr);
 
-    // No steps should have been executed
-    EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-    EXPECT_EQ(0u, mockSystem->updateCallCount);
-    EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+  // No steps should have been executed
+  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(0u, mockSystem->updateCallCount);
+  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
 
-    // Make the server run fast
-    server.SetUpdatePeriod(1ns);
+  // Make the server run fast
+  server.SetUpdatePeriod(1ns);
 
-    while (*server.IterationCount() < 100)
-      server.RunOnce(false);
+  while (*server.IterationCount() < 100)
+    server.RunOnce(false);
 
-    // Check that the server provides the correct information
-    EXPECT_EQ(*server.IterationCount(), 100u);
-    EXPECT_FALSE(server.Running());
-    EXPECT_FALSE(*server.Running(0));
+  // Check that the server provides the correct information
+  EXPECT_EQ(*server.IterationCount(), 100u);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
 
-    // Check that the system has been called correctly
-    EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
-    EXPECT_EQ(100u, mockSystem->updateCallCount);
-    EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
+  // Check that the system has been called correctly
+  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(100u, mockSystem->updateCallCount);
+  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
 }
 
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, RunOncePaused)
 {
-    gazebo::Server server;
-    EXPECT_FALSE(server.Running());
-    EXPECT_FALSE(*server.Running(0));
-    EXPECT_EQ(0u, *server.IterationCount());
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(0u, *server.IterationCount());
 
-    // Load a system
-    gazebo::SystemLoader systemLoader;
-    auto mockSystemPlugin = systemLoader.LoadPlugin(
-        "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-    ASSERT_TRUE(mockSystemPlugin.has_value());
+  // Load a system
+  gazebo::SystemLoader systemLoader;
+  auto mockSystemPlugin = systemLoader.LoadPlugin(
+      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
+  ASSERT_TRUE(mockSystemPlugin.has_value());
 
-    // Check that it was loaded
-    const size_t systemCount = *server.SystemCount();
-    EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-    EXPECT_EQ(systemCount + 1, *server.SystemCount());
+  // Check that it was loaded
+  const size_t systemCount = *server.SystemCount();
+  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+  EXPECT_EQ(systemCount + 1, *server.SystemCount());
 
-    // Query the interface from the plugin
-    auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-    EXPECT_NE(system, nullptr);
-    auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-    EXPECT_NE(mockSystem, nullptr);
+  // Query the interface from the plugin
+  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+  EXPECT_NE(system, nullptr);
+  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+  EXPECT_NE(mockSystem, nullptr);
 
-    // No steps should have been executed
-    EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-    EXPECT_EQ(0u, mockSystem->updateCallCount);
-    EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+  // No steps should have been executed
+  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(0u, mockSystem->updateCallCount);
+  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
 
-    // Make the server run fast
-    server.SetUpdatePeriod(1ns);
+  // Make the server run fast
+  server.SetUpdatePeriod(1ns);
 
-    while (*server.IterationCount() < 100)
-      server.RunOnce(true);
+  while (*server.IterationCount() < 100)
+    server.RunOnce(true);
 
-    // Check that the server provides the correct information
-    EXPECT_EQ(*server.IterationCount(), 100u);
-    EXPECT_FALSE(server.Running());
-    EXPECT_FALSE(*server.Running(0));
+  // Check that the server provides the correct information
+  EXPECT_EQ(*server.IterationCount(), 100u);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
 
-    // Check that the system has been called correctly
-    EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
-    EXPECT_EQ(100u, mockSystem->updateCallCount);
-    EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
+  // Check that the system has been called correctly
+  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(100u, mockSystem->updateCallCount);
+  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
 }
 
 /////////////////////////////////////////////////

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -476,6 +476,42 @@ TEST_P(ServerFixture, RunNonBlocking)
 }
 
 /////////////////////////////////////////////////
+TEST_P(ServerFixture, RunOnceUnpaused)
+{
+    gazebo::Server server;
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+    EXPECT_EQ(0u, *server.IterationCount());
+
+    // Make the server run fast.
+    server.SetUpdatePeriod(1ns);
+
+    while (*server.IterationCount() < 100)
+        server.RunOnce(false);
+
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunOncePaused)
+{
+    gazebo::Server server;
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+    EXPECT_EQ(0u, *server.IterationCount());
+
+    // Make the server run fast.
+    server.SetUpdatePeriod(1ns);
+
+    while (*server.IterationCount() < 100)
+        server.RunOnce(true);
+
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
 TEST_P(ServerFixture, RunNonBlockingMultiple)
 {
   ignition::gazebo::ServerConfig serverConfig;

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -512,14 +512,14 @@ TEST_P(ServerFixture, RunOnceUnpaused)
       server.RunOnce(false);
 
     // Check that the server provides the correct information
-    EXPECT_EQ(*server.IterationCount(), 100);
+    EXPECT_EQ(*server.IterationCount(), 100u);
     EXPECT_FALSE(server.Running());
     EXPECT_FALSE(*server.Running(0));
 
     // Check that the system has been called correctly
-    EXPECT_EQ(100, mockSystem->preUpdateCallCount);
-    EXPECT_EQ(100, mockSystem->updateCallCount);
-    EXPECT_EQ(100, mockSystem->postUpdateCallCount);
+    EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+    EXPECT_EQ(100u, mockSystem->updateCallCount);
+    EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
 }
 
 /////////////////////////////////////////////////
@@ -559,14 +559,14 @@ TEST_P(ServerFixture, RunOncePaused)
       server.RunOnce(true);
 
     // Check that the server provides the correct information
-    EXPECT_EQ(*server.IterationCount(), 100);
+    EXPECT_EQ(*server.IterationCount(), 100u);
     EXPECT_FALSE(server.Running());
     EXPECT_FALSE(*server.Running(0));
 
     // Check that the system has been called correctly
-    EXPECT_EQ(100, mockSystem->preUpdateCallCount);
-    EXPECT_EQ(100, mockSystem->updateCallCount);
-    EXPECT_EQ(100, mockSystem->postUpdateCallCount);
+    EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+    EXPECT_EQ(100u, mockSystem->updateCallCount);
+    EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
 }
 
 /////////////////////////////////////////////////

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -489,6 +489,7 @@ TEST_P(ServerFixture, RunOnceUnpaused)
     while (*server.IterationCount() < 100)
       server.RunOnce(false);
 
+    EXPECT_EQ(*server.IterationCount(), 100);
     EXPECT_FALSE(server.Running());
     EXPECT_FALSE(*server.Running(0));
 }
@@ -507,6 +508,7 @@ TEST_P(ServerFixture, RunOncePaused)
     while (*server.IterationCount() < 100)
       server.RunOnce(true);
 
+    EXPECT_EQ(*server.IterationCount(), 100);
     EXPECT_FALSE(server.Running());
     EXPECT_FALSE(*server.Running(0));
 }

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -483,11 +483,11 @@ TEST_P(ServerFixture, RunOnceUnpaused)
     EXPECT_FALSE(*server.Running(0));
     EXPECT_EQ(0u, *server.IterationCount());
 
-    // Make the server run fast.
+    // Make the server run fast
     server.SetUpdatePeriod(1ns);
 
     while (*server.IterationCount() < 100)
-        server.RunOnce(false);
+      server.RunOnce(false);
 
     EXPECT_FALSE(server.Running());
     EXPECT_FALSE(*server.Running(0));
@@ -501,11 +501,11 @@ TEST_P(ServerFixture, RunOncePaused)
     EXPECT_FALSE(*server.Running(0));
     EXPECT_EQ(0u, *server.IterationCount());
 
-    // Make the server run fast.
+    // Make the server run fast
     server.SetUpdatePeriod(1ns);
 
     while (*server.IterationCount() < 100)
-        server.RunOnce(true);
+      server.RunOnce(true);
 
     EXPECT_FALSE(server.Running());
     EXPECT_FALSE(*server.Running(0));

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -668,6 +668,14 @@ bool SimulationRunner::Run(const uint64_t _iterations)
     {
       this->Step(this->currentInfo);
     }
+
+    // Handle Server::RunOnce(false) in which a single paused run is executed
+    if (this->currentInfo.paused && this->blockingPausedStepPending)
+    {
+      processedIterations++;
+      this->currentInfo.iterations++;
+      this->blockingPausedStepPending = false;
+    }
   }
 
   this->running = false;

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1179,11 +1179,13 @@ void SimulationRunner::AddToFuelUriMap(const std::string &_path,
   this->fuelUriMap[_path] = _uri;
 }
 
+//////////////////////////////////////////////////
 bool SimulationRunner::NextStepIsBlockingPaused() const
 {
   return this->blockingPausedStepPending;
 }
 
+//////////////////////////////////////////////////
 void SimulationRunner::SetNextStepAsBlockingPaused(const bool value)
 {
   this->blockingPausedStepPending = value;

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1178,3 +1178,13 @@ void SimulationRunner::AddToFuelUriMap(const std::string &_path,
 {
   this->fuelUriMap[_path] = _uri;
 }
+
+bool SimulationRunner::NextStepIsBlockingPaused() const
+{
+  return this->blockingPausedStepPending;
+}
+
+void SimulationRunner::SetNextStepAsBlockingPaused(const bool value)
+{
+  this->blockingPausedStepPending = value;
+}

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -491,6 +491,10 @@ namespace ignition
       /// \brief Map from file paths to Fuel URIs.
       private: std::unordered_map<std::string, std::string> fuelUriMap;
 
+      /// \brief True if Server::RunOnce triggered a blocking paused step
+      private: bool blockingPausedStepPending{false};
+
+      friend class Server;
       friend class LevelManager;
     };
     }

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -344,6 +344,13 @@ namespace ignition
       public: void AddToFuelUriMap(const std::string &_path,
                                    const std::string &_uri);
 
+      /// \brief Get whether the next step is going to be executed as paused.
+      /// \return True if the next step is being executed as paused, false otherwise.
+      public: bool NextStepIsBlockingPaused() const;
+
+      /// \brief Set the next step to be blocking and paused.
+      public: void SetNextStepAsBlockingPaused(const bool value);
+
       /// \brief This is used to indicate that a stop event has been received.
       private: std::atomic<bool> stopReceived{false};
 
@@ -494,7 +501,6 @@ namespace ignition
       /// \brief True if Server::RunOnce triggered a blocking paused step
       private: bool blockingPausedStepPending{false};
 
-      friend class Server;
       friend class LevelManager;
     };
     }


### PR DESCRIPTION
This is the second attempt after https://github.com/ignitionrobotics/ign-gazebo/pull/61 to allow executing paused blocking `Server` runs. The first PR was closed as detailed in https://github.com/ignitionrobotics/ign-gazebo/pull/61#issuecomment-655621591 for further discussion https://github.com/ignitionrobotics/ign-gazebo/issues/51#issuecomment-655979495. 

This PR introduces a new `Server::RunOnce` method that allows executing either unpaused or paused steps that are 1) always blocking and 2) always increase the iteration count.

The following table recaps the differences between `Run` and `RunOnce`:

| `Server::Run` | `Server::RunOnce` | Comment |
| --- | --- | --- |
| `Run(blocking=true, iterations=1, paused=false)` | `RunOnce(paused=false)` | Same behaviour, iterations count is increased by 1. |
| `Run(blocking=true, iterations=1, paused=true)` | - | Simulation loops forever until another thread calls `Server::SetPaused(false)`. Paused runs do not increase the iteration count. When the `Run` call returns, the iteration count is increased by 1. |
| - | `RunOnce(paused=true)` | Iteration count is increased by 1. Systems perform a paused step. Physics does not advance. |

Given that this PR touches core classes of the simulator, I tried to implement this feature by modifying the existing classes the little as possible. Rather than adding new APIs also to the `SimulationRunner` class that would have required further discussion, I preferred marking `Server` a friend class and introducing a new private flag.