### PR TITLE
Fix adding performers to entity tree

### DIFF
--- a/src/gui/plugins/entity_tree/EntityTree.hh
+++ b/src/gui/plugins/entity_tree/EntityTree.hh
@@ -75,6 +75,26 @@ namespace gazebo
 
     /// \brief Keep track of which item corresponds to which entity.
     private: std::map<Entity, QStandardItem *> entityItems;
+
+    /// \brief Entity information used to queue the pending entities
+    struct EntityInfo
+    {
+      /// \brief Entity ID
+      unsigned int entity;
+
+      /// \brief Entity name
+      QString name;
+
+      /// \brief Parent ID
+      unsigned int parentEntity;
+
+      /// \brief Entity type
+      QString type;
+    };
+
+    /// \brief If an entity is added before its parent, we queue it in this
+    /// vector until their parent shows up or they are deleted.
+    private: std::vector<EntityInfo> pendingEntities;
   };
 
   /// \brief Displays a tree view with all the entities in the world.

--- a/src/gui/plugins/entity_tree/EntityTree.hh
+++ b/src/gui/plugins/entity_tree/EntityTree.hh
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include <ignition/gazebo/gui/GuiSystem.hh>
 


### PR DESCRIPTION
When running `ign gazebo levels.sdf`, we see these errors, and the performers are never added to the entity tree:

```
[GUI] [Err] [EntityTree.cc:128] Failed to find parent entity [6]                                                                      
[GUI] [Err] [EntityTree.cc:128] Failed to find parent entity [22]
```

Similar errors can be seen whenever a world with a performer is loaded.

This happens because the performer entities come up before their parent models.

This PR puts such entities in a queue so they're processed later once their parents show up.