### PR TITLE
Docker development setup for ign-gazebo3

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,0 +1,59 @@
+# Ubuntu 18.04 with nvidia-docker2 beta opengl support
+FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+
+# install third-party packages for things like developemnt
+RUN apt-get -qq update && apt-get -y install \
+    git \
+    gnupg \
+    g++-8 \
+    lsb-release \
+    sudo \
+    vim \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+# set up repositories
+RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+  && sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list' \
+  && wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+
+# install dependencies
+COPY packages.apt .
+COPY packages-bionic.apt .
+RUN apt-get -qq update && apt-get -y install \
+    $(sort -u $(find . -iname 'packages-bionic.apt' -o -iname 'packages.apt') | tr '\n' ' ') \
+  && rm -rf /var/lib/apt/lists/*
+
+# enable colcon for building packages (time zone needs to be enabled)
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list' \
+  && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN echo 'Etc/UTC' > /etc/timezone && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
+  && apt-get -qq update && apt-get -y install \
+    python3-colcon-common-extensions \
+  && rm -rf /var/lib/apt/lists/*
+
+# configure gcc8
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+
+# create a non-root user
+# uses same user_id as user outside the container
+# requires docker build argument user_id
+ARG user_id
+ENV USERNAME developer
+RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
+ && echo "$USERNAME:$USERNAME" | chpasswd \
+ && adduser $USERNAME sudo \
+ && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
+
+# commands below run as the developer user
+USER $USERNAME
+
+# create a colcon workspace that can build ign-gazebo from source
+# (the ign-gazebo source code will be loaded into the src directory of this workspace)
+RUN mkdir -p ~/ws/src
+
+# start the container where the workspace is
+WORKDIR /home/$USERNAME/ws
+
+# start a bash shell by default
+CMD [ "/bin/bash" ]

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -8,13 +8,11 @@ RUN apt-get -qq update && apt-get -y install \
     g++-8 \
     lsb-release \
     sudo \
-    vim \
     wget \
   && rm -rf /var/lib/apt/lists/*
 
 # set up repositories
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
-  && sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list' \
   && wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 
 # install dependencies

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -2,7 +2,7 @@
 FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
 
 # install third-party packages for things like developemnt
-RUN apt-get -qq update && apt-get -y install \
+RUN apt-get -qq update && apt-get --no-install-recommends -y install \
     git \
     gnupg \
     g++-8 \
@@ -18,7 +18,7 @@ RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb
 # install dependencies
 COPY packages.apt .
 COPY packages-bionic.apt .
-RUN apt-get -qq update && apt-get -y install \
+RUN apt-get -qq update && apt-get --no-install-recommends -y install \
     $(sort -u $(find . -iname 'packages-bionic.apt' -o -iname 'packages.apt') | tr '\n' ' ') \
   && rm -rf /var/lib/apt/lists/*
 
@@ -26,7 +26,7 @@ RUN apt-get -qq update && apt-get -y install \
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list' \
   && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 RUN echo 'Etc/UTC' > /etc/timezone && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
-  && apt-get -qq update && apt-get -y install \
+  && apt-get -qq update && apt-get --no-install-recommends -y install \
     python3-colcon-common-extensions \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -1,0 +1,73 @@
+# Docker for Ignition Gazebo Development
+
+This directory contains files that allow users to use/develop/test source builds of [ign-gazebo](https://github.com/ignitionrobotics/ign-gazebo) inside of a Docker container.
+
+There are three files in this directory:
+* [`Dockerfile`](./Dockerfile): The Dockerfile that defines the image, which includes all of the `ign-gazebo` dependencies and build tools like [colcon](https://colcon.readthedocs.io/en/released/#).
+* [`build.bash`](./build.bash): A bash script that builds the Docker image.
+* [`run.bash`](./run.bash): A bash script that starts a Docker container, loading a user's copy of the `ign-gazebo` repository into the container at run time as a [volume](https://docs.docker.com/storage/volumes/).
+
+## Requirements
+
+* Docker (installation instructions for Ubuntu can be found [here](https://docs.docker.com/engine/install/ubuntu/))
+* [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker)
+* A computer with an Nvidia graphics card
+
+## Usage
+
+1. Clone the `ign-gazebo` repository (in this example, we are cloning the repository to the `$HOME` directory, but you can clone it to another location if you'd like):
+
+```
+cd ~/
+git clone https://github.com/ignitionrobotics/ign-gazebo.git
+```
+
+2. Switch to the `docker/development` directory:
+
+```
+cd ign-gazebo/docker/development/
+```
+
+3. Build the Docker image with the `build.bash` script.
+This script requires an image name and path to the [repository's `packages*.apt` files](https://github.com/ignitionrobotics/ign-gazebo/tree/main/.github/ci) as arguments (`packages*.apt` contains the `ign-gazebo3` dependencies).
+The following command would create a Docker image named `gazebo3_devel`:
+
+```
+./build.bash gazebo3_devel ~/ign-gazebo/.github/ci/
+```
+
+4. Execute `run.bash` to start a container with graphics capabilities that also has the `ign-gazebo3` repository loaded as a volume.
+The two parameters needed for this step are the name of the image (from the previous step) and the path to the `ign-gazebo3` repository.
+If you went through steps 1-3 as shown above, run the following command:
+
+```
+./run.bash gazebo3_devel ~/ign-gazebo/
+```
+
+5. Once in the container, you can build `ign-gazebo3` with `colcon` (the container will start you in the root of the `ign-gazebo3` workspace by default):
+
+```
+colcon build
+```
+
+6. Source the workspace and start gazebo to verify that everything is working properly (if the `ign gazebo` command below doesn't work for you, try the fix in step 7):
+
+```
+. install/setup.bash
+ign gazebo
+```
+
+7. If running `ign gazebo` in step 6 didn't work, you may need to manually specify where gazebo has been installed
+(more information about this issue can be found [here](../../README.md#known-issue-of-command-line-tools)):
+
+```
+export IGN_CONFIG_PATH=~/ws/install/ignition-gazebo3/share/ignition
+ign gazebo
+```
+
+That's it! 
+You can now use your cloned repository of `ign-gazebo` to test or develop new features.
+
+Since the repository was loaded into the container as a volume, you can make changes to the source code on your machine locally with your preferred development tools, and these changes will automatically be reflected inside of the Docker container.
+Another nice thing about loading the repository as a volume is that any changes you make to the repository will persist after the container is shut down.
+This allows for easy development and testing with Docker without having to set up development tools inside of Docker.

--- a/docker/development/build.bash
+++ b/docker/development/build.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: $0 image-name path-to-packages.apt"
+  exit 1
+fi
+
+# build context needs to be the path to the repo's .github/ci/ directory
+docker build -t $1 --build-arg user_id=$(id -u) -f ./Dockerfile $2

--- a/docker/development/run.bash
+++ b/docker/development/run.bash
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: $0 image-name path-to-repo"
+  exit 1
+fi
+
+# Make sure processes in the container can connect to the x server
+# Necessary so gazebo can create a context for OpenGL rendering (even headless)
+XAUTH=/tmp/.docker.xauth
+if [ ! -f $XAUTH ]
+then
+    xauth_list=$(xauth nlist $DISPLAY)
+    xauth_list=$(sed -e 's/^..../ffff/' <<< "$xauth_list")
+    if [ ! -z "$xauth_list" ]
+    then
+        echo "$xauth_list" | xauth -f $XAUTH nmerge -
+    else
+        touch $XAUTH
+    fi
+    chmod a+r $XAUTH
+fi
+
+DOCKER_OPTS=
+
+# Get the current version of docker-ce
+# Strip leading stuff before the version number so it can be compared
+DOCKER_VER=$(dpkg-query -f='${Version}' --show docker-ce | sed 's/[0-9]://')
+if dpkg --compare-versions 19.03 gt "$DOCKER_VER"
+then
+    echo "Docker version is less than 19.03, using nvidia-docker2 runtime"
+    if ! dpkg --list | grep nvidia-docker2
+    then
+        echo "Please either update docker-ce to a version greater than 19.03 or install nvidia-docker2"
+	exit 1
+    fi
+    DOCKER_OPTS="$DOCKER_OPTS --runtime=nvidia"
+else
+    DOCKER_OPTS="$DOCKER_OPTS --gpus all"
+fi
+
+# Prevent executing "docker run" when xauth failed.
+if [ ! -f $XAUTH ]
+then
+  echo "[$XAUTH] was not properly created. Exiting..."
+  exit 1
+fi
+
+docker run -it --rm \
+  -e DISPLAY \
+  -e QT_X11_NO_MITSHM=1 \
+  -e XAUTHORITY=$XAUTH \
+  -v "$XAUTH:$XAUTH" \
+  -v "/tmp/.X11-unix:/tmp/.X11-unix" \
+  -v "/etc/localtime:/etc/localtime:ro" \
+  -v "/dev/input:/dev/input" \
+  -v "$2:/home/developer/ws/src/" \
+  --rm \
+  --security-opt seccomp=unconfined \
+  $DOCKER_OPTS \
+  $1


### PR DESCRIPTION
Here's a proposal to add a Docker setup that would allow for easier development of `ign-gazebo3`. The idea is to have a `Dockerfile` that installs all of the `ign-gazebo3` dependencies, and to load the source code for `ign-gazebo3` into this Docker container as a volume at runtime. Then, users can develop and test their changes inside of Docker without having to worry about configuring source and binary installs on their own machine - users would simply build the source code for `ign-gazebo3` inside of the container using something like [colcon](https://colcon.readthedocs.io/en/released/#).

I've added a [README](https://github.com/ignitionrobotics/ign-gazebo/blob/development_docker/docker/development/README.md), which outlines how to use a source install of `ign-gazebo` within Docker.

A few things to consider:

1. In order to get graphics capabilities inside of docker, `run.bash` configures a few things and then passes this info to the `docker run` command. Right now, `run.bash` can only be used if:
    - You have [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker)
    - Your computer has an nvidia graphics card
2. @iche033 suggested looking into [osrf/rocker](https://github.com/osrf/rocker) as a potential solution for allowing this setup to work with various graphics cards (AMD and NVidia). I haven't had the chance to experiment with this yet.

This is just an initial draft/proposal. I'd love to hear anyone's thoughts if they have any - I'm sure there are ways to improve this setup!

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>