### PR TITLE
Remove sidebar and put world control in bottom left

### DIFF
--- a/examples/worlds/joint_controller.sdf
+++ b/examples/worlds/joint_controller.sdf
@@ -26,18 +26,12 @@
     </plugin>
 
     <gui fullscreen="0">
-
       <!-- 3D scene -->
       <plugin filename="GzScene3D" name="3D View">
         <ignition-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
-          <property type="bool" key="resizable">false</property>
-          <property type="double" key="z">0</property>
-          <anchor line="right" target="window" target_line="right"/>
-          <anchor line="left" target="window" target_line="left"/>
-          <anchor line="top" target="window" target_line="top"/>
-          <anchor line="bottom" target="window" target_line="bottom"/>
+          <property type="string" key="state">docked</property>
         </ignition-gui>
 
         <engine>ogre</engine>
@@ -56,16 +50,19 @@
           <property type="double" key="height">72</property>
           <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
-          <anchor line="left" target="window" target_line="left"/>
-          <anchor line="bottom" target="window" target_line="bottom"/>
-        </ignition-gui>
 
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
         <play_pause>true</play_pause>
         <step>true</step>
         <start_paused>true</start_paused>
-
       </plugin>
     </gui>
+
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
       <pose>0 0 10 0 0 0</pose>

--- a/examples/worlds/joint_position_controller.sdf
+++ b/examples/worlds/joint_position_controller.sdf
@@ -26,12 +26,7 @@
         <ignition-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
-          <property type="bool" key="resizable">false</property>
-          <property type="double" key="z">0</property>
-          <anchor line="right" target="window" target_line="right"/>
-          <anchor line="left" target="window" target_line="left"/>
-          <anchor line="top" target="window" target_line="top"/>
-          <anchor line="bottom" target="window" target_line="bottom"/>
+          <property type="string" key="state">docked</property>
         </ignition-gui>
 
         <engine>ogre</engine>
@@ -50,8 +45,12 @@
           <property type="double" key="height">72</property>
           <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
-          <anchor line="left" target="window" target_line="left"/>
-          <anchor line="bottom" target="window" target_line="bottom"/>
+          
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
         </ignition-gui>
 
         <play_pause>true</play_pause>


### PR DESCRIPTION
I just thought it was slightly weird how all of the other tutorials are in this format and this one had the world control in the side bar, so I just updated it to be like the others.

Signed-off-by: John Shepherd <john@openrobotics.org>