### PR TITLE
Suggestions to scrubber UI (#299)

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -159,12 +159,6 @@ std::unique_ptr<ignition::gui::Application> createGui(
   // Configuration file from command line
   if (_guiConfig != nullptr && std::strlen(_guiConfig) > 0)
   {
-    if (!app->LoadConfig(_guiConfig))
-    {
-      ignwarn << "Failed to load config file[" << _guiConfig << "]."
-              << std::endl;
-    }
-
     // Use the first world name with the config file
     // TODO(anyone) Most of ign-gazebo's transport API includes the world name,
     // which makes it complicated to mix configurations across worlds.
@@ -174,6 +168,13 @@ std::unique_ptr<ignition::gui::Application> createGui(
         &ignition::gazebo::GuiRunner::OnPluginAdded);
     ++runnerCount;
     runner->setParent(ignition::gui::App());
+
+    // Load plugins after runner is up
+    if (!app->LoadConfig(_guiConfig))
+    {
+      ignwarn << "Failed to load config file[" << _guiConfig << "]."
+              << std::endl;
+    }
   }
   // GUI configuration from SDF (request to server)
   else

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -157,7 +157,8 @@ std::unique_ptr<ignition::gui::Application> createGui(
   std::size_t runnerCount = 0;
 
   // Configuration file from command line
-  if (_guiConfig != nullptr && std::strlen(_guiConfig) > 0)
+  if (_guiConfig != nullptr && std::strlen(_guiConfig) > 0 &&
+      std::string(_guiConfig) != "_playback_")
   {
     // Use the first world name with the config file
     // TODO(anyone) Most of ign-gazebo's transport API includes the world name,

--- a/src/gui/playback_gui.config
+++ b/src/gui/playback_gui.config
@@ -63,32 +63,21 @@
 
 </plugin>
 
-<!-- Time / RTF -->
-<plugin filename="WorldStats" name="World stats">
+<!-- Playback Scrubber -->
+<plugin filename="PlaybackScrubber" name="PlaybackScrubber">
   <ignition-gui>
-    <title>World stats</title>
     <property type="bool" key="showTitleBar">false</property>
-    <property type="bool" key="resizable">false</property>
-    <property type="double" key="height">110</property>
-    <property type="double" key="width">290</property>
+    <property type="double" key="height">90</property>
+    <property type="double" key="width">350</property>
     <property type="double" key="z">1</property>
+    <property key="cardBackground" type="string">#66666666</property>
 
     <property type="string" key="state">floating</property>
     <anchors target="3D View">
-      <line own="right" target="right"/>
+      <line own="horizontalCenter" target="horizontalCenter"/>
       <line own="bottom" target="bottom"/>
     </anchors>
   </ignition-gui>
-
-  <sim_time>true</sim_time>
-  <real_time>true</real_time>
-  <real_time_factor>true</real_time_factor>
-  <iterations>true</iterations>
-
-</plugin>
-
-<!-- Playback Scrubber -->
-<plugin filename="PlaybackScrubber" name="PlaybackScrubber">
 </plugin>
 
 <!-- Inspector -->

--- a/src/gui/plugins/playback_scrubber/PlaybackScrubber.qml
+++ b/src/gui/plugins/playback_scrubber/PlaybackScrubber.qml
@@ -27,7 +27,7 @@ GridLayout {
   columns: 2
   rowSpacing: 0
   Layout.minimumWidth: 430
-  Layout.minimumHeight: 80
+  Layout.minimumHeight: 170
   anchors.fill: parent
   anchors.leftMargin: 10
   anchors.rightMargin: 10

--- a/src/gui/plugins/playback_scrubber/PlaybackScrubber.qml
+++ b/src/gui/plugins/playback_scrubber/PlaybackScrubber.qml
@@ -24,9 +24,10 @@ import QtQuick.Controls.Styles 1.4
 
 GridLayout {
   id: playbackScrubber
-  columns: 3
+  columns: 2
+  rowSpacing: 0
   Layout.minimumWidth: 430
-  Layout.minimumHeight: 170
+  Layout.minimumHeight: 80
   anchors.fill: parent
   anchors.leftMargin: 10
   anchors.rightMargin: 10
@@ -91,70 +92,58 @@ GridLayout {
       updateCurrentTime();
     }
   }
-  Rectangle {
+  Slider {
+    id: slider
     height: 40
-    width: 400
-    color: "transparent"
-    Layout.columnSpan: 3
-    Slider {
-      anchors.horizontalCenter: parent.horizontalCenter
-      id: slider
-      from: 0
-      value: updateSliderValue()
-      to: 1
-      stepSize: 0.001
-      width: 380
-      topPadding: 17
-      onPressedChanged: {
-        if (!pressed)
-        {
-          PlaybackScrubber.OnDrop(slider.value);
-          playbackScrubber.isPressed = false;
-        }
-        else
-        {
-          playbackScrubber.isPressed = true;
-        }
-      }
-    }
-  }
-
-  Rectangle {
-    height: 40
-    width: 170
-    color: "transparent"
-    Layout.columnSpan: 1
-    TextField {
-      id: textField
-      anchors.right: parent.right
-      placeholderText: currentTime
-      onAccepted: {
-        PlaybackScrubber.OnTimeEntered(textField.text);
-        textField.text = "";
-      }
-      color: Material.theme == Material.Light ? "black" : "white"
-    }
-  }
-
-  Rectangle {
-    height: 40
-    width: 200
-    color: "transparent"
+    Layout.fillWidth: true
     Layout.columnSpan: 2
-    Text {
-      id: maxTime
-      anchors.left: parent.left
-      anchors.verticalCenter: parent.verticalCenter
-      text: qsTr("/   ") + endTime
-      Layout.alignment: Qt.AlignLeft
-      font.pointSize: 11.5
-      color: Material.theme == Material.Light ? "black" : "white"
+    from: 0
+    value: updateSliderValue()
+    to: 1
+    stepSize: 0.001
+    topPadding: 17
+    onPressedChanged: {
+      if (!pressed)
+      {
+        PlaybackScrubber.OnDrop(slider.value);
+        playbackScrubber.isPressed = false;
+      }
+      else
+      {
+        playbackScrubber.isPressed = true;
+      }
     }
   }
+
+  TextField {
+    id: textField
+    height: 40
+    width: 30
+    Layout.columnSpan: 1
+    Layout.alignment: Qt.AlignRight
+    placeholderText: currentTime
+    onAccepted: {
+      PlaybackScrubber.OnTimeEntered(textField.text);
+      textField.text = "";
+    }
+    color: Material.theme == Material.Light ? "black" : "white"
+  }
+
+  Text {
+    id: maxTime
+    height: 40
+    width: 30
+    Layout.columnSpan: 1
+    text: qsTr("/   ") + endTime
+    Layout.alignment: Qt.AlignLeft
+    font.pointSize: 11.5
+    color: Material.theme == Material.Light ? "black" : "white"
+  }
+
   // Bottom spacer
   Item {
-    Layout.columnSpan: 3
-    height: 15
+    Layout.columnSpan: 2
+    height: 10
     Layout.fillWidth: true
   }
 }

--- a/tutorials/gui_config.md
+++ b/tutorials/gui_config.md
@@ -13,12 +13,15 @@ There are a few places where the GUI configuration can come from:
 
 1. A file passed to the `--gui-config` command line argument
 2. A `<gui>` element inside an SDF file
-3. The default configuration file at `$HOME/.ignition/gazebo/gui.config`
+3. The default configuration file at `$HOME/.ignition/gazebo/gui.config` \*
 
 Each of the items above takes precedence over the ones below it. For example,
 if a user chooses a `--gui-config`, the SDF's `<gui>` element is ignored. And
 the default configuration file is only loaded if no configuration is passed
 through the command line or the SDF file.
+
+> \* For log-playback, the default file is
+> `$HOME/.ignition/gazebo/playback_gui.config`
 
 ## Try it out
 


### PR DESCRIPTION
Targeted at #299 

* Update default `playback_gui.config` so the scrubber is floating and attached to the scene's center bottom (removed `WorldControl` to give it more room)
* Fix problem with passed `--gui-config`s not being able to access `gui::worldNames()` (overlooked at #278)
* Remove `Rectangle`s from QML that were just wrapping other elements, for simplicity

![scrubber_qml2](https://user-images.githubusercontent.com/5751272/93409890-c2586f80-f84c-11ea-86c2-702d0ca290fa.gif)
