### PR TITLE
Add search and sort for resource spawner

### DIFF
--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -366,9 +366,9 @@ bool compareByDownloaded(const Resource &a, const Resource &b)
 }
 
 /////////////////////////////////////////////////
-void ResourceSpawner::FilterSearch(std::vector<Resource> &_resources)
+void ResourceSpawner::FilterResources(std::vector<Resource> &_resources)
 {
-  if (this->dataPtr->displayData.searchKeyword != "")
+  if (this->dataPtr->displayData.searchKeyword == "")
     return;
 
   std::string searchKeyword = this->dataPtr->displayData.searchKeyword;
@@ -446,8 +446,8 @@ void ResourceSpawner::DisplayResources()
   std::vector<Resource> resources;
   this->Resources(resources);
 
-  // Filter the resource vector with the entered keyword
-  this->FilterSearch(resources);
+  // Filter the resource vector with the entered search keyword
+  this->FilterResources(resources);
 
   // Sort the resources by the provided search method
   this->SortResources(resources);
@@ -564,7 +564,6 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
       {
         models.push_back(iter->Identification());
       }
-      std::string serverUrl = server.Url().Str();
 
       // Create each fuel resource and add them to the ownerModelMap
       for (auto id : models)

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -557,6 +557,9 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
   // Pull in fuel models asynchronously
   std::thread t([this, servers]
   {
+    // A set isn't necessary to keep track of the owners, but it
+    // maintains alphabetical order
+    std::set<std::string> ownerSet;
     for (auto const &server : servers)
     {
       std::vector<ignition::fuel_tools::ModelIdentifier> models;
@@ -586,6 +589,7 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
           std::string thumbnailPath = common::joinPaths(path, "thumbnails");
           this->SetThumbnail(thumbnailPath, resource);
         }
+        ownerSet.insert(id.Owner());
         this->dataPtr->ownerModelMap[id.Owner()].push_back(resource);
       }
     }
@@ -594,9 +598,9 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
     this->dataPtr->ownerModel.clear();
 
     // Add all unique owners to the owner model
-    for (const auto &resource : this->dataPtr->ownerModelMap)
+    for (const auto &resource : ownerSet)
     {
-      this->dataPtr->ownerModel.AddPath(resource.first);
+      this->dataPtr->ownerModel.AddPath(resource);
     }
     ignmsg << "Fuel resources loaded.\n";
   });

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.hh
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.hh
@@ -177,11 +177,25 @@ namespace gazebo
     /// \return The vector of resources
     public: std::vector<Resource> FuelResources(const std::string &_owner);
 
-    public: void FilterSearch(std::vector<Resource> &_resources);
-    public: void SortResources(std::vector<Resource> &_resources);
+    /// \brief Populates the passed in `_resources` vector with the
+    /// currently selected group of resources.
+    /// \param[in,out] _resources The vector of resources to populate
     public: void Resources(std::vector<Resource> &_resources);
 
-    /// \brief Displays the resources to the qml grid.
+    /// \brief Filters the vector of resources by the previously entered
+    /// search keyword.
+    /// \param[in,out] _resources The vector of resources to filter
+    public: void FilterResources(std::vector<Resource> &_resources);
+
+    /// \brief Sorts the vector of resources by the previously entered
+    /// sort method.  The sorting types as a string, are "Most Recent",
+    /// "A - Z", "Z - A", and "Downloaded." The sort defaults to
+    /// "Most Recent."
+    /// \param[in,out] _resources The vector of resources to sort
+    public: void SortResources(std::vector<Resource> &_resources);
+
+    /// \brief Displays the resources to the qml grid abiding by all search
+    /// and sort criteria.
     public slots: void DisplayResources();
 
     /// \brief Callback when a resource path is selected, will clear the
@@ -201,8 +215,15 @@ namespace gazebo
     public slots: void OnDownloadFuelResource(const QString &_path,
         const QString &_name, const QString &_owner, int index);
 
