### PR TITLE
Adjust grid config starting size 

### DIFF
--- a/src/gui/plugins/grid_config/GridConfig.qml
+++ b/src/gui/plugins/grid_config/GridConfig.qml
@@ -23,7 +23,7 @@ import "qrc:/qml"
 GridLayout {
   columns: 6
   columnSpacing: 10
-  Layout.minimumWidth: 100
+  Layout.minimumWidth: 240
   Layout.minimumHeight: 600
   anchors.fill: parent
   anchors.leftMargin: 10


### PR DESCRIPTION
update the starting size of grid config when opened from dropdown menu. Fix #311 

Signed-off-by: claireyywang <22240514+claireyywang@users.noreply.github.com>