### PR TITLE
👩‍🌾 Make PeerTracker test more robust

### DIFF
--- a/src/network/PeerTracker_TEST.cc
+++ b/src/network/PeerTracker_TEST.cc
@@ -74,7 +74,17 @@ TEST(PeerTracker, PeerTracker)
   EXPECT_EQ(5, peers);
 
   // Allow all the heartbeats to propagate
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  int maxSleep{100};
+  int sleep{0};
+  for (; sleep < maxSleep &&
+      (tracker1->NumPeers() < 5 ||
+      tracker2->NumPeers() < 5 ||
+      tracker3->NumPeers() < 5 ||
+      tracker4->NumPeers() < 5 ||
+      tracker5->NumPeers() < 5); ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  }
 
   // All counts exclude self.
   EXPECT_EQ(5u, tracker1->NumPeers());
@@ -155,10 +165,14 @@ TEST(PeerTracker, PeerTrackerStale)
   auto tracker2 = std::make_shared<PeerTracker>(info2);
   tracker2->SetHeartbeatPeriod(std::chrono::milliseconds(100));
 
-  for (int sleep = 0; sleep < 50 && tracker2->NumPeers() == 0; ++sleep)
+  int maxSleep{100};
+  int sleep{0};
+  for (; sleep < maxSleep && (tracker2->NumPeers() == 0 || stalePeers == 0);
+      ++sleep)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
   }
+  EXPECT_LT(sleep, maxSleep);
 
   EXPECT_EQ(1, stalePeers);
 

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -626,7 +626,7 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
   sdf::Root root;
   root.Load(sdfFile);
   const sdf::World *world = root.WorldByIndex(0);
-  ASSERT_TRUE(nullptr != world);
+  ASSERT_NE(nullptr, world);
 
   serverConfig.SetSdfFile(sdfFile);
 
@@ -650,6 +650,8 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
         [&](const ignition::gazebo::Entity &_entity,
             const components::Joint *, components::Name *_name) -> bool
       {
+        EXPECT_NE(nullptr, _name);
+
         if (_name->Data() == rotatingJointName)
         {
           auto resetComp =
@@ -669,8 +671,8 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
           }
           else
           {
-              EXPECT_EQ(nullptr, resetComp);
-              EXPECT_NE(nullptr, position);
+            EXPECT_EQ(nullptr, resetComp);
+            EXPECT_NE(nullptr, position);
           }
         }
         return true;
@@ -689,6 +691,8 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
               const components::Name *_name,
               const components::JointPosition *_pos)
           {
+            EXPECT_NE(nullptr, _name);
+
             if (_name->Data() == rotatingJointName)
             {
               positions.push_back(_pos->Data()[0]);
@@ -697,16 +701,16 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
           });
     });
 
-    server.AddSystem(testSystem.systemPtr);
-    server.Run(true, 2, false);
+  server.AddSystem(testSystem.systemPtr);
+  server.Run(true, 2, false);
 
-    ASSERT_EQ(positions.size(), 2ul);
+  ASSERT_EQ(positions.size(), 2ul);
 
-    // First position should be exactly the same
-    EXPECT_DOUBLE_EQ(pos0, positions[0]);
+  // First position should be exactly the same
+  EXPECT_DOUBLE_EQ(pos0, positions[0]);
 
-    // Second position should be different, but close
-    EXPECT_NEAR(pos0, positions[1], 0.01);
+  // Second position should be different, but close
+  EXPECT_NEAR(pos0, positions[1], 0.01);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Various test cases in `PeerTracker_TEST` have been flaking for a while, see the [test history](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/lastBuild/testReport/(root)/PeerTracker/PeerTrackerStale/history/). This PR is an attempt at making it more robust to diverse timing conditions.

I also included some tweaks to the `physics_system` test.

### Most recent `PeerTracker` failures

```
35: [ RUN      ] PeerTracker.PeerTracker
35: /Users/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/ign-gazebo/src/network/PeerTracker_TEST.cc:84: Failure
35: Value of: tracker5->NumPeers()
35:   Actual: 4
35: Expected: 5u
35: Which is: 5
35: [  FAILED  ] PeerTracker.PeerTracker (2601 ms)
```

```
35: [ RUN      ] PeerTracker.PeerTrackerStale
35: /Users/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/ign-gazebo/src/network/PeerTracker_TEST.cc:167: Failure
35: Value of: tracker1->NumPeers()
35:   Actual: 1
35: Expected: 0u
35: Which is: 0
35: [1;36m[Dbg] [PeerTracker.cc:163] [0m[1;36mAttempting to remove peer [[0m[1;36m1aa895e8-ec40-403e-8a5c-1aa2ed5b3fcc[0m[1;36m] from [[0m[1;36m2b497001-2f37-4230-9aa4-8cf6c70173f6[0m[1;36m] but it wasn't connected[0m[1;36m[0m
35: [  FAILED  ] PeerTracker.PeerTrackerStale (294 ms)
```

This one with 2 stale peers is a real mystery to me :monocle_face: 

```
37: [ RUN      ] PeerTracker.PeerTrackerStale
37: /Users/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/ign-gazebo/src/network/PeerTracker_TEST.cc:163: Failure
37: Value of: stalePeers
37:   Actual: 2
37: Expected: 1
37: /Users/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/ign-gazebo/src/network/PeerTracker_TEST.cc:167: Failure
37: Value of: tracker1->NumPeers()
37:   Actual: 1
37: Expected: 0u
37: Which is: 0
37: [Dbg] [PeerTracker.cc:163] Attempting to remove peer [c23a3125-0559-4dd9-8350-f857e08b1f53] from [12b9230d-1416-4382-a73c-e80a6c04aab5] but it wasn't connected
37: [  FAILED  ] PeerTracker.PeerTrackerStale (643 ms)
```

