### PR TITLE
Resource spawner: accept relative paths

### DIFF
--- a/include/ignition/gazebo/gui/GuiEvents.hh
+++ b/include/ignition/gazebo/gui/GuiEvents.hh
@@ -161,13 +161,17 @@ namespace events
     static const QEvent::Type kType = QEvent::Type(QEvent::User + 3);
   };
 
-  /// \brief Event called to spawn a preview model.  Used in shapes plugin.
+  /// \brief Event called to spawn a preview model.
+  /// Used by plugins that spawn models.
   class SpawnPreviewModel : public QEvent
   {
+    /// \brief Constructor
+    /// \param[in] _modelSdfString The model's SDF file as a string.
     public: explicit SpawnPreviewModel(std::string &_modelSdfString)
         : QEvent(kType), modelSdfString(_modelSdfString)
     {
     }
+
     /// \brief Unique type for this event.
     static const QEvent::Type kType = QEvent::Type(QEvent::User + 4);
 
@@ -180,6 +184,31 @@ namespace events
 
     /// \brief The sdf string of the model to be previewed.
     std::string modelSdfString;
+  };
+
+  /// \brief Event called to spawn a preview resource, which takes the path
+  /// to the SDF file. Used by plugins that spawn resources.
+  class SpawnPreviewPath : public QEvent
+  {
+    /// \brief Constructor
+    /// \param[in] _filePath The path to an SDF file.
+    public: explicit SpawnPreviewPath(const std::string &_filePath)
+        : QEvent(kType), filePath(_filePath)
+    {
+    }
+
+    /// \brief Unique type for this event.
+    static const QEvent::Type kType = QEvent::Type(QEvent::User + 5);
+
+    /// \brief Get the path of the SDF file.
+    /// \return The file path.
+    public: std::string FilePath() const
+    {
+      return this->filePath;
+    }
+
+    /// \brief The path of SDF file to be previewed.
+    std::string filePath;
   };
 }  // namespace events
 }

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -345,7 +345,8 @@ namespace ignition
                                    const std::string &_uri);
 
       /// \brief Get whether the next step is going to be executed as paused.
