### PR TITLE
Added tests for the AnimationTime component

### DIFF
--- a/include/ignition/gazebo/components/Actor.hh
+++ b/include/ignition/gazebo/components/Actor.hh
@@ -20,6 +20,7 @@
 #include <ignition/msgs/actor.pb.h>
 
 #include <chrono>
+#include <ratio>
 #include <string>
 
 #include <sdf/Actor.hh>
@@ -50,7 +51,7 @@ namespace serializers
     public: static std::ostream &Serialize(std::ostream &_out,
                 const std::chrono::steady_clock::duration &_time)
     {
-      _out << std::chrono::duration_cast<std::chrono::milliseconds>(
+      _out << std::chrono::duration_cast<std::chrono::nanoseconds>(
           _time).count();
       return _out;
     }
@@ -64,7 +65,7 @@ namespace serializers
     {
       int64_t time;
       _in >> time;
-      _time = std::chrono::duration<int64_t, std::milli>(time);
+      _time = std::chrono::duration<int64_t, std::nano>(time);
       return _in;
     }
   };

--- a/test/integration/components.cc
+++ b/test/integration/components.cc
@@ -159,7 +159,7 @@ TEST_F(ComponentsTest, AnimationTime)
   // Stream operators
   std::ostringstream ostr;
   comp1.Serialize(ostr);
-  EXPECT_EQ("5000", ostr.str());
+  EXPECT_EQ("5000000000", ostr.str());
 
   std::istringstream istr(ostr.str());
   components::AnimationTime comp3;

--- a/test/integration/components.cc
+++ b/test/integration/components.cc
@@ -141,6 +141,33 @@ TEST_F(ComponentsTest, AnimationName)
 }
 
 /////////////////////////////////////////////////
+TEST_F(ComponentsTest, AnimationTime)
+{
+  auto start = std::chrono::steady_clock::now();
+  auto end1 = start + std::chrono::seconds(5);
+  auto end2 = start + std::chrono::seconds(10);
+
+  // Create components
+  auto comp1 = components::AnimationTime(end1 - start);
+  auto comp2 = components::AnimationTime(end2 - start);
+
+  // Equality operators
+  EXPECT_NE(comp1, comp2);
+  EXPECT_FALSE(comp1 == comp2);
+  EXPECT_TRUE(comp1 != comp2);
+
+  // Stream operators
+  std::ostringstream ostr;
+  comp1.Serialize(ostr);
+  EXPECT_EQ("5000", ostr.str());
+
+  std::istringstream istr(ostr.str());
+  components::AnimationTime comp3;
+  comp3.Deserialize(istr);
+  EXPECT_EQ(comp1, comp3);
+}
+
+/////////////////////////////////////////////////
 TEST_F(ComponentsTest, AirPressureSensor)
 {
   sdf::Sensor data1;


### PR DESCRIPTION
I added missing tests for a `std::chrono::steady_clock::duration` component after doing something similar in #401.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>