### PR TITLE
Fix a crash in the grid_config plugin

### DIFF
--- a/src/gui/plugins/grid_config/GridConfig.cc
+++ b/src/gui/plugins/grid_config/GridConfig.cc
@@ -131,8 +131,16 @@ void GridConfig::UpdateGrid()
       mat->SetDiffuse(this->dataPtr->gridParam.color);
       mat->SetSpecular(this->dataPtr->gridParam.color);
     }
+    else
+    {
+      ignerr << "Grid visual missing material" << std::endl;
+    }
 
     visual->SetVisible(this->dataPtr->gridParam.visible);
+  }
+  else
+  {
+    ignerr << "Grid missing parent visual" << std::endl;
   }
 
   this->dataPtr->dirty = false;
@@ -173,7 +181,7 @@ void GridConfig::LoadGrid()
     return;
   }
 
-  if (!scene->IsInitialized() || scene->VisualCount() == 0)
+  if (!scene->IsInitialized() || nullptr == scene->RootVisual())
   {
     return;
   }
@@ -234,6 +242,7 @@ void GridConfig::LoadGrid()
   mat->SetAmbient(this->dataPtr->gridParam.color);
   mat->SetDiffuse(this->dataPtr->gridParam.color);
   mat->SetSpecular(this->dataPtr->gridParam.color);
+  vis->SetMaterial(mat);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/grid_config/GridConfig.cc
+++ b/src/gui/plugins/grid_config/GridConfig.cc
@@ -125,9 +125,12 @@ void GridConfig::UpdateGrid()
     visual->SetLocalPose(this->dataPtr->gridParam.pose);
 
     auto mat = visual->Material();
-    mat->SetAmbient(this->dataPtr->gridParam.color);
-    mat->SetDiffuse(this->dataPtr->gridParam.color);
-    mat->SetSpecular(this->dataPtr->gridParam.color);
+    if (mat)
+    {
+      mat->SetAmbient(this->dataPtr->gridParam.color);
+      mat->SetDiffuse(this->dataPtr->gridParam.color);
+      mat->SetSpecular(this->dataPtr->gridParam.color);
+    }
 
     visual->SetVisible(this->dataPtr->gridParam.visible);
   }


### PR DESCRIPTION
The grid plugin will crash  when changing properties if a world has `<grid>false</grid>` in the `<scene>` tag.

For example:

```
<?xml version="1.0" ?>
<sdf version="1.6">
  <world name="default">
    <plugin
      filename="ignition-gazebo-user-commands-system"
      name="ignition::gazebo::systems::UserCommands">
    </plugin>
    <plugin
      filename="ignition-gazebo-scene-broadcaster-system"
      name="ignition::gazebo::systems::SceneBroadcaster">
    </plugin>
    <physics name="1ms" type="ode">
      <max_step_size>0.004</max_step_size>
      <real_time_factor>1.0</real_time_factor>
    </physics>

    <scene>
      <ambient>0.1 0.1 0.1 1.0</ambient>
      <background>0 0 0 1.0</background>
      <grid>false</grid>
      <origin_visual>false</origin_visual>
    </scene>

    <include>
      <static>true</static>
      <name>staging_area</name>
      <pose>0 0 0 0 0 0</pose>
      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Starting Area Type B</uri>
    </include>
  </world>
</sdf>
```

This fixes the problem, but there might be a more elegant solution.