-      /// \return True if the next step is being executed as paused, false otherwise.
+      /// \return True if the next step is being executed as paused, false
+      /// otherwise.
       public: bool NextStepIsBlockingPaused() const;
 
       /// \brief Set the next step to be blocking and paused.

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -472,15 +472,7 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
 /////////////////////////////////////////////////
 void ResourceSpawner::OnResourceSpawn(const QString &_sdfPath)
 {
-  std::string modelSdfPath = _sdfPath.toStdString();
-  // Parse the sdf from the path
-  std::ifstream nameFileout;
-  nameFileout.open(modelSdfPath);
-  std::string line;
-  std::string modelSdfString = "";
-  while (std::getline(nameFileout, line))
-    modelSdfString += line + "\n";
-  auto event = new gui::events::SpawnPreviewModel(modelSdfString);
+  auto event = new gui::events::SpawnPreviewPath(_sdfPath.toStdString());
   ignition::gui::App()->sendEvent(
       ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
       event);

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -215,35 +215,33 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Flag for indicating whether we are in view angle mode or not
     public: bool viewAngle = false;
 
-    /// \brief Flag for indicating whether we are in shapes mode or not
-    public: bool spawnModel = false;
+    /// \brief Flag for indicating whether we are spawning or not.
+    public: bool isSpawning = false;
 
     /// \brief Flag for indicating whether the user is currently placing a
-    /// model with the shapes plugin or not
-    public: bool placingModel = false;
+    /// resource with the shapes plugin or not
+    public: bool isPlacing = false;
 
-    /// \brief The sdf string of the model to be used with plugins that spawn
-    /// models.
-    public: std::string modelSdfString;
+    /// \brief The SDF string of the resource to be used with plugins that spawn
+    /// entities.
+    public: std::string spawnSdfString;
 
-    /// \brief The path of SDF file of the model to be used with plugins that
-    /// spawn models.
-    public: std::string modelSdfPath;
+    /// \brief Path of an SDF file, to be used with plugins that spawn entities.
+    public: std::string spawnSdfPath;
 
-    /// \brief The pose of the preview model
-    public: ignition::math::Pose3d previewModelPose =
+    /// \brief The pose of the spawn preview.
+    public: ignition::math::Pose3d spawnPreviewPose =
             ignition::math::Pose3d::Zero;
 
     /// \brief The currently hovered mouse position in screen coordinates
     public: math::Vector2i mouseHoverPos = math::Vector2i::Zero;
 
-    /// \brief The model generated from the modelSdfString / modelSdfPath upon
-    /// the user clicking a shape in the shapes plugin
-    public: rendering::VisualPtr spawnPreviewModel = nullptr;
+    /// \brief The visual generated from the spawnSdfString / spawnSdfPath
+    public: rendering::VisualPtr spawnPreview = nullptr;
 
-    /// \brief A record of the ids currently used by the model generation
+    /// \brief A record of the ids currently used by the entity spawner
     /// for easy deletion of visuals later
-    public: std::vector<Entity> modelIds;
+    public: std::vector<Entity> previewIds;
 
     /// \brief The pose set during a view angle button press that holds
     /// the pose the camera should assume relative to the entit(y/ies).
@@ -599,26 +597,26 @@ void IgnRenderer::Render()
   // Shapes
   {
     IGN_PROFILE("IgnRenderer::Render Shapes");
-    if (this->dataPtr->spawnModel)
+    if (this->dataPtr->isSpawning)
     {
-      // Generate preview model
+      // Generate spawn preview
       rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
       rendering::VisualPtr rootVis = scene->RootVisual();
       sdf::Root root;
-      if (!this->dataPtr->modelSdfString.empty())
+      if (!this->dataPtr->spawnSdfString.empty())
       {
-        root.LoadSdfString(this->dataPtr->modelSdfString);
+        root.LoadSdfString(this->dataPtr->spawnSdfString);
       }
-      else if (!this->dataPtr->modelSdfPath.empty())
+      else if (!this->dataPtr->spawnSdfPath.empty())
       {
-        root.Load(this->dataPtr->modelSdfPath);
+        root.Load(this->dataPtr->spawnSdfPath);
       }
       else
       {
         ignwarn << "Failed to spawn: no SDF string or path" << std::endl;
       }
-      this->dataPtr->placingModel = this->GeneratePreview(root);
-      this->dataPtr->spawnModel = false;
+      this->dataPtr->isPlacing = this->GeneratePreview(root);
+      this->dataPtr->isSpawning = false;
     }
   }
 
@@ -633,31 +631,32 @@ void IgnRenderer::Render()
 /////////////////////////////////////////////////
 bool IgnRenderer::GeneratePreview(const sdf::Root &_sdf)
 {
-  // Terminate any pre-existing visualized models
-  this->TerminatePreviewModel();
+  // Terminate any pre-existing spawned entities
+  this->TerminateSpawnPreview();
 
   if (!_sdf.ModelCount())
   {
-    this->TerminatePreviewModel();
+    ignwarn << "Only model entities can be spawned at the moment." << std::endl;
+    this->TerminateSpawnPreview();
     return false;
   }
 
   // Only preview first model
   sdf::Model model = *(_sdf.ModelByIndex(0));
-  this->dataPtr->previewModelPose = model.RawPose();
+  this->dataPtr->spawnPreviewPose = model.RawPose();
   model.SetName(ignition::common::Uuid().String());
   Entity modelId = this->UniqueId();
   if (!modelId)
   {
-    this->TerminatePreviewModel();
+    this->TerminateSpawnPreview();
     return false;
   }
-  this->dataPtr->spawnPreviewModel =
+  this->dataPtr->spawnPreview =
     this->dataPtr->renderUtil.SceneManager().CreateModel(
         modelId, model,
         this->dataPtr->renderUtil.SceneManager().WorldId());
 
-  this->dataPtr->modelIds.push_back(modelId);
+  this->dataPtr->previewIds.push_back(modelId);
   for (auto j = 0u; j < model.LinkCount(); j++)
   {
     sdf::Link link = *(model.LinkByIndex(j));
@@ -665,12 +664,12 @@ bool IgnRenderer::GeneratePreview(const sdf::Root &_sdf)
     Entity linkId = this->UniqueId();
     if (!linkId)
     {
-      this->TerminatePreviewModel();
+      this->TerminateSpawnPreview();
       return false;
     }
     this->dataPtr->renderUtil.SceneManager().CreateLink(
         linkId, link, modelId);
-    this->dataPtr->modelIds.push_back(linkId);
+    this->dataPtr->previewIds.push_back(linkId);
     for (auto k = 0u; k < link.VisualCount(); k++)
     {
      sdf::Visual visual = *(link.VisualByIndex(k));
@@ -678,24 +677,24 @@ bool IgnRenderer::GeneratePreview(const sdf::Root &_sdf)
      Entity visualId = this->UniqueId();
      if (!visualId)
      {
-       this->TerminatePreviewModel();
+       this->TerminateSpawnPreview();
        return false;
      }
      this->dataPtr->renderUtil.SceneManager().CreateVisual(
          visualId, visual, linkId);
-     this->dataPtr->modelIds.push_back(visualId);
+     this->dataPtr->previewIds.push_back(visualId);
     }
   }
   return true;
 }
 
 /////////////////////////////////////////////////
-void IgnRenderer::TerminatePreviewModel()
+void IgnRenderer::TerminateSpawnPreview()
 {
-  for (auto _id : this->dataPtr->modelIds)
+  for (auto _id : this->dataPtr->previewIds)
     this->dataPtr->renderUtil.SceneManager().RemoveEntity(_id);
-  this->dataPtr->modelIds.clear();
-  this->dataPtr->placingModel = false;
+  this->dataPtr->previewIds.clear();
+  this->dataPtr->isPlacing = false;
 }
 
 /////////////////////////////////////////////////
@@ -880,14 +879,14 @@ void IgnRenderer::HandleKeyRelease(QKeyEvent *_e)
 /////////////////////////////////////////////////
 void IgnRenderer::HandleModelPlacement()
 {
-  if (!this->dataPtr->placingModel)
+  if (!this->dataPtr->isPlacing)
     return;
 
-  if (this->dataPtr->spawnPreviewModel && this->dataPtr->hoverDirty)
+  if (this->dataPtr->spawnPreview && this->dataPtr->hoverDirty)
   {
     math::Vector3d pos = this->ScreenToPlane(this->dataPtr->mouseHoverPos);
-    pos.Z(this->dataPtr->spawnPreviewModel->WorldPosition().Z());
-    this->dataPtr->spawnPreviewModel->SetWorldPosition(pos);
+    pos.Z(this->dataPtr->spawnPreview->WorldPosition().Z());
+    this->dataPtr->spawnPreview->SetWorldPosition(pos);
     this->dataPtr->hoverDirty = false;
   }
   if (this->dataPtr->mouseEvent.Button() == common::MouseEvent::LEFT &&
@@ -895,9 +894,9 @@ void IgnRenderer::HandleModelPlacement()
       !this->dataPtr->mouseEvent.Dragging() && this->dataPtr->mouseDirty)
   {
     // Delete the generated visuals
-    this->TerminatePreviewModel();
+    this->TerminateSpawnPreview();
 
-    math::Pose3d modelPose = this->dataPtr->previewModelPose;
+    math::Pose3d modelPose = this->dataPtr->spawnPreviewPose;
     std::function<void(const ignition::msgs::Boolean &, const bool)> cb =
         [](const ignition::msgs::Boolean &/*_rep*/, const bool _result)
     {
@@ -907,13 +906,13 @@ void IgnRenderer::HandleModelPlacement()
     math::Vector3d pos = this->ScreenToPlane(this->dataPtr->mouseEvent.Pos());
     pos.Z(modelPose.Pos().Z());
     msgs::EntityFactory req;
-    if (!this->dataPtr->modelSdfString.empty())
+    if (!this->dataPtr->spawnSdfString.empty())
     {
-      req.set_sdf(this->dataPtr->modelSdfString);
+      req.set_sdf(this->dataPtr->spawnSdfString);
     }
-    else if (!this->dataPtr->modelSdfPath.empty())
+    else if (!this->dataPtr->spawnSdfPath.empty())
     {
-      req.set_sdf_filename(this->dataPtr->modelSdfPath);
+      req.set_sdf_filename(this->dataPtr->spawnSdfPath);
     }
     else
     {
@@ -928,8 +927,10 @@ void IgnRenderer::HandleModelPlacement()
           + "/create";
     }
     this->dataPtr->node.Request(this->dataPtr->createCmdService, req, cb);
-    this->dataPtr->placingModel = false;
+    this->dataPtr->isPlacing = false;
     this->dataPtr->mouseDirty = false;
+    this->dataPtr->spawnSdfString.clear();
+    this->dataPtr->spawnSdfPath.clear();
   }
 }
 
@@ -1585,16 +1586,16 @@ void IgnRenderer::SetTransformMode(const std::string &_mode)
 void IgnRenderer::SetModel(const std::string &_model)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-  this->dataPtr->spawnModel = true;
-  this->dataPtr->modelSdfString = _model;
+  this->dataPtr->isSpawning = true;
+  this->dataPtr->spawnSdfString = _model;
 }
 
 /////////////////////////////////////////////////
 void IgnRenderer::SetModelPath(const std::string &_filePath)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-  this->dataPtr->spawnModel = true;
-  this->dataPtr->modelSdfPath = _filePath;
+  this->dataPtr->isSpawning = true;
+  this->dataPtr->spawnSdfPath = _filePath;
 }
 
 /////////////////////////////////////////////////