+    /// \brief Callback when a sort request is made.
+    /// \param[in] _sortType The sorting type as a string, accepts
+    /// "Most Recent", "A - Z", "Z - A", and "Downloaded." Defaults to
+    /// "Most Recent."
     public slots: void OnSortChosen(const QString &_sortType);
 
+    /// \brief Callback when a search request is made.
+    /// \param[in] _searchKeyword The search keyword, applies to either the
+    /// resource's name or owner
     public slots: void OnSearchEntered(const QString &_searchKeyword);
 
     /// \brief Finds a thumbnail on the provided thumbnail path and

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.hh
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.hh
@@ -33,8 +33,12 @@ namespace gazebo
   /// \brief Resource used to update the ResourceModel
   struct Resource
   {
-    /// \brief The name of the local model
+    /// \brief The name of the resource.
     std::string name = "";
+
+    /// \brief The owner of the resource, if the resource is local,
+    /// owner will be empty.
+    std::string owner = "";
 
     /// \brief The absolute path to the sdf corresponding to the local model
     std::string sdfPath = "";
@@ -51,6 +55,19 @@ namespace gazebo
     /// always be false with local models as it is irrelevant in this case
     // cppcheck-suppress unusedStructMember
     bool isDownloaded = false;
+  };
+
+  /// \brief Data for a search query
+  struct Display
+  {
+    std::string searchKeyword = "";
+
+    // TODO possibly make enum
+    std::string sortMethod = "";
+
+    std::string ownerPath = "";
+
+    bool isFuel = false;
   };
 
   /// \brief Provides a model by which the resource spawner qml plugin pulls
@@ -85,9 +102,14 @@ namespace gazebo
     /// \brief Destructor
     public: ~ResourceModel() override = default;
 
-    /// \brief Add a local resource to the grid view.
+    /// \brief Add a resource to the grid view.
     /// param[in] _resource The local resource to be added
-    public slots: void AddResource(Resource &_resource);
+    public: void AddResource(Resource &_resource);
+
+    /// TODO update the description
+    /// \brief Add a vector of resources to the grid view.
+    /// param[in] _resource The local resource to be added
+    public: void AddResources(std::vector<Resource> &_resources);
 
     /// \brief Clear the current resource model
     public: void Clear();
@@ -130,24 +152,30 @@ namespace gazebo
     /// \param[in] _sdfPath The absolute path to the resource's sdf file
     public slots: void OnResourceSpawn(const QString &_sdfPath);
 
+    // TODO update
     /// \brief Loads a local model from an absolute path to a model.config,
     /// does nothing if a path not containing model.config is passed in
     /// \param[in] _path The path to search
-    public: void LoadLocalResource(const std::string &_path);
+    public: Resource LocalResource(const std::string &_path);
 
     /// \brief Adds a path to the path list model.
     /// \param[in] _path The path to add
     public: void AddPath(const std::string &_path);
 
+    // TODO update
     /// \brief Recursively searches the provided path for all model.config's
     /// and populates a vector of local models with the information
     /// \param[in] _path The path to search
-    public: void FindLocalResources(const std::string &_path);
+    public: std::vector<Resource> LocalResources(const std::string &_path);
 
+    /// TODO redo the brief
     /// \brief Searches through the previously loaded fuel resources to locate
     /// the models belonging to the passed in owner.
     /// \param[in] _owner The name of the owner
-    public: void FindFuelResources(const std::string &_owner);
+    public: std::vector<Resource> FuelResources(const std::string &_owner);
+
+    // TODO update
+    public slots: void DisplayResources();
 
     /// \brief Callback when a resource path is selected, will clear the
     /// currently loaded resources and load the ones at the specified path

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.hh
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.hh
@@ -165,6 +165,10 @@ namespace gazebo
     /// \param[in] index The index of the grid pane to update
     public slots: void OnDownloadFuelResource(const QString &_path, int index);
 
+    public slots: void OnSortChosen(const QString &_sortType);
+    
+    public slots: void OnSearchEntered(const QString &_searchKeyword);
+
     /// \brief Finds a thumbnail on the provided thumbnail path and
     /// sets the model's thumbnail path attribute to it, no action is
     /// taken if no thumbnail is found.

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.hh
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.hh
@@ -191,7 +191,7 @@ namespace gazebo
     /// \brief Callback when a request is made to download a fuel resource.
     /// \param[in] _path URI to the fuel resource
     /// \param[in] index The index of the grid pane to update
