### PR TITLE
Decrease time step for quadcopter world

### DIFF
--- a/examples/worlds/quadcopter.sdf
+++ b/examples/worlds/quadcopter.sdf
@@ -13,7 +13,7 @@
 -->
 <sdf version="1.6">
   <world name="quadcopter">
-    <physics name="4ms" type="ignored">
+    <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>

--- a/examples/worlds/quadcopter.sdf
+++ b/examples/worlds/quadcopter.sdf
@@ -14,7 +14,7 @@
 <sdf version="1.6">
   <world name="quadcopter">
     <physics name="4ms" type="ignored">
-      <max_step_size>0.004</max_step_size>
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin


### PR DESCRIPTION
With the current time step, the quad penetrates the ground if turned off from very high:

![quad_ground](https://user-images.githubusercontent.com/5751272/94190624-34d6da00-fe61-11ea-90eb-29a3feb4d461.gif)

I think users trying out this world may run into this often, so I think it's good to have a good default behaviour. This change doesn't prevent the demo from running at 100% RTF on my machine.