### PR TITLE
Fix gui sendEvent memory leaks

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -384,12 +384,12 @@ sdf::Actor ignition::gazebo::convert(const msgs::Actor &_in)
   for (int i = 0; i < _in.animations_size(); ++i)
   {
     const auto &anim = _in.animations(i);
-    auto newAnim = new sdf::Animation();
-    newAnim->SetName(anim.name());
-    newAnim->SetFilename(anim.filename());
-    newAnim->SetScale(anim.scale());
-    newAnim->SetInterpolateX(anim.interpolate_x());
-    out.AddAnimation(*newAnim);
+    sdf::Animation newAnim;
+    newAnim.SetName(anim.name());
+    newAnim.SetFilename(anim.filename());
+    newAnim.SetScale(anim.scale());
+    newAnim.SetInterpolateX(anim.interpolate_x());
+    out.AddAnimation(newAnim);
   }
   out.SetScriptLoop(_in.script_loop());
   out.SetScriptDelayStart(_in.script_delay_start());
@@ -397,19 +397,19 @@ sdf::Actor ignition::gazebo::convert(const msgs::Actor &_in)
   for (int i = 0; i < _in.trajectories_size(); ++i)
   {
     const auto &traj = _in.trajectories(i);
-    auto newTraj = new sdf::Trajectory();
-    newTraj->SetId(traj.id());
-    newTraj->SetType(traj.type());
-    newTraj->SetTension(traj.tension());
+    sdf::Trajectory newTraj;
+    newTraj.SetId(traj.id());
+    newTraj.SetType(traj.type());
+    newTraj.SetTension(traj.tension());
     for (int j = 0; j < traj.waypoints_size(); ++j)
     {
       const auto &point = traj.waypoints(j);
-      auto newPoint = new sdf::Waypoint();
-      newPoint->SetTime(point.time());
-      newPoint->SetPose(msgs::Convert(point.pose()));
-      newTraj->AddWaypoint(*newPoint);
+      sdf::Waypoint newPoint;
+      newPoint.SetTime(point.time());
+      newPoint.SetPose(msgs::Convert(point.pose()));
+      newTraj.AddWaypoint(newPoint);
     }
-    out.AddTrajectory(*newTraj);
+    out.AddTrajectory(newTraj);
   }
   return out;
 }

--- a/src/gui/plugins/align_tool/AlignTool.cc
+++ b/src/gui/plugins/align_tool/AlignTool.cc
@@ -88,10 +88,10 @@ AlignTool::AlignTool()
   : GuiSystem(), dataPtr(std::make_unique<AlignToolPrivate>())
 {
   // Deselect all entities upon loading plugin
-  auto deselectEvent = new gui::events::DeselectAllEntities(true);
+  gui::events::DeselectAllEntities deselectEvent(true);
   ignition::gui::App()->sendEvent(
       ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-      deselectEvent);
+      &deselectEvent);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -350,19 +350,19 @@ void EntityTree::Update(const UpdateInfo &, EntityComponentManager &_ecm)
 void EntityTree::OnEntitySelectedFromQml(unsigned int _entity)
 {
   std::vector<Entity> entitySet {_entity};
-  auto event = new gui::events::EntitiesSelected(entitySet, true);
+  gui::events::EntitiesSelected event(entitySet, true);
   ignition::gui::App()->sendEvent(
       ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-      event);
+      &event);
 }
 
 /////////////////////////////////////////////////
 void EntityTree::DeselectAllEntities()
 {
-  auto event = new gui::events::DeselectAllEntities(true);
+  gui::events::DeselectAllEntities event(true);
   ignition::gui::App()->sendEvent(
       ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-      event);
+      &event);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -472,10 +472,10 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
 /////////////////////////////////////////////////
 void ResourceSpawner::OnResourceSpawn(const QString &_sdfPath)
 {
-  auto event = new gui::events::SpawnPreviewPath(_sdfPath.toStdString());
+  gui::events::SpawnPreviewPath event(_sdfPath.toStdString());
   ignition::gui::App()->sendEvent(
       ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-      event);
+      &event);
 }
 
 // Register this plugin

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -667,9 +667,10 @@ void IgnRenderer::Render()
 
   if (ignition::gui::App())
   {
+    gui::events::Render event;
     ignition::gui::App()->sendEvent(
         ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-        new gui::events::Render());
+        &event);
   }
 }
 
@@ -1012,10 +1013,10 @@ void IgnRenderer::DeselectAllEntities(bool _sendEvent)
 
   if (_sendEvent)
   {
-    auto deselectEvent = new gui::events::DeselectAllEntities();
+    gui::events::DeselectAllEntities deselectEvent;
     ignition::gui::App()->sendEvent(
         ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-        deselectEvent);
+        &deselectEvent);
   }
 }
 
@@ -1596,11 +1597,11 @@ void IgnRenderer::UpdateSelectedEntity(const rendering::NodePtr &_node,
   // Notify other widgets of the currently selected entities
   if (_sendEvent || deselectedAll)
   {
-    auto selectEvent = new gui::events::EntitiesSelected(
+    gui::events::EntitiesSelected selectEvent(
         this->dataPtr->renderUtil.SelectedEntities());
     ignition::gui::App()->sendEvent(
         ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-        selectEvent);
+        &selectEvent);
   }
 }
 

--- a/src/gui/plugins/shapes/Shapes.cc
+++ b/src/gui/plugins/shapes/Shapes.cc
@@ -196,10 +196,10 @@ void Shapes::OnMode(const QString &_mode)
     return;
   }
 
-  auto event = new gui::events::SpawnPreviewModel(modelSdfString);
+  gui::events::SpawnPreviewModel event(modelSdfString);
   ignition::gui::App()->sendEvent(
       ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-      event);
+      &event);
 }
 
 // Register this plugin

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -105,12 +105,12 @@ void TransformControl::OnSnapUpdate(
   this->dataPtr->rpySnapVals = math::Vector3d(_roll, _pitch, _yaw);
   this->dataPtr->scaleSnapVals = math::Vector3d(_scaleX, _scaleY, _scaleZ);
 
-  auto event = new gui::events::SnapIntervals(
+  gui::events::SnapIntervals event(
       this->dataPtr->xyzSnapVals,
       this->dataPtr->rpySnapVals,
       this->dataPtr->scaleSnapVals);
   ignition::gui::App()->sendEvent(
-      ignition::gui::App()->findChild<ignition::gui::MainWindow *>(), event);
+      ignition::gui::App()->findChild<ignition::gui::MainWindow *>(), &event);
 
   this->newSnapValues();
 }


### PR DESCRIPTION
The leaks mainly come from `sendEvent` calls. According to Qt's [API documentation](https://doc.qt.io/qt-5/qcoreapplication.html#sendEvent), the events are not deleted and so should be created on the stack

With the animation memory fix in ignitionrobotics/ign-common#98, I see fixed memory usage over time when running the `actors_population.sdf` world.

![ign-gazebo-gui-mem-usage](https://user-images.githubusercontent.com/4000684/93971170-68601a00-fd24-11ea-88b5-ee6e37022cb2.png)


Signed-off-by: Ian Chen <ichen@osrfoundation.org>