@@ -2429,12 +2430,12 @@ bool Scene3D::eventFilter(QObject *_obj, QEvent *_event)
   else if (_event->type() ==
       ignition::gazebo::gui::events::SpawnPreviewModel::kType)
   {
-    auto spawnPreviewModelEvent =
+    auto spawnPreviewEvent =
       reinterpret_cast<gui::events::SpawnPreviewModel *>(_event);
-    if (spawnPreviewModelEvent)
+    if (spawnPreviewEvent)
     {
       auto renderWindow = this->PluginItem()->findChild<RenderWindowItem *>();
-      renderWindow->SetModel(spawnPreviewModelEvent->ModelSdfString());
+      renderWindow->SetModel(spawnPreviewEvent->ModelSdfString());
     }
   }
   else if (_event->type() ==
@@ -2641,7 +2642,7 @@ void RenderWindowItem::keyReleaseEvent(QKeyEvent *_e)
       _e->accept();
     }
     this->DeselectAllEntities(true);
-    this->dataPtr->renderThread->ignRenderer.TerminatePreviewModel();
+    this->dataPtr->renderThread->ignRenderer.TerminateSpawnPreview();
   }
 }
 

--- a/src/gui/plugins/scene3d/Scene3D.hh
+++ b/src/gui/plugins/scene3d/Scene3D.hh
@@ -348,8 +348,8 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \return True on success, false if failure
     public: bool GeneratePreview(const sdf::Root &_sdf);
 
