### PR TITLE
3 to 4

### DIFF
--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Collection Labeler
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   pr_collection_labeler:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ set(IGN_SENSORS_VER ${ignition-sensors4_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering
-ign_find_package(ignition-rendering4 REQUIRED)
+ign_find_package(ignition-rendering4 REQUIRED VERSION 4.1.0)
 set(IGN_RENDERING_VER ${ignition-rendering4_VERSION_MAJOR})
 
 #--------------------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -99,6 +99,33 @@
 
 ### Ignition Gazebo 3.X.X (20XX-XX-XX)
 
+### Ignition Gazebo 3.5.0 (2020-11-03)
+
+1. Updated source build instructions
+    * [Pull Request 403](https://github.com/ignitionrobotics/ign-gazebo/pull/403)
+
+1. More world APIs, helper function ComponentData
+    * [Pull Request 378](https://github.com/ignitionrobotics/ign-gazebo/pull/378)
+
+1. Improve fork experience
+    * [Pull Request 411](https://github.com/ignitionrobotics/ign-gazebo/pull/411)
+
+1. Fix a crash in the grid config plugin, set grid material
+    * [Pull Request 412](https://github.com/ignitionrobotics/ign-gazebo/pull/412)
+
+1. Document deprecation of log playback `<path>` SDF param
+    * [Pull Request 424](https://github.com/ignitionrobotics/ign-gazebo/pull/424)
+    * [Pull Request 425](https://github.com/ignitionrobotics/ign-gazebo/pull/425)
+
+1. Enable mouse highlighting selection on resource spawner
+    * [Pull Request 402](https://github.com/ignitionrobotics/ign-gazebo/pull/402)
+
+1. Add support for custom render engines
+    * [Pull Request 373](https://github.com/ignitionrobotics/ign-gazebo/pull/373)
+
+1. Component Vector -> Map ECM Optimization
+    * [Pull Request 416](https://github.com/ignitionrobotics/ign-gazebo/pull/416)
+
 ### Ignition Gazebo 3.4.0 (2020-10-14)
 
 1. Fix gui sendEvent memory leaks

--- a/Migration.md
+++ b/Migration.md
@@ -48,6 +48,9 @@ Gazebo 2+ for playback. [BitBucket pull request
 #257](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/257)
 added an SDF message to the start of log files.
 
+* Log playback using `<path>` SDF parameter is deprecated. Use `--playback`
+  command line argument instead.
+
 ## Ignition Gazebo 1.0.2 to 1.1.0
 
 * All headers in `gazebo/network` are no longer installed.

--- a/examples/worlds/thermal_camera.sdf
+++ b/examples/worlds/thermal_camera.sdf
@@ -23,6 +23,10 @@
       filename="ignition-gazebo-scene-broadcaster-system"
       name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
 
     <gui fullscreen="0">
 

--- a/include/ignition/gazebo/Util.hh
+++ b/include/ignition/gazebo/Util.hh
@@ -145,6 +145,10 @@ namespace ignition
     /// \brief Environment variable used by SDFormat to find URIs inside
     /// `<include>`
     const std::string kSdfPathEnv{"SDF_PATH"};
+
+    /// \brief Environment variable holding paths to custom rendering engine
+    /// plugins.
+    const std::string kRenderPluginPathEnv{"IGN_GAZEBO_RENDER_ENGINE_PATH"};
     }
   }
 }

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -113,6 +113,7 @@ math::Pose3d ignition::gazebo::convert(const msgs::Pose &_in)
                    _in.orientation().x(),
                    _in.orientation().y(),
                    _in.orientation().z());
+  out.Correct();
 
   return out;
 }

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -171,6 +171,15 @@ TEST(Conversions, Pose)
 
   auto pose = convert<math::Pose3d>(msg);
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3, 0.4), pose);
+
+  // Test empty orientation.
+  msgs::Pose msg2;
+  msg2.mutable_position()->set_x(1);
+  msg2.mutable_position()->set_y(2);
+  msg2.mutable_position()->set_z(3);
+
+  pose = convert<math::Pose3d>(msg2);
+  EXPECT_EQ(math::Pose3d(1, 2, 3, 1.0, 0, 0, 0), pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -17,6 +17,8 @@
 
 #include <map>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <ignition/common/Profiler.hh>
@@ -41,7 +43,7 @@ class ignition::gazebo::EntityComponentManagerPrivate
   /// \param[in] _entity Entity to be inserted.
   /// \param[in, out] _set Set to be filled.
   public: void InsertEntityRecursive(Entity _entity,
-      std::set<Entity> &_set);
+      std::unordered_set<Entity> &_set);
 
   /// \brief Register a new component type.
   /// \param[in] _typeId Type if of the new component.
@@ -62,7 +64,7 @@ class ignition::gazebo::EntityComponentManagerPrivate
 
   /// \brief Map of component storage classes. The key is a component
   /// type id, and the value is a pointer to the component storage.
-  public: std::map<ComponentTypeId,
+  public: std::unordered_map<ComponentTypeId,
           std::unique_ptr<ComponentStorageBase>> components;
 
   /// \brief A graph holding all entities, arranged according to their
@@ -76,16 +78,17 @@ class ignition::gazebo::EntityComponentManagerPrivate
   public: std::set<ComponentKey> oneTimeChangedComponents;
 
   /// \brief Entities that have just been created
-  public: std::set<Entity> newlyCreatedEntities;
+  public: std::unordered_set<Entity> newlyCreatedEntities;
 
   /// \brief Entities that need to be removed.
-  public: std::set<Entity> toRemoveEntities;
+  public: std::unordered_set<Entity> toRemoveEntities;
 
   /// \brief Flag that indicates if all entities should be removed.
   public: bool removeAllEntities{false};
 
   /// \brief The set of components that each entity has
-  public: std::map<Entity, std::vector<ComponentKey>> entityComponents;
+  public: std::unordered_map<Entity,
+          std::unordered_map<ComponentTypeId, ComponentKey>> entityComponents;
 
   /// \brief A mutex to protect newly created entities.
   public: std::mutex entityCreatedMutex;
@@ -105,7 +108,8 @@ class ignition::gazebo::EntityComponentManagerPrivate
   /// \brief Cache of previously queried descendants. The key is the parent
   /// entity for which descendants were queried, and the value are all its
   /// descendants.
-  public: mutable std::map<Entity, std::unordered_set<Entity>> descendantCache;
+  public: mutable std::unordered_map<Entity, std::unordered_set<Entity>>
+          descendantCache;
 
   /// \brief Keep track of entities already used to ensure uniqueness.
   public: uint64_t entityCount{0};
@@ -185,7 +189,7 @@ void EntityComponentManager::ClearRemovedComponents()
 
 /////////////////////////////////////////////////
 void EntityComponentManagerPrivate::InsertEntityRecursive(Entity _entity,
-    std::set<Entity> &_set)
+    std::unordered_set<Entity> &_set)
 {
   for (const auto &vertex : this->entities.AdjacentsFrom(_entity))
   {
@@ -200,7 +204,7 @@ void EntityComponentManager::RequestRemoveEntity(Entity _entity,
 {
   // Store the to-be-removed entities in a temporary set so we can call
   // UpdateViews on each of them
-  std::set<Entity> tmpToRemoveEntities;
+  std::unordered_set<Entity> tmpToRemoveEntities;
   if (!_recursive)
   {
     tmpToRemoveEntities.insert(_entity);
@@ -268,14 +272,14 @@ void EntityComponentManager::ProcessRemoveEntityRequests()
       // Remove from graph
       this->dataPtr->entities.RemoveVertex(entity);
 
+      auto entityIter = this->dataPtr->entityComponents.find(entity);
       // Remove the components, if any.
-      if (this->dataPtr->entityComponents.find(entity) !=
-          this->dataPtr->entityComponents.end())
+      if (entityIter != this->dataPtr->entityComponents.end())
       {
-        for (const ComponentKey &key :
-            this->dataPtr->entityComponents.at(entity))
+        for (const auto &key : entityIter->second)
         {
-          this->dataPtr->components.at(key.first)->Remove(key.second);
+          this->dataPtr->components.at(key.second.first)->Remove(
+              key.second.second);
         }
 
         // Remove the entry in the entityComponent map
@@ -314,12 +318,8 @@ bool EntityComponentManager::RemoveComponent(
   if (!this->EntityHasComponent(_entity, _key))
     return false;
 
-  auto entityComponentIter = std::find(
-      this->dataPtr->entityComponents[_entity].begin(),
-      this->dataPtr->entityComponents[_entity].end(), _key);
-
   this->dataPtr->components.at(_key.first)->Remove(_key.second);
-  this->dataPtr->entityComponents[_entity].erase(entityComponentIter);
+  this->dataPtr->entityComponents[_entity].erase(_key.first);
   this->dataPtr->oneTimeChangedComponents.erase(_key);
   this->dataPtr->periodicChangedComponents.erase(_key);
 
@@ -338,10 +338,10 @@ bool EntityComponentManager::RemoveComponent(
 bool EntityComponentManager::EntityHasComponent(const Entity _entity,
     const ComponentKey &_key) const
 {
-  return this->HasEntity(_entity) &&
-    std::find(this->dataPtr->entityComponents[_entity].begin(),
-        this->dataPtr->entityComponents[_entity].end(), _key) !=
-    this->dataPtr->entityComponents[_entity].end();
+  if (!this->HasEntity(_entity))
+    return false;
+  auto &compMap = this->dataPtr->entityComponents[_entity];
+  return compMap.find(_key.first) != compMap.end();
 }
 
 /////////////////////////////////////////////////
@@ -356,11 +356,8 @@ bool EntityComponentManager::EntityHasComponentType(const Entity _entity,
   if (iter == this->dataPtr->entityComponents.end())
     return false;
 
-  return std::find_if(iter->second.begin(), iter->second.end(),
-      [&] (const ComponentKey &_key)
-      {
-        return _key.first == _typeId;
-      }) != iter->second.end();
+  auto typeIter = iter->second.find(_typeId);
+  return (typeIter != iter->second.end());
 }
 
 /////////////////////////////////////////////////
@@ -394,21 +391,16 @@ ComponentState EntityComponentManager::ComponentState(const Entity _entity,
   if (ecIter == this->dataPtr->entityComponents.end())
     return result;
 
-  auto iter = std::find_if(ecIter->second.begin(), ecIter->second.end(),
-        [&] (const ComponentKey &_key)
-  {
-    return _key.first == _typeId;
-  });
-
-  if (iter == ecIter->second.end())
+  auto typeKey = ecIter->second.find(_typeId);
+  if (typeKey == ecIter->second.end())
     return result;
 
-  if (this->dataPtr->oneTimeChangedComponents.find(*iter) !=
+  if (this->dataPtr->oneTimeChangedComponents.find(typeKey->second) !=
       this->dataPtr->oneTimeChangedComponents.end())
   {
     result = ComponentState::OneTimeChange;
   }
-  else if (this->dataPtr->periodicChangedComponents.find(*iter) !=
+  else if (this->dataPtr->periodicChangedComponents.find(typeKey->second) !=
       this->dataPtr->periodicChangedComponents.end())
   {
     result = ComponentState::PeriodicChange;
@@ -502,7 +494,8 @@ ComponentKey EntityComponentManager::CreateComponentImplementation(
 
   ComponentKey componentKey{_componentTypeId, componentIdPair.first};
 
-  this->dataPtr->entityComponents[_entity].push_back(componentKey);
+  this->dataPtr->entityComponents[_entity].insert(
+      {_componentTypeId, componentKey});
   this->dataPtr->oneTimeChangedComponents.insert(componentKey);
 
   if (componentIdPair.second)
@@ -521,23 +514,14 @@ bool EntityComponentManager::EntityMatches(Entity _entity,
   if (iter == this->dataPtr->entityComponents.end())
     return false;
 
-  // \todo(nkoenig) The performance of this could be improved. Ideally we
-  // wouldn't need two loops to confirm that an entity matches a set of
-  // types. It might be possible to create bitmask for component sets.
+  // \todo(nkoenig) The performance of this could be improved.
+  // It might be possible to create bitmask for component sets.
   // Fixing this might not be high priority, unless we expect frequent
   // creation of entities and/or queries.
   for (const ComponentTypeId &type : _types)
   {
-    bool found = false;
-    for (const ComponentKey &comp : iter->second)
-    {
-      if (comp.first == type)
-      {
-        found = true;
-        break;
-      }
-    }
-    if (!found)
+    auto typeIter = iter->second.find(type);
+    if (typeIter == iter->second.end())
       return false;
   }
 
@@ -553,15 +537,9 @@ ComponentId EntityComponentManager::EntityComponentIdFromType(
   if (ecIter == this->dataPtr->entityComponents.end())
     return -1;
 
-  auto iter =
-    std::find_if(ecIter->second.begin(), ecIter->second.end(),
-      [&] (const ComponentKey &_key)
-  {
-    return _key.first == _type;
-  });
-
-  if (iter != ecIter->second.end())
-    return iter->second;
+  auto typeIter = ecIter->second.find(_type);
+  if (typeIter != ecIter->second.end())
+    return typeIter->second.second;
 
   return -1;
 }
@@ -577,14 +555,10 @@ const components::BaseComponent
   if (ecIter == this->dataPtr->entityComponents.end())
     return nullptr;
 
-  auto iter = std::find_if(ecIter->second.begin(), ecIter->second.end(),
-      [&] (const ComponentKey &_key)
-  {
-    return _key.first == _type;
-  });
-
-  if (iter != ecIter->second.end())
-    return this->dataPtr->components.at(iter->first)->Component(iter->second);
+  auto typeIter = ecIter->second.find(_type);
+  if (typeIter != ecIter->second.end())
+    return this->dataPtr->components.at(typeIter->second.first)->Component(
+        typeIter->second.second);
 
   return nullptr;
 }
@@ -598,15 +572,10 @@ components::BaseComponent *EntityComponentManager::ComponentImplementation(
   if (ecIter == this->dataPtr->entityComponents.end())
     return nullptr;
 
-  auto iter =
-    std::find_if(ecIter->second.begin(), ecIter->second.end(),
-        [&] (const ComponentKey &_key)
-  {
-    return _key.first == _type;
-  });
-
-  if (iter != ecIter->second.end())
-    return this->dataPtr->components.at(iter->first)->Component(iter->second);
+  auto typeIter = ecIter->second.find(_type);
+  if (typeIter != ecIter->second.end())
+    return this->dataPtr->components.at(typeIter->second.first)->Component(
+        typeIter->second.second);
 
   return nullptr;
 }
@@ -829,6 +798,9 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedState &_msg,
 {
   auto entityMsg = _msg.add_entities();
   entityMsg->set_id(_entity);
+  auto iter = this->dataPtr->entityComponents.find(_entity);
+  if (iter == this->dataPtr->entityComponents.end())
+    return;
 
   if (this->dataPtr->toRemoveEntities.find(_entity) !=
       this->dataPtr->toRemoveEntities.end())
@@ -836,19 +808,29 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedState &_msg,
     entityMsg->set_remove(true);
   }
 
-  // Empty means all types
-  bool allTypes = _types.empty();
-
-  auto components = this->dataPtr->entityComponents[_entity];
-  for (const auto &comp : components)
+  // Insert all of the entity's components if the passed in types
+  // set is empty
+  auto types = _types;
+  if (types.empty())
   {
-    if (!allTypes && _types.find(comp.first) == _types.end())
+    for (auto &type : this->dataPtr->entityComponents[_entity])
+    {
+      types.insert(type.first);
+    }
+  }
+
+  for (const ComponentTypeId type : types)
+  {
+    // If the entity does not have the component, continue
+    std::unordered_map<ComponentTypeId, ComponentKey>::iterator typeIter =
+      iter->second.find(type);
+    if (typeIter == iter->second.end())
     {
       continue;
     }
+    ComponentKey comp = (typeIter->second);
 
     auto compMsg = entityMsg->add_components();
-
     auto compBase = this->ComponentImplementation(_entity, comp.first);
     compMsg->set_type(compBase->TypeId());
 
@@ -868,10 +850,13 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
     Entity _entity, const std::unordered_set<ComponentTypeId> &_types,
     bool _full) const
 {
+  auto iter = this->dataPtr->entityComponents.find(_entity);
+  if (iter == this->dataPtr->entityComponents.end())
+    return;
+
   // Set the default entity iterator to the end. This will allow us to know
   // if the entity has been added to the message.
   auto entIter = _msg.mutable_entities()->end();
-
   // Add an entity to the message and set it to be removed if the entity
   // exists in the toRemoveEntities list.
   if (this->dataPtr->toRemoveEntities.find(_entity) !=
@@ -890,16 +875,28 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
     entIter->second.set_remove(true);
   }
 
-  // Empty means all types
-  bool allTypes = _types.empty();
-
-  for (const ComponentKey &comp : this->dataPtr->entityComponents[_entity])
+  // Insert all of the entity's components if the passed in types
+  // set is empty
+  auto types = _types;
+  if (types.empty())
   {
-    if (!allTypes && _types.find(comp.first) == _types.end())
+    for (auto &type : this->dataPtr->entityComponents[_entity])
+    {
+      types.insert(type.first);
+    }
+  }
+
+  // Empty means all types
+  for (const ComponentTypeId type : types)
+  {
+    std::unordered_map<ComponentTypeId, ComponentKey>::iterator typeIter =
+      iter->second.find(type);
+    if (typeIter == iter->second.end())
     {
       continue;
     }
 
+    ComponentKey comp = typeIter->second;
     const components::BaseComponent *compBase =
       this->ComponentImplementation(_entity, comp.first);
 
@@ -927,9 +924,9 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
       }
     }
 
+    auto compIter = entIter->second.mutable_components()->find(comp.first);
     // Find the component in the message, and add the component to the
     // message if it's not present.
-    auto compIter = entIter->second.mutable_components()->find(comp.first);
     if (compIter == entIter->second.mutable_components()->end())
     {
       msgs::SerializedComponent cmp;
@@ -1275,29 +1272,24 @@ void EntityComponentManager::SetChanged(
   if (ecIter == this->dataPtr->entityComponents.end())
     return;
 
-  auto iter = std::find_if(ecIter->second.begin(), ecIter->second.end(),
-        [&] (const ComponentKey &_key)
-  {
-    return _key.first == _type;
-  });
-
-  if (iter == ecIter->second.end())
+  auto typeIter = ecIter->second.find(_type);
+  if (typeIter == ecIter->second.end())
     return;
 
   if (_c == ComponentState::PeriodicChange)
   {
-    this->dataPtr->periodicChangedComponents.insert(*iter);
-    this->dataPtr->oneTimeChangedComponents.erase(*iter);
+    this->dataPtr->periodicChangedComponents.insert(typeIter->second);
+    this->dataPtr->oneTimeChangedComponents.erase(typeIter->second);
   }
   else if (_c == ComponentState::OneTimeChange)
   {
-    this->dataPtr->periodicChangedComponents.erase(*iter);
-    this->dataPtr->oneTimeChangedComponents.insert(*iter);
+    this->dataPtr->periodicChangedComponents.erase(typeIter->second);
+    this->dataPtr->oneTimeChangedComponents.insert(typeIter->second);
   }
   else
   {
-    this->dataPtr->periodicChangedComponents.erase(*iter);
-    this->dataPtr->oneTimeChangedComponents.erase(*iter);
+    this->dataPtr->periodicChangedComponents.erase(typeIter->second);
+    this->dataPtr->oneTimeChangedComponents.erase(typeIter->second);
   }
 }
 

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -15,6 +15,10 @@
  *
  */
 
+#include "LevelManager.hh"
+
+#include <algorithm>
+
 #include <sdf/Actor.hh>
 #include <sdf/Atmosphere.hh>
 #include <sdf/Light.hh>
@@ -50,7 +54,6 @@
 #include "ignition/gazebo/components/Wind.hh"
 #include "ignition/gazebo/components/World.hh"
 
-#include "LevelManager.hh"
 #include "SimulationRunner.hh"
 
 using namespace ignition;

--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -14,7 +14,11 @@
  * limitations under the License.
  *
  */
+
+#include "SdfGenerator.hh"
+
 #include <memory>
+#include <vector>
 
 #include <sdf/sdf.hh>
 
@@ -29,7 +33,6 @@
 #include "ignition/gazebo/components/SourceFilePath.hh"
 #include "ignition/gazebo/components/World.hh"
 
-#include "SdfGenerator.hh"
 
 namespace ignition
 {
@@ -346,7 +349,7 @@ namespace sdf_generator
               // https://example.org/1.0/test/models/Backpack
               // the path to the directory containing the sdf file (modelDir)
               // will be:
-              // $HOME/.ignition/fuel/example.org/test/models/Backpack/1/
+              // $HOME/.ignition/fuel/example.org/test/models/Backpack/2/
               // and the basename of the directory is "1", which is the model
               // version.
               //

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -543,13 +543,13 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1";
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {
       // Thes following two URIs are valid, but have a trailing '/'
       "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/",
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1/",
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2/",
       // Thes following two URIs are invalid, and will not be saved
       "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/"
       "notInt",

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -17,6 +17,8 @@
 
 #include "SimulationRunner.hh"
 
+#include <algorithm>
+
 #include "ignition/common/Profiler.hh"
 
 #include "ignition/gazebo/components/Model.hh"

--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -131,14 +131,20 @@ COMMANDS = { 'gazebo' =>
   "  --render-engine [arg]        Ignition Rendering engine plugin to load for     \n"\
   "                               both the server and the GUI. Gazebo will use     \n"\
   "                               OGRE2 by default. (ogre2)                        \n"\
+  "                               Make sure custom plugins are in                  \n"\
+  "                               IGN_GAZEBO_RENDER_ENGINE_PATH.                   \n"\
   "\n"\
   "  --render-engine-gui [arg]    Ignition Rendering engine plugin to load for     \n"\
   "                               the GUI. Gazebo will use OGRE2 by default.       \n"\
   "                               (ogre2)                                          \n"\
+  "                               Make sure custom plugins are in                  \n"\
+  "                               IGN_GAZEBO_RENDER_ENGINE_PATH.                   \n"\
   "\n"\
   "  --render-engine-server [arg] Ignition Rendering engine plugin to load for     \n"\
   "                               the server. Gazebo will use OGRE2 by default.    \n"\
   "                               (ogre2)                                          \n"\
+  "                               Make sure custom plugins are in                  \n"\
+  "                               IGN_GAZEBO_RENDER_ENGINE_PATH.                   \n"\
   "\n"\
   "  --version                    Print Gazebo version information.                \n"\
   "\n"\

--- a/src/gui/PathManager.cc
+++ b/src/gui/PathManager.cc
@@ -15,14 +15,18 @@
  *
  */
 
+#include "PathManager.hh"
+
 #include <ignition/msgs/sdf_generator_config.pb.h>
+
+#include <string>
+#include <vector>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
 
 #include "ignition/gazebo/Util.hh"
-#include "PathManager.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/gui/PathManager.hh
+++ b/src/gui/PathManager.hh
@@ -22,6 +22,7 @@
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/config.hh"
 
 namespace ignition
 {

--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -15,7 +15,11 @@
  *
 */
 
+#include "EntityTree.hh"
+
 #include <iostream>
+#include <vector>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
@@ -37,8 +41,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "EntityTree.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/grid_config/GridConfig.cc
+++ b/src/gui/plugins/grid_config/GridConfig.cc
@@ -125,11 +125,22 @@ void GridConfig::UpdateGrid()
     visual->SetLocalPose(this->dataPtr->gridParam.pose);
 
     auto mat = visual->Material();
-    mat->SetAmbient(this->dataPtr->gridParam.color);
-    mat->SetDiffuse(this->dataPtr->gridParam.color);
-    mat->SetSpecular(this->dataPtr->gridParam.color);
+    if (mat)
+    {
+      mat->SetAmbient(this->dataPtr->gridParam.color);
+      mat->SetDiffuse(this->dataPtr->gridParam.color);
+      mat->SetSpecular(this->dataPtr->gridParam.color);
+    }
+    else
+    {
+      ignerr << "Grid visual missing material" << std::endl;
+    }
 
     visual->SetVisible(this->dataPtr->gridParam.visible);
+  }
+  else
+  {
+    ignerr << "Grid missing parent visual" << std::endl;
   }
 
   this->dataPtr->dirty = false;
@@ -170,7 +181,7 @@ void GridConfig::LoadGrid()
     return;
   }
 
-  if (!scene->IsInitialized() || scene->VisualCount() == 0)
+  if (!scene->IsInitialized() || nullptr == scene->RootVisual())
   {
     return;
   }
@@ -231,6 +242,7 @@ void GridConfig::LoadGrid()
   mat->SetAmbient(this->dataPtr->gridParam.color);
   mat->SetDiffuse(this->dataPtr->gridParam.color);
   mat->SetSpecular(this->dataPtr->gridParam.color);
+  vis->SetMaterial(mat);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -14,18 +14,21 @@
  * limitations under the License.
  *
 */
+
+#include "EntityContextMenu.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 #include <ignition/msgs/entity.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gazebo/gui/GuiRunner.hh>
 #include <ignition/gazebo/Conversions.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/transport/Node.hh>
-
-#include "EntityContextMenu.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/playback_scrubber/PlaybackScrubber.cc
+++ b/src/gui/plugins/playback_scrubber/PlaybackScrubber.cc
@@ -14,14 +14,21 @@
  * limitations under the License.
  *
 */
+
+#include "PlaybackScrubber.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
-#include <ignition/math/Helpers.hh>
 
 #include <chrono>
 #include <ctime>
 #include <iostream>
 #include <regex>
+#include <string>
+#include <utility>
+
+#include <ignition/math/Helpers.hh>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/Helpers.hh>
@@ -34,8 +41,6 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "PlaybackScrubber.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -15,8 +15,13 @@
  *
  */
 
+#include "ResourceSpawner.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
+
+#include <set>
+#include <unordered_map>
 
 #include <sdf/Root.hh>
 #include <sdf/parser.hh>
@@ -32,12 +37,8 @@
 #include <ignition/fuel_tools/FuelClient.hh>
 #include <ignition/fuel_tools/ClientConfig.hh>
 
-#include <set>
-
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "ResourceSpawner.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.qml
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.qml
@@ -344,6 +344,7 @@ Rectangle {
               anchors.fill: parent
               topPadding: 8
               leftPadding: 5
+              selectByMouse: true
               color: Material.theme == Material.Light ? "black" : "white"
               onTextEdited: {
                 ResourceSpawner.OnSearchEntered(searchField.text);

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -15,10 +15,15 @@
  *
 */
 
+#include "Scene3D.hh"
+
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sdf/Link.hh>
@@ -59,8 +64,6 @@
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 #include "ignition/gazebo/rendering/RenderUtil.hh"
-
-#include "Scene3D.hh"
 
 Q_DECLARE_METATYPE(std::string)
 
@@ -405,6 +408,14 @@ RenderUtil *IgnRenderer::RenderUtil() const
 /////////////////////////////////////////////////
 void IgnRenderer::Render()
 {
+  rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
+  if (!scene)
+  {
+    ignwarn << "Scene is null. The render step will not occur in Scene3D."
+      << std::endl;
+    return;
+  }
+
   this->dataPtr->renderThreadId = std::this_thread::get_id();
 
   IGN_PROFILE_THREAD_NAME("RenderThread");
@@ -440,7 +451,6 @@ void IgnRenderer::Render()
   // reset follow mode if target node got removed
   if (!this->dataPtr->followTarget.empty())
   {
-    rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
     rendering::NodePtr target = scene->NodeByName(this->dataPtr->followTarget);
     if (!target && !this->dataPtr->followTargetWait)
     {
@@ -498,7 +508,6 @@ void IgnRenderer::Render()
     {
       if (this->dataPtr->moveToHelper.Idle())
       {
-        rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
         rendering::NodePtr target = scene->NodeByName(
             this->dataPtr->moveToTarget);
         if (target)
@@ -554,7 +563,6 @@ void IgnRenderer::Render()
     rendering::NodePtr followTarget = this->dataPtr->camera->FollowTarget();
     if (!this->dataPtr->followTarget.empty())
     {
-      rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
       rendering::NodePtr target = scene->NodeByName(
           this->dataPtr->followTarget);
       if (target)
@@ -645,7 +653,6 @@ void IgnRenderer::Render()
     if (this->dataPtr->isSpawning)
     {
       // Generate spawn preview
-      rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
       rendering::VisualPtr rootVis = scene->RootVisual();
       sdf::Root root;
       if (!this->dataPtr->spawnSdfString.empty())
@@ -1466,6 +1473,9 @@ void IgnRenderer::Initialize()
   this->dataPtr->renderUtil.Init();
 
   rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
+  if (!scene)
+    return;
+
   auto root = scene->RootVisual();
 
   // Camera
@@ -1497,6 +1507,7 @@ void IgnRenderer::Destroy()
   auto scene = engine->SceneByName(this->dataPtr->renderUtil.SceneName());
   if (!scene)
     return;
+
   scene->DestroySensor(this->dataPtr->camera);
 
   // If that was the last sensor, destroy scene

--- a/src/gui/plugins/shapes/Shapes.cc
+++ b/src/gui/plugins/shapes/Shapes.cc
@@ -14,10 +14,16 @@
  * limitations under the License.
  *
 */
+
+#include "Shapes.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
+#include <algorithm>
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
@@ -27,8 +33,6 @@
 
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "Shapes.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -14,10 +14,15 @@
  * limitations under the License.
  *
 */
+
+#include "TransformControl.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
@@ -36,8 +41,6 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
-
-#include "TransformControl.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/video_recorder/VideoRecorder.cc
+++ b/src/gui/plugins/video_recorder/VideoRecorder.cc
@@ -14,10 +14,15 @@
  * limitations under the License.
  *
 */
+
+#include "VideoRecorder.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/video_record.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/gui/Application.hh>
@@ -28,8 +33,6 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
-
-#include "VideoRecorder.hh"
 
 namespace ignition::gazebo
 {

--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -14,15 +14,18 @@
  * limitations under the License.
  *
 */
+
+#include "ViewAngle.hh"
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/vector3d.pb.h>
 
 #include <iostream>
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
-
-#include "ViewAngle.hh"
 
 namespace ignition::gazebo
 {

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -14,7 +14,13 @@
  * limitations under the License.
  *
 */
+
+#include "ign.hh"
+
 #include <cstring>
+#include <string>
+#include <vector>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/fuel_tools/FuelClient.hh>
@@ -27,7 +33,6 @@
 #include "ignition/gazebo/ServerConfig.hh"
 
 #include "ignition/gazebo/gui/Gui.hh"
-#include "ign.hh"
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GAZEBO_VISIBLE char *ignitionGazeboVersion()

--- a/src/network/NetworkManagerPrimary.cc
+++ b/src/network/NetworkManagerPrimary.cc
@@ -15,8 +15,12 @@
  *
 */
 
+#include "NetworkManagerPrimary.hh"
+
 #include <algorithm>
+#include <set>
 #include <string>
+#include <utility>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
@@ -32,7 +36,6 @@
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Events.hh"
 
-#include "NetworkManagerPrimary.hh"
 #include "NetworkManagerPrivate.hh"
 #include "PeerTracker.hh"
 

--- a/src/network/PeerTracker.cc
+++ b/src/network/PeerTracker.cc
@@ -16,6 +16,9 @@
 */
 #include "PeerTracker.hh"
 
+#include <algorithm>
+#include <utility>
+
 using namespace ignition;
 using namespace gazebo;
 

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1210,6 +1210,10 @@ void RenderUtilPrivate::RemoveRenderingEntities(
 /////////////////////////////////////////////////
 void RenderUtil::Init()
 {
+  ignition::common::SystemPaths pluginPath;
+  pluginPath.SetPluginPathEnv(kRenderPluginPathEnv);
+  rendering::setPluginPaths(pluginPath.PluginPaths());
+
   std::map<std::string, std::string> params;
   if (this->dataPtr->useCurrentGLContext)
     params["useCurrentGLContext"] = "1";
@@ -1229,8 +1233,11 @@ void RenderUtil::Init()
     igndbg << "Create scene [" << this->dataPtr->sceneName << "]" << std::endl;
     this->dataPtr->scene =
         this->dataPtr->engine->CreateScene(this->dataPtr->sceneName);
-    this->dataPtr->scene->SetAmbientLight(this->dataPtr->ambientLight);
-    this->dataPtr->scene->SetBackgroundColor(this->dataPtr->backgroundColor);
+    if (this->dataPtr->scene)
+    {
+      this->dataPtr->scene->SetAmbientLight(this->dataPtr->ambientLight);
+      this->dataPtr->scene->SetBackgroundColor(this->dataPtr->backgroundColor);
+    }
   }
   this->dataPtr->sceneManager.SetScene(this->dataPtr->scene);
   if (this->dataPtr->enableSensors)
@@ -1253,6 +1260,9 @@ void RenderUtil::SetAmbientLight(const math::Color &_ambient)
 /////////////////////////////////////////////////
 void RenderUtil::ShowGrid()
 {
+  if (!this->dataPtr->scene)
+    return;
+
   rendering::VisualPtr root = this->dataPtr->scene->RootVisual();
 
   // create gray material

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -124,6 +124,9 @@ Entity SceneManager::WorldId() const
 rendering::VisualPtr SceneManager::CreateModel(Entity _id,
     const sdf::Model &_model, Entity _parentId)
 {
+  if (!this->dataPtr->scene)
+    return rendering::VisualPtr();
+
   if (this->dataPtr->visuals.find(_id) != this->dataPtr->visuals.end())
   {
     ignerr << "Entity with Id: [" << _id << "] already exists in the scene"
@@ -176,6 +179,9 @@ rendering::VisualPtr SceneManager::CreateModel(Entity _id,
 rendering::VisualPtr SceneManager::CreateLink(Entity _id,
     const sdf::Link &_link, Entity _parentId)
 {
+  if (!this->dataPtr->scene)
+    return rendering::VisualPtr();
+
   if (this->dataPtr->visuals.find(_id) != this->dataPtr->visuals.end())
   {
     ignerr << "Entity with Id: [" << _id << "] already exists in the scene"
@@ -217,6 +223,9 @@ rendering::VisualPtr SceneManager::CreateLink(Entity _id,
 rendering::VisualPtr SceneManager::CreateVisual(Entity _id,
     const sdf::Visual &_visual, Entity _parentId)
 {
+  if (!this->dataPtr->scene)
+    return rendering::VisualPtr();
+
   if (this->dataPtr->visuals.find(_id) != this->dataPtr->visuals.end())
   {
     ignerr << "Entity with Id: [" << _id << "] already exists in the scene"
@@ -350,6 +359,9 @@ rendering::VisualPtr SceneManager::CreateVisual(Entity _id,
 rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
     math::Vector3d &_scale, math::Pose3d &_localPose)
 {
+  if (!this->dataPtr->scene)
+    return rendering::GeometryPtr();
+
   math::Vector3d scale = math::Vector3d::One;
   math::Pose3d localPose = math::Pose3d::Zero;
   rendering::GeometryPtr geom{nullptr};
@@ -419,6 +431,9 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
 rendering::MaterialPtr SceneManager::LoadMaterial(
     const sdf::Material &_material)
 {
+  if (!this->dataPtr->scene)
+    return rendering::MaterialPtr();
+
   rendering::MaterialPtr material = this->dataPtr->scene->CreateMaterial();
   material->SetAmbient(_material.Ambient());
   material->SetDiffuse(_material.Diffuse());
@@ -524,6 +539,9 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
 rendering::VisualPtr SceneManager::CreateActor(Entity _id,
     const sdf::Actor &_actor, Entity _parentId)
 {
+  if (!this->dataPtr->scene)
+    return rendering::VisualPtr();
+
   // creating an actor needs to create the visual and the mesh
   // the visual is stored in: this->dataPtr->visuals
   // the mesh is stored in: this->dataPtr->actors
@@ -827,6 +845,9 @@ rendering::VisualPtr SceneManager::CreateActor(Entity _id,
 rendering::LightPtr SceneManager::CreateLight(Entity _id,
     const sdf::Light &_light, Entity _parentId)
 {
+  if (!this->dataPtr->scene)
+    return rendering::LightPtr();
+
   if (this->dataPtr->lights.find(_id) != this->dataPtr->lights.end())
   {
     ignerr << "Light with Id: [" << _id << "] already exists in the scene"
@@ -906,6 +927,9 @@ rendering::LightPtr SceneManager::CreateLight(Entity _id,
 bool SceneManager::AddSensor(Entity _gazeboId, const std::string &_sensorName,
     Entity _parentGazeboId)
 {
+  if (!this->dataPtr->scene)
+    return false;
+
   if (this->dataPtr->sensors.find(_gazeboId) != this->dataPtr->sensors.end())
   {
     ignerr << "Sensor for entity [" << _gazeboId
@@ -1174,6 +1198,9 @@ std::map<std::string, math::Matrix4d> SceneManager::ActorSkeletonTransformsAt(
 /////////////////////////////////////////////////
 void SceneManager::RemoveEntity(Entity _id)
 {
+  if (!this->dataPtr->scene)
+    return;
+
   {
     auto it = this->dataPtr->visuals.find(_id);
     if (it != this->dataPtr->visuals.end())
@@ -1218,6 +1245,9 @@ rendering::VisualPtr SceneManager::TopLevelVisual(
 rendering::NodePtr SceneManager::TopLevelNode(
     const rendering::NodePtr &_node) const
 {
+  if (!this->dataPtr->scene)
+    return rendering::NodePtr();
+
   rendering::NodePtr rootNode =
       this->dataPtr->scene->RootVisual();
 

--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -14,7 +14,14 @@
  * limitations under the License.
  *
  */
+
+#include "AirPressure.hh"
+
 #include <ignition/msgs/air_pressure_sensor.pb.h>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <ignition/plugin/Register.hh>
 
@@ -34,8 +41,6 @@
 #include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "AirPressure.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -15,7 +15,13 @@
  *
  */
 
+#include "Altimeter.hh"
+
 #include <ignition/msgs/altimeter.pb.h>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -37,8 +43,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "Altimeter.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/apply_joint_force/ApplyJointForce.cc
+++ b/src/systems/apply_joint_force/ApplyJointForce.cc
@@ -14,14 +14,17 @@
  * limitations under the License.
  *
  */
+
+#include "ApplyJointForce.hh"
+
+#include <string>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "ApplyJointForce.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -15,13 +15,17 @@
  *
  */
 
+#include "LinearBatteryPlugin.hh"
+
 #include <ignition/msgs/battery_state.pb.h>
 #include <ignition/msgs/boolean.pb.h>
 
 #include <algorithm>
 #include <atomic>
+#include <deque>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include <ignition/common/Battery.hh>
 #include <ignition/common/Profiler.hh>
@@ -43,8 +47,6 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "LinearBatteryPlugin.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/breadcrumbs/Breadcrumbs.hh
+++ b/src/systems/breadcrumbs/Breadcrumbs.hh
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <sdf/Element.hh>
+#include <sdf/Geometry.hh>
 #include <sdf/Root.hh>
 
 #include <ignition/transport/Node.hh>

--- a/src/systems/contact/Contact.cc
+++ b/src/systems/contact/Contact.cc
@@ -15,11 +15,15 @@
  *
  */
 
+#include "Contact.hh"
 
 #include <ignition/msgs/contact.pb.h>
 #include <ignition/msgs/contacts.pb.h>
 
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -37,8 +41,6 @@
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
-
-#include "Contact.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -14,9 +14,15 @@
  * limitations under the License.
  *
  */
+
+#include "DiffDrive.hh"
+
 #include <ignition/msgs/odometry.pb.h>
 
+#include <limits>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/DiffDriveOdometry.hh>
@@ -30,7 +36,6 @@
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
 
-#include "DiffDrive.hh"
 #include "SpeedLimiter.hh"
 
 using namespace ignition;

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -15,6 +15,12 @@
  *
  */
 
+#include "Imu.hh"
+
+#include <unordered_map>
+#include <utility>
+#include <string>
+
 #include <ignition/plugin/Register.hh>
 
 #include <sdf/Element.hh>
@@ -37,8 +43,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "Imu.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -15,7 +15,12 @@
  *
  */
 
+#include "JointController.hh"
+
 #include <ignition/msgs/double.pb.h>
+
+#include <string>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/PID.hh>
 #include <ignition/plugin/Register.hh>
@@ -25,8 +30,6 @@
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/JointVelocityCmd.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "JointController.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -15,7 +15,12 @@
  *
  */
 
+#include "JointPositionController.hh"
+
 #include <ignition/msgs/double.pb.h>
+
+#include <string>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/PID.hh>
 #include <ignition/plugin/Register.hh>
@@ -24,8 +29,6 @@
 #include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/components/JointPosition.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "JointPositionController.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -15,7 +15,13 @@
  *
  */
 
+#include "JointStatePublisher.hh"
+
 #include <ignition/msgs/model.pb.h>
+
+#include <string>
+#include <vector>
+
 #include <ignition/plugin/Register.hh>
 
 #include "ignition/gazebo/components/Name.hh"
@@ -25,7 +31,6 @@
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Pose.hh"
-#include "JointStatePublisher.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -15,7 +15,10 @@
  *
  */
 
+#include "LiftDrag.hh"
+
 #include <algorithm>
+#include <string>
 #include <vector>
 
 #include <ignition/common/Profiler.hh>
@@ -36,8 +39,6 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ExternalWorldWrenchCmd.hh"
 #include "ignition/gazebo/components/Pose.hh"
-
-#include "LiftDrag.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/log/LogPlayback.cc
+++ b/src/systems/log/LogPlayback.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/pose_v.pb.h>
 #include <ignition/msgs/log_playback_stats.pb.h>
 
+#include <set>
 #include <string>
 #include <unordered_map>
 

--- a/src/systems/log_video_recorder/LogVideoRecorder.cc
+++ b/src/systems/log_video_recorder/LogVideoRecorder.cc
@@ -15,10 +15,14 @@
  *
 */
 
+#include "LogVideoRecorder.hh"
+
 #include <ignition/msgs/scene.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
 #include <chrono>
+#include <set>
+#include <string>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/AxisAlignedBox.hh>
@@ -33,8 +37,6 @@
 #include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Events.hh"
-
-#include "LogVideoRecorder.hh"
 
 using namespace std::chrono_literals;
 

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -15,7 +15,14 @@
  *
  */
 
+#include "LogicalCamera.hh"
+
 #include <ignition/msgs/logical_camera_image.pb.h>
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -37,8 +44,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "LogicalCamera.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -15,6 +15,12 @@
  *
  */
 
+#include "Magnetometer.hh"
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include <ignition/plugin/Register.hh>
 
 #include <sdf/Sensor.hh>
@@ -35,8 +41,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "Magnetometer.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/multicopter_control/Common.cc
+++ b/src/systems/multicopter_control/Common.cc
@@ -15,6 +15,10 @@
  *
  */
 
+#include "Common.hh"
+
+#include <string>
+
 #include <ignition/common/Console.hh>
 #include <ignition/math/eigen3/Conversions.hh>
 
@@ -27,8 +31,6 @@
 #include <ignition/gazebo/components/Pose.hh>
 #include "ignition/gazebo/components/LinearVelocity.hh"
 #include "ignition/gazebo/components/AngularVelocity.hh"
-
-#include "Common.hh"
 
 namespace ignition
 {

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -20,7 +20,11 @@
  * limitations under the License.
  *
  */
+
+#include "MulticopterMotorModel.hh"
+
 #include <mutex>
+#include <string>
 
 #include <ignition/common/Profiler.hh>
 
@@ -45,8 +49,6 @@
 #include "ignition/gazebo/components/Wind.hh"
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
-
-#include "MulticopterMotorModel.hh"
 
 // from rotors_gazebo_plugins/include/rotors_gazebo_plugins/common.h
 /// \brief    This class can be used to apply a first order filter on a signal.

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -15,14 +15,19 @@
  *
  */
 
+#include "Physics.hh"
+
 #include <ignition/msgs/contact.pb.h>
 #include <ignition/msgs/contacts.pb.h>
 #include <ignition/msgs/entity.pb.h>
 #include <ignition/msgs/Utility.hh>
 
+#include <algorithm>
 #include <iostream>
 #include <deque>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <ignition/common/MeshManager.hh>
 #include <ignition/common/Profiler.hh>
@@ -33,34 +38,11 @@
 #include <ignition/physics/config.hh>
 #include <ignition/physics/FeatureList.hh>
 #include <ignition/physics/FeaturePolicy.hh>
-#include <ignition/physics/FindFeatures.hh>
 #include <ignition/physics/RelativeQuantity.hh>
 #include <ignition/physics/RequestEngine.hh>
 #include <ignition/plugin/Loader.hh>
 #include <ignition/plugin/PluginPtr.hh>
 #include <ignition/plugin/Register.hh>
-
-// Features
-#include <ignition/physics/BoxShape.hh>
-#include <ignition/physics/CylinderShape.hh>
-#include <ignition/physics/ForwardStep.hh>
-#include <ignition/physics/FrameSemantics.hh>
-#include <ignition/physics/FreeGroup.hh>
-#include <ignition/physics/FixedJoint.hh>
-#include <ignition/physics/GetContacts.hh>
-#include <ignition/physics/GetBoundingBox.hh>
-#include <ignition/physics/Joint.hh>
-#include <ignition/physics/Link.hh>
-#include <ignition/physics/RemoveEntities.hh>
-#include <ignition/physics/Shape.hh>
-#include <ignition/physics/SphereShape.hh>
-#include <ignition/physics/mesh/MeshShape.hh>
-#include <ignition/physics/sdf/ConstructCollision.hh>
-#include <ignition/physics/sdf/ConstructJoint.hh>
-#include <ignition/physics/sdf/ConstructLink.hh>
-#include <ignition/physics/sdf/ConstructModel.hh>
-#include <ignition/physics/sdf/ConstructNestedModel.hh>
-#include <ignition/physics/sdf/ConstructWorld.hh>
 
 // SDF
 #include <sdf/Collision.hh>
@@ -114,8 +96,6 @@
 #include "ignition/gazebo/components/Static.hh"
 #include "ignition/gazebo/components/ThreadPitch.hh"
 #include "ignition/gazebo/components/World.hh"
-
-#include "Physics.hh"
 
 using namespace ignition;
 using namespace ignition::gazebo::systems;

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -20,7 +20,30 @@
 #include <memory>
 #include <unordered_map>
 #include <utility>
+#include <ignition/physics/FindFeatures.hh>
 #include <ignition/physics/RequestFeatures.hh>
+
+// Features need to be defined ahead of entityCast
+#include <ignition/physics/BoxShape.hh>
+#include <ignition/physics/CylinderShape.hh>
+#include <ignition/physics/ForwardStep.hh>
+#include <ignition/physics/FrameSemantics.hh>
+#include <ignition/physics/FreeGroup.hh>
+#include <ignition/physics/FixedJoint.hh>
+#include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/GetBoundingBox.hh>
+#include <ignition/physics/Joint.hh>
+#include <ignition/physics/Link.hh>
+#include <ignition/physics/RemoveEntities.hh>
+#include <ignition/physics/Shape.hh>
+#include <ignition/physics/SphereShape.hh>
+#include <ignition/physics/mesh/MeshShape.hh>
+#include <ignition/physics/sdf/ConstructCollision.hh>
+#include <ignition/physics/sdf/ConstructJoint.hh>
+#include <ignition/physics/sdf/ConstructLink.hh>
+#include <ignition/physics/sdf/ConstructModel.hh>
+#include <ignition/physics/sdf/ConstructNestedModel.hh>
+#include <ignition/physics/sdf/ConstructWorld.hh>
 
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Export.hh>

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -15,9 +15,15 @@
  *
  */
 
+#include "PosePublisher.hh"
+
 #include <ignition/msgs/pose.pb.h>
 
 #include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <sdf/Joint.hh>
@@ -43,7 +49,6 @@
 #include "ignition/gazebo/components/Visual.hh"
 #include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/Model.hh"
-#include "PosePublisher.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -15,10 +15,13 @@
  *
 */
 
+#include "SceneBroadcaster.hh"
+
 #include <ignition/msgs/scene.pb.h>
 
 #include <chrono>
 #include <condition_variable>
+#include <string>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/graph/Graph.hh>
@@ -39,8 +42,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
-
-#include "SceneBroadcaster.hh"
 
 using namespace std::chrono_literals;
 

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -15,7 +15,12 @@
  *
  */
 
+#include "Sensors.hh"
+
+#include <map>
 #include <set>
+#include <utility>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
@@ -43,8 +48,6 @@
 
 #include "ignition/gazebo/rendering/Events.hh"
 #include "ignition/gazebo/rendering/RenderUtil.hh"
-
-#include "Sensors.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -207,6 +210,9 @@ void SensorsPrivate::RunOnce()
   });
 
   if (!this->running)
+    return;
+
+  if (!this->scene)
     return;
 
   IGN_PROFILE("SensorsPrivate::RunOnce");

--- a/src/systems/sensors/Sensors.hh
+++ b/src/systems/sensors/Sensors.hh
@@ -19,9 +19,11 @@
 
 #include <memory>
 #include <string>
+
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Export.hh>
 #include <ignition/gazebo/System.hh>
+#include <sdf/Sensor.hh>
 
 namespace ignition
 {

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -15,8 +15,11 @@
  *
  */
 
+#include "TouchPlugin.hh"
+
 #include <algorithm>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <ignition/common/Profiler.hh>
@@ -34,8 +37,6 @@
 
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/Util.hh"
-
-#include "TouchPlugin.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -15,14 +15,17 @@
  *
  */
 
+#include "TriggeredPublisher.hh"
+
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
+
+#include <limits>
+#include <utility>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/plugin/Register.hh>
-
-#include "TriggeredPublisher.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -15,10 +15,17 @@
  *
  */
 
+#include "UserCommands.hh"
+
 #include <google/protobuf/message.h>
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/entity_factory.pb.h>
 #include <ignition/msgs/pose.pb.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <ignition/msgs/Utility.hh>
 
 #include <sdf/Root.hh>
@@ -38,8 +45,6 @@
 #include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
-
-#include "UserCommands.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/wheel_slip/WheelSlip.cc
+++ b/src/systems/wheel_slip/WheelSlip.cc
@@ -15,6 +15,12 @@
  *
  */
 
+#include "WheelSlip.hh"
+
+#include <map>
+#include <string>
+#include <vector>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
@@ -27,8 +33,6 @@
 #include "ignition/gazebo/components/Joint.hh"
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/SlipComplianceCmd.hh"
-
-#include "WheelSlip.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -15,9 +15,14 @@
  *
  */
 
+#include "WindEffects.hh"
+
 #include <google/protobuf/message.h>
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/entity_factory.pb.h>
+
+#include <string>
+#include <vector>
 
 #include <sdf/Root.hh>
 #include <sdf/Error.hh>
@@ -43,8 +48,6 @@
 #include "ignition/gazebo/components/WindMode.hh"
 
 #include "ignition/gazebo/Link.hh"
-
-#include "WindEffects.hh"
 
 using namespace ignition;
 using namespace gazebo;

--- a/test/worlds/breadcrumbs_levels.sdf
+++ b/test/worlds/breadcrumbs_levels.sdf
@@ -1,0 +1,120 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="breadcrumbs_levels">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="libignition-gazebo-physics-system.so"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-user-commands-system.so"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-scene-broadcaster-system.so"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <model name="tile_1">
+      <pose>0 0 0.1 0 0 0</pose>
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>10 10 0.2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>10 10 0.2</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.0 0.8 0.0 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+      <plugin filename="libignition-gazebo-breadcrumbs-system.so" name="ignition::gazebo::systems::Breadcrumbs">
+       <max_deployments>3</max_deployments>
+       <disable_physics_time>15</disable_physics_time>
+       <allow_renaming>true</allow_renaming>
+       <breadcrumb>
+         <sdf version="1.6">
+          <model name="B1">
+            <pose>0 0 5 0 0 0</pose>
+            <link name='body'>
+              <visual name='visual'>
+                <geometry>
+                  <box>
+                    <size>0.3 0.3 0.5</size>
+                  </box>
+                </geometry>
+              </visual>
+              <collision name='collision'>
+                <geometry>
+                  <box>
+                    <size>0.3 0.3 0.5</size>
+                  </box>
+                </geometry>
+              </collision>
+            </link>
+          </model>
+        </sdf>
+       </breadcrumb>
+      </plugin>
+    </model>
+
+    <model name="sphere">
+      <pose>0 0 2 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>1.0</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="sphere_visual">
+          <geometry>
+            <sphere>
+              <radius>1.0</radius>
+            </sphere>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+    <plugin name="ignition::gazebo" filename="dummy">
+      <performer name="perf1">
+        <ref>sphere</ref>
+        <geometry>
+          <box>
+            <size>4 4 2</size>
+          </box>
+        </geometry>
+      </performer>
+      <level name="level1">
+        <pose>0 0 2.5 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>10 10 10</size>
+          </box>
+        </geometry>
+        <buffer>2</buffer>
+        <ref>tile_1</ref>
+      </level>
+    </plugin>
+  </world>
+</sdf>
+
+

--- a/test/worlds/save_world.sdf
+++ b/test/worlds/save_world.sdf
@@ -30,7 +30,7 @@
       <pose>1 2 3 0.1 0.2 0.3</pose>
     </include>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/1</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2</uri>
       <name>backpack3</name>
       <pose>2 0 0 0.1 0.2 0.3</pose>
     </include>

--- a/tutorials/log.md
+++ b/tutorials/log.md
@@ -99,6 +99,9 @@ directory specified to record:
 
 ### From plugin in SDF
 
+This feature is deprecated and will be removed in Ignition Dome.
+Use the command line argument instead.
+
 Alternatively, playback can be specified in an SDF file. See example file
 `examples/worlds/log_playback.sdf`:
 

--- a/tutorials/log.md
+++ b/tutorials/log.md
@@ -96,35 +96,6 @@ directory specified to record:
 
 `ign gazebo -r -v 4 --playback <path>`
 
-
-### From plugin in SDF
-
-This feature is deprecated and will be removed in Ignition Dome.
-Use the command line argument instead.
-
-Alternatively, playback can be specified in an SDF file. See example file
-`examples/worlds/log_playback.sdf`:
-
-```{.xml}
-<world name="default">
-    ...
-    <plugin
-      filename='ignition-gazebo-log-system'
-      name='ignition::gazebo::systems::LogPlayback'>
-      <path>/tmp/log</path>
-    </plugin>
-    ...
-</world>
-```
-
-\note The physics plugin should not be specified in the SDF. If specified,
-it will be automatically removed so that physics does not clash with the
-recorded poses.
-
-\note If both a world file `<file>` and `--playback <path>` are
-specified, an error is printed. This is not allowed, because the world file
-may be a very different world from the one that was recorded.
-
 ## Known issues
 
 * When using command-line playback there is currently a small caveat.


### PR DESCRIPTION
Forward port `ign-gazebo3` to `ign-gazebo4`.

One thing to note about this forward port is that `examples/worlds/log_playback.sdf` exists in `ign-gazebo3`, but not `ign-gazebo4`. #386 details why this file was removed. Also, is the `examples/worlds/log_playback.sdf` file in `ign-gazebo3` correct, or does that also need to be updated?