### PR TITLE
docker: update Dockerfiles to use focal images

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 RUN apt-get update \
  && apt-get install -y \

--- a/docker/Dockerfile.ignition
+++ b/docker/Dockerfile.ignition
@@ -3,8 +3,8 @@
 #   This docker file is used by build.bash and run.bash to build and run
 #   an Ignition distribution based on binaries. See the README.md file.
 
-# Ubuntu 18.04 with nvidia-docker2 beta opengl support
-FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+# Ubuntu 20.04 with nvidia opengl support
+FROM nvidia/opengl:1.2-glvnd-devel-ubuntu20.04
 
 # Name of the Ignition distribution
 ARG ign_distribution

--- a/docker/README.md
+++ b/docker/README.md
@@ -154,7 +154,7 @@ Docker has two available versions: Community Edition (CE) and Enterprise Edition
 
 1. Verify the installation:
 
-        docker run --runtime=nvidia --rm nvidia/cuda nvidia-smi
+        docker run --gpus all --rm nvidia/cuda nvidia-smi
 
     This command should print your GPU information, for example:
 

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -40,7 +40,7 @@ docker run -it \
   -v "/etc/localtime:/etc/localtime:ro" \
   -v "/dev/input:/dev/input" \
   --rm \
-  --runtime=nvidia \
+  --gpus all \
   --security-opt seccomp=unconfined \
   $IMG \
   ${@:2}


### PR DESCRIPTION
To close #382 

  * use focal base images instead of bionic, including using newer version of libglvnd
  * runtime=nvidia is deprecated, gpus=all has replaced it in newer
  versions of docker

This has not been built or tested by me.