### PR TITLE
Fix Qt5 warnings for using anchors

### DIFF
--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -134,7 +134,7 @@ Rectangle {
           sourceSize.height: indentation
           sourceSize.width: indentation
           fillMode: Image.Pad
-          anchors.verticalCenter: parent.verticalCenter
+          Layout.alignment : Qt.AlignVCenter
           source: content.show ?
               "qrc:/Gazebo/images/minus.png" : "qrc:/Gazebo/images/plus.png"
         }

--- a/src/gui/plugins/component_inspector/Vector3d.qml
+++ b/src/gui/plugins/component_inspector/Vector3d.qml
@@ -95,7 +95,7 @@ Rectangle {
           sourceSize.height: indentation
           sourceSize.width: indentation
           fillMode: Image.Pad
-          anchors.verticalCenter: parent.verticalCenter
+          Layout.alignment : Qt.AlignVCenter
           source: content.show ?
               "qrc:/Gazebo/images/minus.png" : "qrc:/Gazebo/images/plus.png"
         }


### PR DESCRIPTION
I have been getting a lot of warnings being print out by Qt5 with the Component Inspector GUI plugin when clicking on models, specifically two warnings repeated many times:

```
[ign-8] [GUI] [Wrn] [Application.cc:649] [QT] file::/ComponentInspector/Pose3d.qml:132:9: QML Image: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
[ign-8] [GUI] [Wrn] [Application.cc:649] [QT] file::/ComponentInspector/Vector3d.qml:93:9: QML Image: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
```

This is way out of my comfort zone but by looking around I found [some examples](https://stackoverflow.com/questions/55566536/qml-rectangle-detected-anchors-on-an-item-that-is-managed-by-a-layout-this-is) using [Layout.alignment](https://doc.qt.io/qt-5/qml-qtquick-layouts-layout.html#alignment-attached-prop) instead of anchors so went ahead to change the objects and the warnings disappeared.
As a sanity check this is what component inspector looks like with the changes:

![image](https://user-images.githubusercontent.com/9111558/93865361-c37c1780-fcf8-11ea-8b10-0b6db078e0eb.png)

There is a similar warning being caused by [this line](https://github.com/ignitionrobotics/ign-gui/blob/master/src/plugins/world_control/WorldControl.qml#L93) in the world-control plugin:

```
[ign-8] [GUI] [Wrn] [Application.cc:649] [QT] file::/WorldControl/WorldControl.qml:88:3: QML RoundButton: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
```

If this fix is approved I'll open a PR to fix that warning as well.