### PR TITLE
Fix top-left toolbar layout so magnet shows

### DIFF
--- a/src/gui/gui.config
+++ b/src/gui/gui.config
@@ -112,7 +112,7 @@
       <line own="top" target="top"/>
     </anchors>
     <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">200</property>
+    <property key="width" type="double">250</property>
     <property key="height" type="double">50</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>


### PR DESCRIPTION
The plugin was too small to show it :scream: 

Before:

![nognet](https://user-images.githubusercontent.com/5751272/94327576-ce38e580-ff60-11ea-823e-f69108431a71.png)


After:

![magnet](https://user-images.githubusercontent.com/5751272/94327561-bcefd900-ff60-11ea-8aaf-eeca838b5a09.png)



> I had to change the size of `Shapes` for `TransformControl` to grow. See https://github.com/ignitionrobotics/ign-gui/issues/129