### PR TITLE
Fix source build instructions for ign-gazebo2

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,7 @@ for dependency installation instructions for each supported operating system.
 
 **[Ubuntu Bionic](http://releases.ubuntu.com/18.04/)**
 
-1. Install third-party libraries:
-
-    ```
-    sudo apt-get -y install cmake build-essential curl cppcheck g++-8 libbenchmark-dev libgflags-dev doxygen ruby-ronn libtinyxml2-dev libtinyxml-dev software-properties-common libeigen3-dev qtdeclarative5-models-plugin
-    ```
-
-2. Install required Ignition libraries:
+1. Enable the Ignition software repositories:
 
     ```
     sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
@@ -161,8 +155,16 @@ for dependency installation instructions for each supported operating system.
     sudo apt-get update
     ```
 
+2. Install package dependencies:
+
     ```
-    sudo apt-get -y install libignition-cmake2-dev libignition-common3-dev libignition-math6-eigen3-dev libignition-plugin-dev libignition-physics-dev libignition-rendering2-dev libignition-tools-dev libignition-transport7-dev libignition-gui2-dev libignition-msgs4-dev libsdformat8-dev
+    git clone https://github.com/ignitionrobotics/ign-gazebo -b ign-gazebo2
+    ```
+
+    ```
+    export SYSTEM_VERSION=bionic
+    sudo apt -y install \
+      $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
     ```
 
 ### Building from source
@@ -174,16 +176,20 @@ for dependency installation instructions for each supported operating system.
     * Ubuntu
 
         ```
+        sudo apt-get install g++-8
+        ```
+
+        ```
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
         ```
 
-1. Clone the repository.
+3. Clone the repository if you haven't already.
 
     ```
     git clone https://github.com/ignitionrobotics/ign-gazebo -b ign-gazebo2
     ```
 
-2. Configure and  build.
+4. Configure and build.
 
     ```
     cd ign-gazebo
@@ -245,7 +251,7 @@ You can also generate the documentation from a clone of this repository by follo
 
 Follow these steps to run tests and static code analysis in your clone of this repository.
 
-1. Follow the [source install instruction](#source-install).
+1. Follow the [source install instructions](#source-install).
 
 2. Run tests.
 
@@ -254,6 +260,10 @@ Follow these steps to run tests and static code analysis in your clone of this r
     ```
 
 3. Static code checker.
+
+    ```
+    sudo apt-get update && sudo apt-get -y install cppcheck
+    ```
 
     ```
     make codecheck


### PR DESCRIPTION
I've updated the `ign-gazebo2` README to have the same source build approach as `ign-gazebo3` (#395). The main change is replacing the manual list of dependencies with the packages listed in `.github/ci/`.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>