### PR TITLE
[Citadel] Document deprecation of playback <path> SDF param

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -36,6 +36,9 @@ Gazebo 2+ for playback. [BitBucket pull request
 #257](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/257)
 added an SDF message to the start of log files.
 
+* Log playback using `<path>` SDF parameter is deprecated. Use `--playback`
+  command line argument instead.
+
 ## Ignition Gazebo 1.0.2 to 1.1.0
 
 * All headers in `gazebo/network` are no longer installed.

--- a/examples/worlds/log_playback.sdf
+++ b/examples/worlds/log_playback.sdf
@@ -2,6 +2,9 @@
 <!--
   Log playback demo.
 
+  This file will be removed in Ignition Dome. Use the command line argument
+  for playback instead.
+
   Running this world will playback log files located at /tmp/log.
 
   You can record such a log by running one of the `log_record*.sdf` files,
@@ -15,6 +18,8 @@
     <plugin
       filename='ignition-gazebo-log-system'
       name='ignition::gazebo::systems::LogPlayback'>
+      <!-- Deprecation warning: This parameter will be removed in Ignition Dome.
+           Use the command line argument for playback instead. -->
       <path>/tmp/log</path>
     </plugin>
   </world>

--- a/tutorials/log.md
+++ b/tutorials/log.md
@@ -114,6 +114,9 @@ directory specified to record:
 
 ### From plugin in SDF
 
+This feature is deprecated and will be removed in Ignition Dome.
+Use the command line argument instead.
+
 Alternatively, playback can be specified in an SDF file. See example file
 `examples/worlds/log_playback.sdf`:
 


### PR DESCRIPTION
Documentation to address #293 for Citadel.

Discussed with @chapulina and we decided to do the following:
Blueprint & Citadel:
- Keep `log_playback.sdf` since the distros have already been released and the file installed.
- Update tutorial to say `<path>` is not recommended.
- Update header comment in example file. I thought it made more sense to update `log_playback.sdf` rather than `log_record_*.sdf`, because it's really the playback file that's being replaced, and they just have to use `--playback [arg]`. Nothing changes for recording.
- Add a note in `Migration.md`

Essentially deprecate `<path>` for Blueprint and Citadel, remove it in Dome.

Will make followup PR for Blueprint.
Dome will be in a separate PR with different items - `log_playback.sdf` has already been removed in Dome, documentation needs to be updated, and some test code needs to be changed, so it'll take a bit longer.