### PR TITLE
[Backport] Enable alpha based transparency on PBR materials by default #249

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Gazebo 3.X.X (20XX-XX-XX)
 
+1. Enable alpha based transparency on PBR materials by default
+    * [Pull Request 249](https://github.com/ignitionrobotics/ign-gazebo/pull/249)
+
 ### Ignition Gazebo 3.4.0 (2020-10-14)
 
 1. Fix gui sendEvent memory leaks

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -462,6 +462,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
       if (!fullPath.empty())
       {
         material->SetTexture(fullPath);
+        // Use alpha channel for transparency
+        material->SetAlphaFromTexture(true);
       }
       else
         ignerr << "Unable to find file [" << albedoMap << "]\n";


### PR DESCRIPTION
Backporting #249 to improve transparent materials on Citadel.

It changes the default behavior, but most likely no users are using materials with alpha yet. That's the hope :crossed_fingers: 