-    /// \brief Delete the visuals generated from the shapes plugin.
-    public: void TerminatePreviewModel();
+    /// \brief Delete the visuals generated while an entity is being spawned.
+    public: void TerminateSpawnPreview();
 
     /// \brief Retrieve the point on a plane at z = 0 in the 3D scene hit by a
     /// ray cast from the given 2D screen coordinates.

--- a/src/gui/plugins/scene3d/Scene3D.hh
+++ b/src/gui/plugins/scene3d/Scene3D.hh
@@ -27,6 +27,8 @@
 #include <memory>
 #include <mutex>
 
+#include <sdf/Root.hh>
+
 #include <ignition/math/Color.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector2.hh>
@@ -185,6 +187,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \param[in] _model Sdf string of the model to load in for the user.
     public: void SetModel(const std::string &_model);
 
+    /// \brief Set the path to the model to hover over the scene.
+    /// \param[in] _filePath Sdf path of the model to load in for the user.
+    public: void SetModelPath(const std::string &_filePath);
+
     /// \brief Set whether to record video
     /// \param[in] _record True to start video recording, false to stop.
     /// \param[in] _format Video encoding format: "mp4", "ogv"
@@ -337,10 +343,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \return The unique entity id
     private: Entity UniqueId();
 
-    /// \brief Generate a preview of a model.
-    /// \param[in] _modelSdfString The sdf string of the model to be generated
+    /// \brief Generate a preview of a resource.
+    /// \param[in] _sdf The SDF to be previewed.
     /// \return True on success, false if failure
-    public: bool GeneratePreviewModel(const std::string &_modelSdfString);
+    public: bool GeneratePreview(const sdf::Root &_sdf);
 
     /// \brief Delete the visuals generated from the shapes plugin.
     public: void TerminatePreviewModel();
@@ -474,6 +480,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Set the model to hover.
     /// \param[in] _model Sdf string of the model to load in for the user.
     public: void SetModel(const std::string &_model);
+
+    /// \brief Set the path of the model to hover.
+    /// \param[in] _filePath File path of the model to load in for the user.
+    public: void SetModelPath(const std::string &_filePath);
 
     /// \brief Set whether to record video
     /// \param[in] _record True to start video recording, false to stop.


### PR DESCRIPTION
The resource spawner currently doesn't work for relative paths, because the file is being converted to text before URIs can be resolved.

This PR adds a new event that accepts a file path instead of an SDF string. Notably, this fixes spawning models from this collection:

https://app.ignitionrobotics.org/GoogleResearch/fuel/collections/Google%20Scanned%20Objects

I also went ahead and updated a lot of the terminology on the plugin to be more generic and don't apply just to models. We should add support for actors and lights soon.
