### PR TITLE
Support relative paths for PBR materials

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -259,16 +259,25 @@ msgs::Material ignition::gazebo::convert(const sdf::Material &_in)
     if (workflow)
     {
       pbrMsg->set_metalness(workflow->Metalness());
-      pbrMsg->set_metalness_map(workflow->MetalnessMap());
+      pbrMsg->set_metalness_map(workflow->MetalnessMap().empty() ? "" :
+          asFullPath(workflow->MetalnessMap(), _in.FilePath()));
       pbrMsg->set_roughness(workflow->Roughness());
-      pbrMsg->set_roughness_map(workflow->RoughnessMap());
+      pbrMsg->set_roughness_map(workflow->RoughnessMap().empty() ? "" :
+          asFullPath(workflow->RoughnessMap(), _in.FilePath()));
       pbrMsg->set_glossiness(workflow->Glossiness());
-      pbrMsg->set_glossiness_map(workflow->GlossinessMap());
-      pbrMsg->set_specular_map(workflow->SpecularMap());
-      pbrMsg->set_albedo_map(workflow->AlbedoMap());
-      pbrMsg->set_normal_map(workflow->NormalMap());
-      pbrMsg->set_ambient_occlusion_map(workflow->AmbientOcclusionMap());
-      pbrMsg->set_environment_map(workflow->EnvironmentMap());
+      pbrMsg->set_glossiness_map(workflow->GlossinessMap().empty() ? "" :
+          asFullPath(workflow->GlossinessMap(), _in.FilePath()));
+      pbrMsg->set_specular_map(workflow->SpecularMap().empty() ? "" :
+          asFullPath(workflow->SpecularMap(), _in.FilePath()));
+      pbrMsg->set_albedo_map(workflow->AlbedoMap().empty() ? "" :
+          asFullPath(workflow->AlbedoMap(), _in.FilePath()));
+      pbrMsg->set_normal_map(workflow->NormalMap().empty() ? "" :
+          asFullPath(workflow->NormalMap(), _in.FilePath()));
+      pbrMsg->set_ambient_occlusion_map(
+          workflow->AmbientOcclusionMap().empty() ? "" :
+          asFullPath(workflow->AmbientOcclusionMap(), _in.FilePath()));
+      pbrMsg->set_environment_map(workflow->EnvironmentMap().empty() ? "" :
+          asFullPath(workflow->EnvironmentMap(), _in.FilePath()));
     }
   }
   return out;


### PR DESCRIPTION
Resolves #286.

Requires: https://github.com/osrf/sdformat/pull/349.

To test, you can modify PBR map URIs similar to the following.

Old
```
<pbr>
  <metal>
    <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight Type A/3/files/materials/textures/Gravel_Albedo.png</albedo_map>
    <normal_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight Type A/3/files/materials/textures/Gravel_Normal.png</normal_map>
    <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight Type A/3/files/materials/textures/Gravel_Roughness.png</roughness_map>
  </metal>
</pbr>
```

New
```
<pbr>
  <metal>
    <albedo_map>materials/textures/Gravel_Albedo.png</albedo_map>
    <normal_map>materials/textures/Gravel_Normal.png</normal_map>
    <roughness_map>materials/textures/Gravel_Roughness.png</roughness_map>
  </metal>
</pbr>
```

Signed-off-by: Nate Koenig <nate@openrobotics.org>