### PR TITLE
Fix Log system tests to work with plugin names without ".so"

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -65,27 +65,27 @@ struct DefaultWorld
   {
     std::vector<std::string> pluginsV = {
       {
-        std::string("<plugin filename='libignition-gazebo") +
-        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-scene-broadcaster-system.so' "
+        std::string("<plugin filename='ignition-gazebo") +
+        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-scene-broadcaster-system' "
         "name='ignition::gazebo::systems::SceneBroadcaster'></plugin>"
       }};
 
     // The set of default gazebo plugins.
     if (_config.LogPlaybackPath().empty())
     {
-      pluginsV.push_back(std::string("<plugin filename='libignition-gazebo") +
-        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system.so' "
+      pluginsV.push_back(std::string("<plugin filename='ignition-gazebo") +
+        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system' "
         "name='ignition::gazebo::systems::Physics'></plugin>");
-      pluginsV.push_back(std::string("<plugin filename='libignition-gazebo") +
-        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-user-commands-system.so' " +
+      pluginsV.push_back(std::string("<plugin filename='ignition-gazebo") +
+        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-user-commands-system' " +
         "name='ignition::gazebo::systems::UserCommands'></plugin>");
     }
 
     // Playback plugin
     else
     {
-      pluginsV.push_back(std::string("<plugin filename='libignition-gazebo") +
-        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-log-system.so' "
+      pluginsV.push_back(std::string("<plugin filename='ignition-gazebo") +
+        IGNITION_GAZEBO_MAJOR_VERSION_STR + "-log-system' "
         "name='ignition::gazebo::systems::LogPlayback'><path>" +
         _config.LogPlaybackPath() + "</path></plugin>");
     }

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -42,7 +42,7 @@ struct LoggingPlugin
   public: static std::string &LoggingPluginFileName()
   {
     static std::string recordPluginFileName =
-      std::string("libignition-gazebo") +
+      std::string("ignition-gazebo") +
       IGNITION_GAZEBO_MAJOR_VERSION_STR + "-log-system";
     return recordPluginFileName;
   }

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -43,7 +43,7 @@ struct LoggingPlugin
   {
     static std::string recordPluginFileName =
       std::string("libignition-gazebo") +
-      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-log-system.so";
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-log-system";
     return recordPluginFileName;
   }
 
@@ -52,7 +52,7 @@ struct LoggingPlugin
   /// \return A string that contains the record plugin suffix.
   public: static std::string &LoggingPluginSuffix()
   {
-    static std::string recordPluginSuffix = "-log-system.so";
+    static std::string recordPluginSuffix = "-log-system";
     return recordPluginSuffix;
   }
 


### PR DESCRIPTION
This fixes a regression from ignitionrobotics/ign-gazebo#279.