-    public slots: void OnDownloadFuelResource(const QString &_path, int index);
+    public slots: void OnDownloadFuelResource(const QString &_path, const QString &_name, const QString &_owner, int index);
 
     public slots: void OnSortChosen(const QString &_sortType);
     

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.hh
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.hh
@@ -57,16 +57,25 @@ namespace gazebo
     bool isDownloaded = false;
   };
 
-  /// \brief Data for a search query
+  /// \brief Data used by the `DisplayData()` function to filter and sort
+  /// the resources to be displayed.
   struct Display
   {
+    /// \brief The currently entered keyword that the user wants to search,
+    /// empty if there is currently no search query.
     std::string searchKeyword = "";
 
-    // TODO possibly make enum
+    /// \brief The currently chosen method of sorting, which includes "A - Z",
+    /// "Z - A", "Most Recent", and "Downloaded."  The default sort method is
+    /// "Most Recent" as that is the order the fuel models are initially loaded.
     std::string sortMethod = "";
 
+    /// \brief The name of the owner if the user has Fuel resources chosen,
+    /// and the name of the local path if the user has local resources chosen.
     std::string ownerPath = "";
 
+    /// \brief True if the user is currently observing fuel resources and false
+    /// if the user is currently observing local resources.
     bool isFuel = false;
   };
 
@@ -106,9 +115,8 @@ namespace gazebo
     /// param[in] _resource The local resource to be added
     public: void AddResource(Resource &_resource);
 
-    /// TODO update the description
     /// \brief Add a vector of resources to the grid view.
-    /// param[in] _resource The local resource to be added
+    /// param[in] _resource The vector of local resources to be added
     public: void AddResources(std::vector<Resource> &_resources);
 
     /// \brief Clear the current resource model
@@ -124,13 +132,9 @@ namespace gazebo
     // Documentation inherited
     public: QHash<int, QByteArray> roleNames() const override;
 
-    // \brief Index to keep track of the position of each fuel resource,
-    // used primarily to access currently loaded resources for updates
-    public: int fuelGridIndex = 0;
-
-    // \brief Index to keep track of the position of each local resource,
-    // used primarily to access currently loaded resources for updates
-    public: int localGridIndex = 0;
+    // \brief Index to keep track of the position of each resource in the qml
+    // grid, used primarily to access currently loaded resources for updates.
+    public: int gridIndex = 0;
   };
 
   /// \brief Provides interface for communicating to backend for generation
@@ -152,29 +156,32 @@ namespace gazebo
     /// \param[in] _sdfPath The absolute path to the resource's sdf file
     public slots: void OnResourceSpawn(const QString &_sdfPath);
 
-    // TODO update
-    /// \brief Loads a local model from an absolute path to a model.config,
-    /// does nothing if a path not containing model.config is passed in
-    /// \param[in] _path The path to search
+    /// \brief Returns the resource corresponding to the model.config file
+    /// \param[in] _path The path of the model.config file
+    /// \return The local resource
     public: Resource LocalResource(const std::string &_path);
 
     /// \brief Adds a path to the path list model.
     /// \param[in] _path The path to add
     public: void AddPath(const std::string &_path);
 
-    // TODO update
-    /// \brief Recursively searches the provided path for all model.config's
-    /// and populates a vector of local models with the information
+    /// \brief Returns the local resources as a vector located under
+    /// the passed in path.
     /// \param[in] _path The path to search
+    /// \return The vector of resources
     public: std::vector<Resource> LocalResources(const std::string &_path);
 
-    /// TODO redo the brief
-    /// \brief Searches through the previously loaded fuel resources to locate
-    /// the models belonging to the passed in owner.
+    /// \brief Returns the fuel resources as a vector belonging to the
+    /// passed in owner.
     /// \param[in] _owner The name of the owner
