### PR TITLE
Add instructions to bitmask world

### DIFF
--- a/examples/worlds/shapes_bitmask.sdf
+++ b/examples/worlds/shapes_bitmask.sdf
@@ -1,4 +1,15 @@
 <?xml version="1.0" ?>
+<!--
+  Demonstrates the use of collide bitmasks.
+
+  The world has 3 boxes with the following bitmasks:
+  * redBox: 0x01 (01)
+  * greenBox: 0x02 (10)
+  * yellowBox: 0x03 (11)
+
+  Which means that green and red can't collide with each other, but they both
+  collide with yellow. Move them around to see it working!
+-->
 <sdf version="1.6">
   <world name="shapes_bitmask">
     <physics name="1ms" type="ignored">
@@ -22,87 +33,6 @@
       <ambient>1.0 1.0 1.0</ambient>
       <background>0.8 0.8 0.8</background>
     </scene>
-
-    <gui fullscreen="0">
-
-      <!-- 3D scene -->
-      <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
-          <title>3D View</title>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="string" key="state">docked</property>
-        </ignition-gui>
-
-        <engine>ogre2</engine>
-        <scene>scene</scene>
-        <ambient_light>1.0 1.0 1.0</ambient_light>
-        <background_color>0.8 0.8 0.8</background_color>
-        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
-      </plugin>
-
-      <!-- World control -->
-      <plugin filename="WorldControl" name="World control">
-        <ignition-gui>
-          <title>World control</title>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="bool" key="resizable">false</property>
-          <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
-          <property type="double" key="z">1</property>
-
-          <property type="string" key="state">floating</property>
-          <anchors target="3D View">
-            <line own="left" target="left"/>
-            <line own="bottom" target="bottom"/>
-          </anchors>
-        </ignition-gui>
-
-        <play_pause>true</play_pause>
-        <step>true</step>
-        <start_paused>true</start_paused>
-        <service>/world/shapes_bitmask/control</service>
-        <stats_topic>/world/shapes_bitmask/stats</stats_topic>
-
-      </plugin>
-
-      <!-- World statistics -->
-      <plugin filename="WorldStats" name="World stats">
-        <ignition-gui>
-          <title>World stats</title>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="bool" key="resizable">false</property>
-          <property type="double" key="height">110</property>
-          <property type="double" key="width">290</property>
-          <property type="double" key="z">1</property>
-
-          <property type="string" key="state">floating</property>
-          <anchors target="3D View">
-            <line own="right" target="right"/>
-            <line own="bottom" target="bottom"/>
-          </anchors>
-        </ignition-gui>
-
-        <sim_time>true</sim_time>
-        <real_time>true</real_time>
-        <real_time_factor>true</real_time_factor>
-        <iterations>true</iterations>
-        <topic>/world/shapes_bitmask/stats</topic>
-
-      </plugin>
-
-      <!-- Entity tree -->
-      <plugin filename="EntityTree" name="Entity tree">
-        <ignition-gui>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="string" key="state">docked</property>
-        </ignition-gui>
-      </plugin>
-
-      <!-- Transform Control -->
-      <plugin filename="TransformControl" name="Transform Control">
-      </plugin>
-
-    </gui>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -144,7 +74,7 @@
       </link>
     </model>
 
-    <model name="boxA">
+    <model name="redBox">
       <pose>0 0 1.0 0 0 0</pose>
       <link name="link">
         <inertial>
@@ -185,7 +115,7 @@
       </link>
     </model>
 
-    <model name="boxB">
+    <model name="greenBox">
       <pose>0 0 3.0 0 0 0</pose>
       <link name="link">
         <inertial>
@@ -226,7 +156,7 @@
       </link>
     </model>
 
-    <model name="boxC">
+    <model name="yellowBox">
       <pose>0 0 6.0 0 0 0</pose>
       <link name="link">
         <inertial>


### PR DESCRIPTION
All example worlds should have some instructions so the user knows what the world is trying to demonstrate.

I also removed the `<gui>` tag because the default GUI fits this world well.