### PR TITLE
Replaced common::Time for std::chrono

### DIFF
--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -105,7 +105,7 @@ void AirPressure::PostUpdate(const UpdateInfo &_info,
       // Update measurement time
       auto time = math::durationToSecNsec(_info.simTime);
       dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          common::Time(time.first, time.second), false);
+          common::Time::GetTime(time.first, time.second), false);
     }
   }
 

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -107,7 +107,7 @@ void Altimeter::PostUpdate(const UpdateInfo &_info,
       // Update measurement time
       auto time = math::durationToSecNsec(_info.simTime);
       dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          common::Time(time.first, time.second), false);
+          common::Time::GetTime(time.first, time.second), false);
     }
   }
 

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -109,7 +109,7 @@ void Imu::PostUpdate(const UpdateInfo &_info,
       // Update measurement time
       auto time = math::durationToSecNsec(_info.simTime);
       dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          common::Time(time.first, time.second), false);
+          common::Time::GetTime(time.first, time.second), false);
     }
   }
 

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -108,7 +108,7 @@ void LogicalCamera::PostUpdate(const UpdateInfo &_info,
       // Update sensor
       auto time = math::durationToSecNsec(_info.simTime);
       dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          common::Time(time.first, time.second), false);
+          common::Time::GetTime(time.first, time.second), false);
     }
   }
 

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -106,7 +106,7 @@ void Magnetometer::PostUpdate(const UpdateInfo &_info,
       // Update measurement time
       auto time = math::durationToSecNsec(_info.simTime);
       dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          common::Time(time.first, time.second), false);
+          common::Time::GetTime(time.first, time.second), false);
     }
   }
 

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -85,11 +85,12 @@ TEST_F(DepthCameraTest, DepthCameraBox)
   size_t iters100 = 100u;
   server.Run(true, iters100, false);
 
-  ignition::common::Time waitTime = ignition::common::Time(0.001);
+  auto waitTime = std::chrono::duration_cast< std::chrono::milliseconds>(
+      std::chrono::duration<double>(0.001));
   int i = 0;
   while (i < 300)
   {
-    ignition::common::Time::Sleep(waitTime);
+    std::this_thread::sleep_for(waitTime);
     i++;
   }
   EXPECT_NE(depthBuffer, nullptr);

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -141,7 +141,7 @@ TEST_F(PosePublisherTest, PublishCmd)
   std::list<math::Pose3d> lowerLinkPoses;
   std::list<math::Pose3d> upperLinkPoses;
   std::list<math::Pose3d> sensorPoses;
-  std::list<common::Time> timestamps;
+  std::list<std::chrono::system_clock::time_point> timestamps;
   testSystem.OnPostUpdate(
       [&modelName, &baseName, &lowerLinkName, &upperLinkName, &sensorName,
       &poses, &basePoses, &lowerLinkPoses, &upperLinkPoses, &sensorPoses,
@@ -196,7 +196,7 @@ TEST_F(PosePublisherTest, PublishCmd)
       auto simTimeSecNsec =
           ignition::math::durationToSecNsec(_info.simTime);
        timestamps.push_back(
-           common::Time(simTimeSecNsec.first, simTimeSecNsec.second));
+           common::Time::GetTime(simTimeSecNsec.first, simTimeSecNsec.second));
     });
   server.AddSystem(testSystem.systemPtr);
 
@@ -243,8 +243,10 @@ TEST_F(PosePublisherTest, PublishCmd)
   std::sort(poseMsgs.begin(), poseMsgs.end(), [](
       const ignition::msgs::Pose &_l, const ignition::msgs::Pose &_r)
   {
-    common::Time lt(_l.header().stamp().sec(), _l.header().stamp().nsec());
-    common::Time rt(_r.header().stamp().sec(), _r.header().stamp().nsec());
+    std::chrono::system_clock::time_point lt =
+      common::Time::GetTime(_l.header().stamp().sec(), _l.header().stamp().nsec());
+    std::chrono::system_clock::time_point rt =
+      common::Time::GetTime(_r.header().stamp().sec(), _r.header().stamp().nsec());
     return lt < rt;
   });
 