+    /// \return The vector of resources
     public: std::vector<Resource> FuelResources(const std::string &_owner);
 
-    // TODO update
+    public: void FilterSearch(std::vector<Resource> &_resources);
+    public: void SortResources(std::vector<Resource> &_resources);
+    public: void Resources(std::vector<Resource> &_resources);
+
+    /// \brief Displays the resources to the qml grid.
     public slots: void DisplayResources();
 
     /// \brief Callback when a resource path is selected, will clear the
@@ -191,10 +198,11 @@ namespace gazebo
     /// \brief Callback when a request is made to download a fuel resource.
     /// \param[in] _path URI to the fuel resource
     /// \param[in] index The index of the grid pane to update
-    public slots: void OnDownloadFuelResource(const QString &_path, const QString &_name, const QString &_owner, int index);
+    public slots: void OnDownloadFuelResource(const QString &_path,
+        const QString &_name, const QString &_owner, int index);
 
     public slots: void OnSortChosen(const QString &_sortType);
-    
+
     public slots: void OnSearchEntered(const QString &_searchKeyword);
 
     /// \brief Finds a thumbnail on the provided thumbnail path and

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -30,7 +30,7 @@ import QtQml.Models 2.2
 Rectangle {
   id: resourceSpawner
   color: Material.background
-  Layout.minimumWidth: 600
+  Layout.minimumWidth: 700
   Layout.minimumHeight: 500
   anchors.fill: parent
 
@@ -320,49 +320,59 @@ Rectangle {
         Layout.minimumHeight: 50
         Layout.fillWidth: true
         RowLayout {
-        id: rowLayout
-        spacing: 20
-        Rectangle {
-          color: "transparent"
-          height: 50
-          Layout.minimumWidth: 100
-          Layout.minimumHeight: 50
-          Layout.preferredWidth: (searchSortBar.width - 80) / 2
-          Layout.leftMargin: 10
-          TextField {
-            id: searchField
-            anchors.fill: parent
-            placeholderText: "Search"
-            leftPadding: 2
-            topPadding: 15
-            color: Material.theme == Material.Light ? "black" : "white"
-            onAccepted: {
-              ResourceSpawner.OnSearchEntered(searchField.text);
-              ResourceSpawner.DisplayResources();
+          id: rowLayout
+          spacing: 7
+          Rectangle {
+            color: "transparent"
+            height: 25
+            width: 25
+            Layout.leftMargin: 15
+            Image {
+              id: searchIcon
+              source: "Search.svg"
+              anchors.verticalCenter: parent.verticalCenter
+            }
+          }
+          Rectangle {
+            color: oddColor
+            height: 35
+            Layout.minimumWidth: 100
+            Layout.minimumHeight: 30
+            Layout.preferredWidth: (searchSortBar.width - 80) / 2
+            TextInput {
+              id: searchField
+              anchors.fill: parent
+              topPadding: 12
+              leftPadding: 5
+              color: Material.theme == Material.Light ? "black" : "white"
+              onTextEdited: {
+                print(searchField.text)
+                ResourceSpawner.OnSearchEntered(searchField.text);
+                ResourceSpawner.DisplayResources();
+              }
+            }
+          }
+          Rectangle {
+            color: "transparent"
+            height: 50
+            Layout.minimumWidth: 140
+            Layout.preferredWidth: (searchSortBar.width - 80) / 2
+            ComboBox {
+              anchors.fill: parent
+              model: ListModel {
+                id: cbItems
+                ListElement { text: "Most Recent"}
+                ListElement { text: "A - Z"}
+                ListElement { text: "Z - A"}
+                ListElement { text: "Downloaded"}
+              }
+              onActivated: {
+                ResourceSpawner.OnSortChosen(cbItems.get(currentIndex).text);
+                ResourceSpawner.DisplayResources();
+              }
             }
           }
         }
-        Rectangle {
-          color: "transparent"
-          height: 50
-          Layout.minimumWidth: 140
-          Layout.preferredWidth: (searchSortBar.width - 80) / 2
-          ComboBox {
-            anchors.fill: parent
-            model: ListModel {
-              id: cbItems
-              ListElement { text: "Most Recent"}
-              ListElement { text: "A - Z"}
-              ListElement { text: "Z - A"}
-              ListElement { text: "Downloaded"}
-            }
-            onActivated: {
-              ResourceSpawner.OnSortChosen(cbItems.get(currentIndex).text);
-              ResourceSpawner.DisplayResources();
-            }
-          }
-        }
-      }
       }
 
       Rectangle {

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -171,6 +171,7 @@ Rectangle {
                 hoverEnabled: true
                 onClicked: {
                   ResourceSpawner.OnPathClicked(model.path);
+                  ResourceSpawner.DisplayResources();
                   currentPath = model.path
                   gridView.currentIndex = -1
                   mouse.accepted = false
@@ -274,6 +275,7 @@ Rectangle {
                 hoverEnabled: true
                 onClicked: {
                   ResourceSpawner.OnOwnerClicked(model.path)
+                  ResourceSpawner.DisplayResources();
                   treeView2.selection.select(styleData.index, ItemSelectionModel.ClearAndSelect)
                   treeView.selection.clearSelection()
                   currentPath = model.path
@@ -314,6 +316,7 @@ Rectangle {
             Layout.minimumWidth: 135
             onAccepted: {
               ResourceSpawner.OnSearchEntered(searchField.text);
+              ResourceSpawner.DisplayResources();
             }
           }
           ComboBox {
@@ -327,6 +330,7 @@ Rectangle {
             }
             onCurrentIndexChanged: {
               ResourceSpawner.OnSortChosen(cbItems.get(currentIndex).text);
+              ResourceSpawner.DisplayResources();
             }
           }
         }
@@ -432,7 +436,7 @@ Rectangle {
                 Label {
                   width: downloadDialog.width - 50
                   height: downloadDialog.height
-                  text: "Please download the model first by clicking the cloud icon."
+                  text: "Please download the resource first by clicking the cloud icon."
                   wrapMode: Text.WordWrap
                 }
               }
@@ -465,8 +469,11 @@ Rectangle {
                 sourceSize.height: 35;
               }
               onClicked: {
-                ResourceSpawner.OnDownloadFuelResource(model.sdf, model.index)
+                // ResourceSpawner.OnDownloadFuelResource(model.sdf, model.index)
                 model.isDownloaded = true
+		print(model.owner)
+		print(model.sdf)
+		print(model.name)
               }
             }
           }

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -339,7 +339,7 @@ Rectangle {
         Layout.fillWidth: true
         Layout.minimumWidth: 300
         height: 40
-        color: "blue"
+        color: "transparent"
         Label {
           text: currentPath
           font.pointSize: 12

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -30,7 +30,7 @@ import QtQml.Models 2.2
 Rectangle {
   id: resourceSpawner
   color: Material.background
-  Layout.minimumWidth: 500
+  Layout.minimumWidth: 600
   Layout.minimumHeight: 500
   anchors.fill: parent
 
@@ -305,7 +305,35 @@ Rectangle {
         Layout.fillWidth: true
         Layout.minimumWidth: 300
         height: 40
-        color: evenColor
+        RowLayout {
+          spacing: 10
+          TextField {
+            id: searchField
+            placeholderText: "Search"
+            color: Material.theme == Material.Light ? "black" : "white"
+            Layout.minimumWidth: 135
+            onAccepted: {
+              print(searchField.text)
+            }
+          }
+          ComboBox {
+            Layout.minimumWidth: 140
+            model: ListModel {
+              id: cbItems
+              ListElement { text: "Most Recent"}
+              ListElement { text: "A - Z"}
+              ListElement { text: "Z - A"}
+              ListElement { text: "Downloaded"}
+            }
+            onCurrentIndexChanged: print(cbItems.get(currentIndex).text)
+          }
+        }
+      }
+      Rectangle {
+        Layout.fillWidth: true
+        Layout.minimumWidth: 300
+        height: 40
+        color: "blue"
         Label {
           text: currentPath
           font.pointSize: 12
@@ -316,6 +344,7 @@ Rectangle {
           anchors.right: parent.right
         }
       }
+      
       Rectangle {
         Layout.fillHeight: true
         Layout.fillWidth: true

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -313,7 +313,7 @@ Rectangle {
             color: Material.theme == Material.Light ? "black" : "white"
             Layout.minimumWidth: 135
             onAccepted: {
-              print(searchField.text)
+              ResourceSpawner.OnSearchEntered(searchField.text);
             }
           }
           ComboBox {
@@ -325,7 +325,9 @@ Rectangle {
               ListElement { text: "Z - A"}
               ListElement { text: "Downloaded"}
             }
-            onCurrentIndexChanged: print(cbItems.get(currentIndex).text)
+            onCurrentIndexChanged: {
+              ResourceSpawner.OnSortChosen(cbItems.get(currentIndex).text);
+            }
           }
         }
       }

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -83,7 +83,7 @@ Rectangle {
     SplitView {
       orientation: Qt.Vertical
       Layout.minimumHeight: 400
-      Layout.minimumWidth: 300
+      Layout.minimumWidth: 315
       anchors.bottom: parent.bottom
       anchors.top: parent.top
       anchors.left: parent.left
@@ -92,12 +92,17 @@ Rectangle {
         id: localColumn
         Layout.minimumHeight: 100
         Layout.fillWidth: true
+        spacing: 0
         Rectangle {
           color: evenColor
+          border.color: "gray"
+          border.width: 1
           Layout.alignment: Qt.AlignLeft
-          Layout.preferredHeight: 20
+          Layout.preferredHeight: 25
           Layout.fillWidth: true
           Label {
+            topPadding: 2
+            leftPadding: 5
             text: "Local resources"
             anchors.fill: parent
             font.pointSize: 12
@@ -197,13 +202,17 @@ Rectangle {
       ColumnLayout {
         id: fuelColumn
         Layout.minimumHeight: 100
+        spacing: 0
         Rectangle {
           color: evenColor
+          border.color: "gray"
           Layout.alignment: Qt.AlignLeft
-          Layout.preferredHeight: 20
+          Layout.preferredHeight: 25
           Layout.fillWidth: true
           Label {
             text: "Fuel resources"
+            topPadding: 2
+            leftPadding: 5
             anchors.fill: parent
             font.pointSize: 12
           }
@@ -304,23 +313,42 @@ Rectangle {
       Layout.fillWidth: true
       spacing: 0
       Rectangle {
+        id: searchSortBar
+        color: evenColor
+        height: 50
+        Layout.minimumWidth: 290
+        Layout.minimumHeight: 50
         Layout.fillWidth: true
-        Layout.minimumWidth: 300
-        height: 40
         RowLayout {
-          spacing: 10
+        id: rowLayout
+        spacing: 20
+        Rectangle {
+          color: "transparent"
+          height: 50
+          Layout.minimumWidth: 100
+          Layout.minimumHeight: 50
+          Layout.preferredWidth: (searchSortBar.width - 80) / 2
+          Layout.leftMargin: 10
           TextField {
             id: searchField
+            anchors.fill: parent
             placeholderText: "Search"
+            leftPadding: 2
+            topPadding: 15
             color: Material.theme == Material.Light ? "black" : "white"
-            Layout.minimumWidth: 135
             onAccepted: {
               ResourceSpawner.OnSearchEntered(searchField.text);
               ResourceSpawner.DisplayResources();
             }
           }
+        }
+        Rectangle {
+          color: "transparent"
+          height: 50
+          Layout.minimumWidth: 140
+          Layout.preferredWidth: (searchSortBar.width - 80) / 2
           ComboBox {
-            Layout.minimumWidth: 140
+            anchors.fill: parent
             model: ListModel {
               id: cbItems
               ListElement { text: "Most Recent"}
@@ -335,6 +363,8 @@ Rectangle {
           }
         }
       }
+      }
+
       Rectangle {
         Layout.fillWidth: true
         Layout.minimumWidth: 300
@@ -350,7 +380,7 @@ Rectangle {
           anchors.right: parent.right
         }
       }
-      
+
       Rectangle {
         Layout.fillHeight: true
         Layout.fillWidth: true
@@ -397,9 +427,9 @@ Rectangle {
                 Layout.fillWidth: true
                 Layout.margins: 1
                 source: (model.isFuel && !model.isDownloaded) ?
-                        "DownloadToUse.png" :
-                        (model.thumbnail == "" ?
-                        "NoThumbnail.png" : "file:" + model.thumbnail)
+                "DownloadToUse.png" :
+                (model.thumbnail == "" ?
+                "NoThumbnail.png" : "file:" + model.thumbnail)
                 fillMode: Image.PreserveAspectFit
               }
             }

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -30,7 +30,7 @@ import QtQml.Models 2.2
 Rectangle {
   id: resourceSpawner
   color: Material.background
-  Layout.minimumWidth: 700
+  Layout.minimumWidth: 730
   Layout.minimumHeight: 500
   anchors.fill: parent
 
@@ -342,11 +342,10 @@ Rectangle {
             TextInput {
               id: searchField
               anchors.fill: parent
-              topPadding: 12
+              topPadding: 8
               leftPadding: 5
               color: Material.theme == Material.Light ? "black" : "white"
               onTextEdited: {
-                print(searchField.text)
                 ResourceSpawner.OnSearchEntered(searchField.text);
                 ResourceSpawner.DisplayResources();
               }

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -328,7 +328,7 @@ Rectangle {
               ListElement { text: "Z - A"}
               ListElement { text: "Downloaded"}
             }
-            onCurrentIndexChanged: {
+            onActivated: {
               ResourceSpawner.OnSortChosen(cbItems.get(currentIndex).text);
               ResourceSpawner.DisplayResources();
             }
@@ -469,11 +469,8 @@ Rectangle {
                 sourceSize.height: 35;
               }
               onClicked: {
-                // ResourceSpawner.OnDownloadFuelResource(model.sdf, model.index)
+                ResourceSpawner.OnDownloadFuelResource(model.sdf, model.name, model.owner, model.index)
                 model.isDownloaded = true
-		print(model.owner)
-		print(model.sdf)
-		print(model.name)
               }
             }
           }

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -30,7 +30,7 @@ import QtQml.Models 2.2
 Rectangle {
   id: resourceSpawner
   color: Material.background
-  Layout.minimumWidth: 730
+  Layout.minimumWidth: 740
   Layout.minimumHeight: 500
   anchors.fill: parent
 

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qrc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qrc
@@ -6,5 +6,6 @@
   <file>folder_open.png</file>
   <file>NoThumbnail.png</file>
   <file>ResourceSpawner.qml</file>
+  <file>Search.svg</file>
 </qresource>
 </RCC>

--- a/src/gui/plugins/resource_spawner/Search.svg
+++ b/src/gui/plugins/resource_spawner/Search.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   fill="#000000"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="search.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <path
+       d="M0 0h24v24H0V0z"
+       id="a" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1548"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="1280"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <path
+     d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+     id="path4"
+     style="fill:#4d4d4d;fill-opacity:0.9544993" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path6" />
+</svg>


### PR DESCRIPTION
Closes #341 

This PR most of all implements a Search textfield as well as a Sort By Combo Box.  It also introduces some optimizations in loading the models (stores all resources by owner at initialization, previously only the owner data was being gathered and another search for the models was done when the user clicked on each owner). Some slight formatting was changed with the QML as I thought some of it looked a little wonky, I'm still open for suggestions on the QML.

The search bar will search (case insensitive) all the names and owners of all the resources with your submitted keyword, similar to how Fuel's website does.  I also added a sort by Most Recent, A - Z, Z - A, and Downloaded.  The sort and search work together to display the subset of the two. 

Are there any more similar organization features or sorting methods that would be desired while we're here?

Here's a small example:

![searchandsort](https://user-images.githubusercontent.com/8881852/93826190-9443a880-fc1b-11ea-91fe-c2ce63f71e8f.gif)
