### PR TITLE
2 ➡️ 3

### DIFF
--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -15,6 +15,10 @@
  *
  */
 
+#include "LevelManager.hh"
+
+#include <algorithm>
+
 #include <sdf/Actor.hh>
 #include <sdf/Atmosphere.hh>
 #include <sdf/Light.hh>
@@ -50,7 +54,6 @@
 #include "ignition/gazebo/components/Wind.hh"
 #include "ignition/gazebo/components/World.hh"
 
-#include "LevelManager.hh"
 #include "SimulationRunner.hh"
 
 using namespace ignition;

--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -14,7 +14,11 @@
  * limitations under the License.
  *
  */
+
+#include "SdfGenerator.hh"
+
 #include <memory>
+#include <vector>
 
 #include <sdf/sdf.hh>
 
@@ -29,7 +33,6 @@
 #include "ignition/gazebo/components/SourceFilePath.hh"
 #include "ignition/gazebo/components/World.hh"
 
-#include "SdfGenerator.hh"
 
 namespace ignition
 {
@@ -346,7 +349,7 @@ namespace sdf_generator
               // https://example.org/1.0/test/models/Backpack
               // the path to the directory containing the sdf file (modelDir)
               // will be:
-              // $HOME/.ignition/fuel/example.org/test/models/Backpack/1/
+              // $HOME/.ignition/fuel/example.org/test/models/Backpack/2/
               // and the basename of the directory is "1", which is the model
               // version.
               //

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -543,13 +543,13 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1";
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {
       // Thes following two URIs are valid, but have a trailing '/'
       "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/",
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1/",
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2/",
       // Thes following two URIs are invalid, and will not be saved
       "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/"
       "notInt",

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -17,6 +17,8 @@
 
 #include "SimulationRunner.hh"
 
+#include <algorithm>
+
 #include "ignition/common/Profiler.hh"
 
 #include "ignition/gazebo/components/Model.hh"

--- a/src/gui/PathManager.cc
+++ b/src/gui/PathManager.cc
@@ -15,14 +15,18 @@
  *
  */
 
+#include "PathManager.hh"
+
 #include <ignition/msgs/sdf_generator_config.pb.h>
+
+#include <string>
+#include <vector>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
 
 #include "ignition/gazebo/Util.hh"
-#include "PathManager.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/gui/PathManager.hh
+++ b/src/gui/PathManager.hh
@@ -22,6 +22,7 @@
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/config.hh"
 
 namespace ignition
 {

--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -15,7 +15,11 @@
  *
 */
 
+#include "EntityTree.hh"
+
 #include <iostream>
+#include <vector>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
@@ -37,8 +41,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "EntityTree.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -14,18 +14,21 @@
  * limitations under the License.
  *
 */
+
+#include "EntityContextMenu.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 #include <ignition/msgs/entity.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gazebo/gui/GuiRunner.hh>
 #include <ignition/gazebo/Conversions.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/transport/Node.hh>
-
-#include "EntityContextMenu.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/playback_scrubber/PlaybackScrubber.cc
+++ b/src/gui/plugins/playback_scrubber/PlaybackScrubber.cc
@@ -14,14 +14,21 @@
  * limitations under the License.
  *
 */
+
+#include "PlaybackScrubber.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
-#include <ignition/math/Helpers.hh>
 
 #include <chrono>
 #include <ctime>
 #include <iostream>
 #include <regex>
+#include <string>
+#include <utility>
+
+#include <ignition/math/Helpers.hh>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/Helpers.hh>
@@ -34,8 +41,6 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "PlaybackScrubber.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -15,8 +15,13 @@
  *
  */
 
+#include "ResourceSpawner.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
+
+#include <set>
+#include <unordered_map>
 
 #include <sdf/Root.hh>
 #include <sdf/parser.hh>
@@ -32,12 +37,8 @@
 #include <ignition/fuel_tools/FuelClient.hh>
 #include <ignition/fuel_tools/ClientConfig.hh>
 
-#include <set>
-
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "ResourceSpawner.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -15,10 +15,15 @@
  *
 */
 
+#include "Scene3D.hh"
+
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sdf/Link.hh>
@@ -59,8 +64,6 @@
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 #include "ignition/gazebo/rendering/RenderUtil.hh"
-
-#include "Scene3D.hh"
 
 Q_DECLARE_METATYPE(std::string)
 

--- a/src/gui/plugins/shapes/Shapes.cc
+++ b/src/gui/plugins/shapes/Shapes.cc
@@ -14,10 +14,16 @@
  * limitations under the License.
  *
 */
+
+#include "Shapes.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
+#include <algorithm>
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
@@ -27,8 +33,6 @@
 
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "Shapes.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -14,10 +14,15 @@
  * limitations under the License.
  *
 */
+
+#include "TransformControl.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
@@ -36,8 +41,6 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "TransformControl.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/video_recorder/VideoRecorder.cc
+++ b/src/gui/plugins/video_recorder/VideoRecorder.cc
@@ -14,10 +14,15 @@
  * limitations under the License.
  *
 */
+
+#include "VideoRecorder.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/video_record.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/gui/Application.hh>
@@ -28,8 +33,6 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
-
-#include "VideoRecorder.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -14,15 +14,18 @@
  * limitations under the License.
  *
 */
+
+#include "ViewAngle.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/vector3d.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
-
-#include "ViewAngle.hh"
 
 namespace ignition::gazebo
 {

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -14,7 +14,13 @@
  * limitations under the License.
  *
 */
+
+#include "ign.hh"
+
 #include <cstring>
+#include <string>
+#include <vector>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/fuel_tools/FuelClient.hh>
@@ -27,7 +33,6 @@
 #include "ignition/gazebo/ServerConfig.hh"
 
 #include "ignition/gazebo/gui/Gui.hh"
-#include "ign.hh"
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GAZEBO_VISIBLE char *ignitionGazeboVersion()

--- a/src/network/NetworkManagerPrimary.cc
+++ b/src/network/NetworkManagerPrimary.cc
@@ -15,8 +15,12 @@
  *
 */
 
+#include "NetworkManagerPrimary.hh"
+
 #include <algorithm>
+#include <set>
 #include <string>
+#include <utility>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
@@ -32,7 +36,6 @@
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Events.hh"
 
-#include "NetworkManagerPrimary.hh"
 #include "NetworkManagerPrivate.hh"
 #include "PeerTracker.hh"
 

--- a/src/network/PeerTracker.cc
+++ b/src/network/PeerTracker.cc
@@ -16,6 +16,9 @@
 */
 #include "PeerTracker.hh"
 
+#include <algorithm>
+#include <utility>
+
 using namespace ignition;
 using namespace gazebo;
 

--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -14,7 +14,14 @@
  * limitations under the License.
  *
  */
+
+#include "AirPressure.hh"
+
 #include <ignition/msgs/air_pressure_sensor.pb.h>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <ignition/plugin/Register.hh>
 
@@ -34,8 +41,6 @@
 #include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "AirPressure.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -15,7 +15,13 @@
  *
  */
 
+#include "Altimeter.hh"
+
 #include <ignition/msgs/altimeter.pb.h>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -37,8 +43,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "Altimeter.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/apply_joint_force/ApplyJointForce.cc
+++ b/src/systems/apply_joint_force/ApplyJointForce.cc
@@ -14,14 +14,17 @@
  * limitations under the License.
  *
  */
+
+#include "ApplyJointForce.hh"
+
+#include <string>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "ApplyJointForce.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -15,13 +15,17 @@
  *
  */
 
+#include "LinearBatteryPlugin.hh"
+
 #include <ignition/msgs/battery_state.pb.h>
 #include <ignition/msgs/boolean.pb.h>
 
 #include <algorithm>
 #include <atomic>
+#include <deque>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include <ignition/common/Battery.hh>
 #include <ignition/common/Profiler.hh>
@@ -43,8 +47,6 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "LinearBatteryPlugin.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/breadcrumbs/Breadcrumbs.hh
+++ b/src/systems/breadcrumbs/Breadcrumbs.hh
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <sdf/Element.hh>
+#include <sdf/Geometry.hh>
 #include <sdf/Root.hh>
 
 #include <ignition/transport/Node.hh>

--- a/src/systems/contact/Contact.cc
+++ b/src/systems/contact/Contact.cc
@@ -15,11 +15,15 @@
  *
  */
 
+#include "Contact.hh"
 
 #include <ignition/msgs/contact.pb.h>
 #include <ignition/msgs/contacts.pb.h>
 
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -37,8 +41,6 @@
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
-
-#include "Contact.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -14,9 +14,15 @@
  * limitations under the License.
  *
  */
+
+#include "DiffDrive.hh"
+
 #include <ignition/msgs/odometry.pb.h>
 
+#include <limits>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/DiffDriveOdometry.hh>
@@ -30,7 +36,6 @@
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
 
-#include "DiffDrive.hh"
 #include "SpeedLimiter.hh"
 
 using namespace ignition;

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -15,6 +15,12 @@
  *
  */
 
+#include "Imu.hh"
+
+#include <unordered_map>
+#include <utility>
+#include <string>
+
 #include <ignition/plugin/Register.hh>
 
 #include <sdf/Element.hh>
@@ -37,8 +43,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "Imu.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -15,7 +15,12 @@
  *
  */
 
+#include "JointController.hh"
+
 #include <ignition/msgs/double.pb.h>
+
+#include <string>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/PID.hh>
 #include <ignition/plugin/Register.hh>
@@ -25,8 +30,6 @@
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/JointVelocityCmd.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "JointController.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -15,7 +15,12 @@
  *
  */
 
+#include "JointPositionController.hh"
+
 #include <ignition/msgs/double.pb.h>
+
+#include <string>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/PID.hh>
 #include <ignition/plugin/Register.hh>
@@ -24,8 +29,6 @@
 #include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/components/JointPosition.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "JointPositionController.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -15,7 +15,13 @@
  *
  */
 
+#include "JointStatePublisher.hh"
+
 #include <ignition/msgs/model.pb.h>
+
+#include <string>
+#include <vector>
+
 #include <ignition/plugin/Register.hh>
 
 #include "ignition/gazebo/components/Name.hh"
@@ -25,7 +31,6 @@
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Pose.hh"
-#include "JointStatePublisher.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -15,7 +15,10 @@
  *
  */
 
+#include "LiftDrag.hh"
+
 #include <algorithm>
+#include <string>
 #include <vector>
 
 #include <ignition/common/Profiler.hh>
@@ -36,8 +39,6 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ExternalWorldWrenchCmd.hh"
 #include "ignition/gazebo/components/Pose.hh"
-
-#include "LiftDrag.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/log/LogPlayback.cc
+++ b/src/systems/log/LogPlayback.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/pose_v.pb.h>
 #include <ignition/msgs/log_playback_stats.pb.h>
 
+#include <set>
 #include <string>
 #include <unordered_map>
 

--- a/src/systems/log_video_recorder/LogVideoRecorder.cc
+++ b/src/systems/log_video_recorder/LogVideoRecorder.cc
@@ -15,10 +15,14 @@
  *
 */
 
+#include "LogVideoRecorder.hh"
+
 #include <ignition/msgs/scene.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
 #include <chrono>
+#include <set>
+#include <string>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/AxisAlignedBox.hh>
@@ -33,8 +37,6 @@
 #include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Events.hh"
-
-#include "LogVideoRecorder.hh"
 
 using namespace std::chrono_literals;
 

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -15,7 +15,14 @@
  *
  */
 
+#include "LogicalCamera.hh"
+
 #include <ignition/msgs/logical_camera_image.pb.h>
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -37,8 +44,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "LogicalCamera.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -15,6 +15,12 @@
  *
  */
 
+#include "Magnetometer.hh"
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include <ignition/plugin/Register.hh>
 
 #include <sdf/Sensor.hh>
@@ -35,8 +41,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "Magnetometer.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/multicopter_control/Common.cc
+++ b/src/systems/multicopter_control/Common.cc
@@ -15,6 +15,10 @@
  *
  */
 
+#include "Common.hh"
+
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/math/eigen3/Conversions.hh>
 
@@ -27,8 +31,6 @@
 #include <ignition/gazebo/components/Pose.hh>
 #include "ignition/gazebo/components/LinearVelocity.hh"
 #include "ignition/gazebo/components/AngularVelocity.hh"
-
-#include "Common.hh"
 
 namespace ignition
 {

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -20,7 +20,11 @@
  * limitations under the License.
  *
  */
+
+#include "MulticopterMotorModel.hh"
+
 #include <mutex>
+#include <string>
 
 #include <ignition/common/Profiler.hh>
 
@@ -45,8 +49,6 @@
 #include "ignition/gazebo/components/Wind.hh"
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "MulticopterMotorModel.hh"
 
 // from rotors_gazebo_plugins/include/rotors_gazebo_plugins/common.h
 /// \brief    This class can be used to apply a first order filter on a signal.

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -15,14 +15,19 @@
  *
  */
 
+#include "Physics.hh"
+
 #include <ignition/msgs/contact.pb.h>
 #include <ignition/msgs/contacts.pb.h>
 #include <ignition/msgs/entity.pb.h>
 #include <ignition/msgs/Utility.hh>
 
+#include <algorithm>
 #include <iostream>
 #include <deque>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <ignition/common/MeshManager.hh>
 #include <ignition/common/Profiler.hh>
@@ -33,34 +38,11 @@
 #include <ignition/physics/config.hh>
 #include <ignition/physics/FeatureList.hh>
 #include <ignition/physics/FeaturePolicy.hh>
-#include <ignition/physics/FindFeatures.hh>
 #include <ignition/physics/RelativeQuantity.hh>
 #include <ignition/physics/RequestEngine.hh>
 #include <ignition/plugin/Loader.hh>
 #include <ignition/plugin/PluginPtr.hh>
 #include <ignition/plugin/Register.hh>
-
-// Features
-#include <ignition/physics/BoxShape.hh>
-#include <ignition/physics/CylinderShape.hh>
-#include <ignition/physics/ForwardStep.hh>
-#include <ignition/physics/FrameSemantics.hh>
-#include <ignition/physics/FreeGroup.hh>
-#include <ignition/physics/FixedJoint.hh>
-#include <ignition/physics/GetContacts.hh>
-#include <ignition/physics/GetBoundingBox.hh>
-#include <ignition/physics/Joint.hh>
-#include <ignition/physics/Link.hh>
-#include <ignition/physics/RemoveEntities.hh>
-#include <ignition/physics/Shape.hh>
-#include <ignition/physics/SphereShape.hh>
-#include <ignition/physics/mesh/MeshShape.hh>
-#include <ignition/physics/sdf/ConstructCollision.hh>
-#include <ignition/physics/sdf/ConstructJoint.hh>
-#include <ignition/physics/sdf/ConstructLink.hh>
-#include <ignition/physics/sdf/ConstructModel.hh>
-#include <ignition/physics/sdf/ConstructNestedModel.hh>
-#include <ignition/physics/sdf/ConstructWorld.hh>
 
 // SDF
 #include <sdf/Collision.hh>
@@ -114,8 +96,6 @@
 #include "ignition/gazebo/components/Static.hh"
 #include "ignition/gazebo/components/ThreadPitch.hh"
 #include "ignition/gazebo/components/World.hh"
-
-#include "Physics.hh"
 
 using namespace ignition;
 using namespace ignition::gazebo::systems;

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -20,7 +20,30 @@
 #include <memory>
 #include <unordered_map>
 #include <utility>
+#include <ignition/physics/FindFeatures.hh>
 #include <ignition/physics/RequestFeatures.hh>
+
+// Features need to be defined ahead of entityCast
+#include <ignition/physics/BoxShape.hh>
+#include <ignition/physics/CylinderShape.hh>
+#include <ignition/physics/ForwardStep.hh>
+#include <ignition/physics/FrameSemantics.hh>
+#include <ignition/physics/FreeGroup.hh>
+#include <ignition/physics/FixedJoint.hh>
+#include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/GetBoundingBox.hh>
+#include <ignition/physics/Joint.hh>
+#include <ignition/physics/Link.hh>
+#include <ignition/physics/RemoveEntities.hh>
+#include <ignition/physics/Shape.hh>
+#include <ignition/physics/SphereShape.hh>
+#include <ignition/physics/mesh/MeshShape.hh>
+#include <ignition/physics/sdf/ConstructCollision.hh>
+#include <ignition/physics/sdf/ConstructJoint.hh>
+#include <ignition/physics/sdf/ConstructLink.hh>
+#include <ignition/physics/sdf/ConstructModel.hh>
+#include <ignition/physics/sdf/ConstructNestedModel.hh>
+#include <ignition/physics/sdf/ConstructWorld.hh>
 
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Export.hh>

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -15,9 +15,15 @@
  *
  */
 
+#include "PosePublisher.hh"
+
 #include <ignition/msgs/pose.pb.h>
 
 #include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <sdf/Joint.hh>
@@ -44,7 +50,6 @@
 #include "ignition/gazebo/components/Visual.hh"
 #include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/Model.hh"
-#include "PosePublisher.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -15,10 +15,13 @@
  *
 */
 
+#include "SceneBroadcaster.hh"
+
 #include <ignition/msgs/scene.pb.h>
 
 #include <chrono>
 #include <condition_variable>
+#include <string>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/graph/Graph.hh>
@@ -39,8 +42,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
-
-#include "SceneBroadcaster.hh"
 
 using namespace std::chrono_literals;
 

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -15,7 +15,12 @@
  *
  */
 
+#include "Sensors.hh"
+
+#include <map>
 #include <set>
+#include <utility>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -44,8 +49,6 @@
 
 #include "ignition/gazebo/rendering/Events.hh"
 #include "ignition/gazebo/rendering/RenderUtil.hh"
-
-#include "Sensors.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/sensors/Sensors.hh
+++ b/src/systems/sensors/Sensors.hh
@@ -19,9 +19,11 @@
 
 #include <memory>
 #include <string>
+
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Export.hh>
 #include <ignition/gazebo/System.hh>
+#include <sdf/Sensor.hh>
 
 namespace ignition
 {

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -15,8 +15,11 @@
  *
  */
 
+#include "TouchPlugin.hh"
+
 #include <algorithm>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <ignition/common/Profiler.hh>
@@ -34,8 +37,6 @@
 
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "TouchPlugin.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -15,14 +15,17 @@
  *
  */
 
+#include "TriggeredPublisher.hh"
+
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
+
+#include <limits>
+#include <utility>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/plugin/Register.hh>
-
-#include "TriggeredPublisher.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -15,10 +15,17 @@
  *
  */
 
+#include "UserCommands.hh"
+
 #include <google/protobuf/message.h>
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/entity_factory.pb.h>
 #include <ignition/msgs/pose.pb.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <ignition/msgs/Utility.hh>
 
 #include <sdf/Root.hh>
@@ -38,8 +45,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
-
-#include "UserCommands.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/wheel_slip/WheelSlip.cc
+++ b/src/systems/wheel_slip/WheelSlip.cc
@@ -15,6 +15,12 @@
  *
  */
 
+#include "WheelSlip.hh"
+
+#include <map>
+#include <string>
+#include <vector>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
@@ -27,8 +33,6 @@
 #include "ignition/gazebo/components/Joint.hh"
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/SlipComplianceCmd.hh"
-
-#include "WheelSlip.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -15,9 +15,14 @@
  *
  */
 
+#include "WindEffects.hh"
+
 #include <google/protobuf/message.h>
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/entity_factory.pb.h>
+
+#include <string>
+#include <vector>
 
 #include <sdf/Root.hh>
 #include <sdf/Error.hh>
@@ -43,8 +48,6 @@
 #include "ignition/gazebo/components/WindMode.hh"
 
 #include "ignition/gazebo/Link.hh"
-
-#include "WindEffects.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/test/worlds/breadcrumbs_levels.sdf
+++ b/test/worlds/breadcrumbs_levels.sdf
@@ -1,0 +1,120 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="breadcrumbs_levels">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="libignition-gazebo-physics-system.so"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-user-commands-system.so"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-scene-broadcaster-system.so"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <model name="tile_1">
+      <pose>0 0 0.1 0 0 0</pose>
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>10 10 0.2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>10 10 0.2</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.0 0.8 0.0 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+      <plugin filename="libignition-gazebo-breadcrumbs-system.so" name="ignition::gazebo::systems::Breadcrumbs">
+       <max_deployments>3</max_deployments>
+       <disable_physics_time>15</disable_physics_time>
+       <allow_renaming>true</allow_renaming>
+       <breadcrumb>
+         <sdf version="1.6">
+          <model name="B1">
+            <pose>0 0 5 0 0 0</pose>
+            <link name='body'>
+              <visual name='visual'>
+                <geometry>
+                  <box>
+                    <size>0.3 0.3 0.5</size>
+                  </box>
+                </geometry>
+              </visual>
+              <collision name='collision'>
+                <geometry>
+                  <box>
+                    <size>0.3 0.3 0.5</size>
+                  </box>
+                </geometry>
+              </collision>
+            </link>
+          </model>
+        </sdf>
+       </breadcrumb>
+      </plugin>
+    </model>
+
+    <model name="sphere">
+      <pose>0 0 2 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>1.0</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="sphere_visual">
+          <geometry>
+            <sphere>
+              <radius>1.0</radius>
+            </sphere>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+    <plugin name="ignition::gazebo" filename="dummy">
+      <performer name="perf1">
+        <ref>sphere</ref>
+        <geometry>
+          <box>
+            <size>4 4 2</size>
+          </box>
+        </geometry>
+      </performer>
+      <level name="level1">
+        <pose>0 0 2.5 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>10 10 10</size>
+          </box>
+        </geometry>
+        <buffer>2</buffer>
+        <ref>tile_1</ref>
+      </level>
+    </plugin>
+  </world>
+</sdf>
+
+

--- a/test/worlds/save_world.sdf
+++ b/test/worlds/save_world.sdf
@@ -30,7 +30,7 @@
       <pose>1 2 3 0.1 0.2 0.3</pose>
     </include>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2</uri>
       <name>backpack3</name>
       <pose>2 0 0 0.1 0.2 0.3</pose>
     </include>


### PR DESCRIPTION
Forward-porting `ign-gazebo2` to `ign-gazebo3`.

The only extra change I needed to do for the port to compile was moving several `ign-physics` includes from `Physics.cc` to `Physics.hh` to compensate for the header inclusion moved up in #443 . The `entityCast` function needs the features defined before it. CC @adlarkin 