@@ -273,7 +275,8 @@ TEST_F(PosePublisherTest, PublishCmd)
     EXPECT_EQ(childFrame, msg.name());
 
     // verify timestamp
-    common::Time time(msg.header().stamp().sec(), msg.header().stamp().nsec());
+    std::chrono::system_clock::time_point time =
+      common::Time::GetTime(msg.header().stamp().sec(), msg.header().stamp().nsec());
     EXPECT_EQ(timestamps.front(), time);
     // assume msgs arrive in order and there is a pose msg for every link
     // so we only remove a timestamp from list after checking against all links
@@ -423,8 +426,8 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
   std::list<math::Pose3d> lowerLinkPoses;
   std::list<math::Pose3d> upperLinkPoses;
   std::list<math::Pose3d> sensorPoses;
-  std::list<common::Time> timestamps;
-  std::list<common::Time> staticPoseTimestamps;
+  std::list<std::chrono::system_clock::time_point> timestamps;
+  std::list<std::chrono::system_clock::time_point> staticPoseTimestamps;
 
   testSystem.OnPostUpdate(
       [&modelName, &baseName, &lowerLinkName, &upperLinkName, &sensorName,
@@ -480,9 +483,9 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
       auto simTimeSecNsec =
           ignition::math::durationToSecNsec(_info.simTime);
       timestamps.push_back(
-          common::Time(simTimeSecNsec.first, simTimeSecNsec.second));
+          common::Time::GetTime(simTimeSecNsec.first, simTimeSecNsec.second));
       staticPoseTimestamps.push_back(
-          common::Time(simTimeSecNsec.first, simTimeSecNsec.second));
+          common::Time::GetTime(simTimeSecNsec.first, simTimeSecNsec.second));
     });
   server.AddSystem(testSystem.systemPtr);
 
@@ -548,8 +551,9 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
       EXPECT_EQ(childFrame, msg.name());
 
       // verify timestamp
-      common::Time time(msg.header().stamp().sec(),
-          msg.header().stamp().nsec());
+      std::chrono::system_clock::time_point time =
+        common::Time::GetTime(msg.header().stamp().sec(),
+        msg.header().stamp().nsec());
       EXPECT_EQ(timestamps.front(), time);
 
       // verify pose
@@ -602,7 +606,8 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
       EXPECT_EQ(childFrame, msg.name());
 
       // verify timestamp
-      common::Time time(msg.header().stamp().sec(),
+      std::chrono::system_clock::time_point time =
+        common::Time::GetTime(msg.header().stamp().sec(),
           msg.header().stamp().nsec());
       EXPECT_EQ(staticPoseTimestamps.front(), time);
 

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -85,11 +85,12 @@ TEST_F(RgbdCameraTest, RgbdCameraBox)
   size_t iters100 = 100u;
   server.Run(true, iters100, false);
 
-  ignition::common::Time waitTime = ignition::common::Time(0.001);
+  auto waitTime = std::chrono::duration_cast< std::chrono::milliseconds>(
+      std::chrono::duration<double>(0.001));
   int i = 0;
   while (nullptr == depthBuffer && i < 500)
   {
-    ignition::common::Time::Sleep(waitTime);
+    std::this_thread::sleep_for(waitTime);
     i++;
   }
   ASSERT_NE(depthBuffer, nullptr);


### PR DESCRIPTION
This PR is part of this issue https://github.com/ignitionrobotics/ign-common/issues/61. The idea it's to deprecate the class `common::Time` in favor of `std::chrono`.

Related with 
 - https://github.com/ignitionrobotics/ign-common/pull/90
 - https://github.com/ignitionrobotics/ign-sensors/pull/41

Signed-off-by: ahcorde <ahcorde@gmail.com>