### PR TITLE
Switch to async state service request

### DIFF
--- a/examples/worlds/thermal_camera.sdf
+++ b/examples/worlds/thermal_camera.sdf
@@ -23,6 +23,10 @@
       filename="ignition-gazebo-scene-broadcaster-system"
       name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
 
     <gui fullscreen="0">
 

--- a/include/ignition/gazebo/gui/GuiRunner.hh
+++ b/include/ignition/gazebo/gui/GuiRunner.hh
@@ -55,11 +55,9 @@ class IGNITION_GAZEBO_VISIBLE GuiRunner : public QObject
   /// \brief Make a new state request to the server.
   public slots: void RequestState();
 
-  /// \brief Callback for the state service.
+  /// \brief Callback for the async state service.
   /// \param[in] _res Response containing new state.
-  /// \param[in] _result True if successful.
-  private: void OnStateService(const msgs::SerializedStepMap &_res,
-      const bool _result);
+  private: void OnStateAsyncService(const msgs::SerializedStepMap &_res);
 
   /// \brief Callback when a new state is received from the server.
   /// \param[in] _msg New state message.

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -90,6 +90,13 @@ void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
 {
   this->OnState(_res);
 
+  // todo(anyone) store reqSrv string in a member variable and use it here
+  // and in RequestState()
+  std::string id = std::to_string(gui::App()->applicationPid());
+  std::string reqSrv =
+      this->node.Options().NameSpace() + "/" + id + "/state_async";
+  this->node.UnadvertiseSrv(reqSrv);
+
   // Only subscribe to periodic updates after receiving initial state
   if (this->node.SubscribedTopics().empty())
     this->node.Subscribe(this->stateTopic, &GuiRunner::OnState, this);

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -59,7 +59,16 @@ GuiRunner::~GuiRunner() = default;
 /////////////////////////////////////////////////
 void GuiRunner::RequestState()
 {
-  this->node.Request(this->stateTopic, &GuiRunner::OnStateService, this);
+  // set up service for async state response callback
+  std::string id = std::to_string(gui::App()->applicationPid());
+  std::string reqSrv =
+      this->node.Options().NameSpace() + "/" + id + "/state_async";
+  this->node.Advertise(reqSrv, &GuiRunner::OnStateAsyncService, this);
+  ignition::msgs::StringMsg req;
+  req.set_data(reqSrv);
+
+  // send async state request
+  this->node.Request(this->stateTopic + "_async", req);
 }
 
 /////////////////////////////////////////////////
@@ -77,15 +86,8 @@ void GuiRunner::OnPluginAdded(const QString &_objectName)
 }
 
 /////////////////////////////////////////////////
-void GuiRunner::OnStateService(const msgs::SerializedStepMap &_res,
-    const bool _result)
+void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
 {
-  if (!_result)
-  {
-    ignerr << "Service call failed for [" << this->stateTopic << "]"
-           << std::endl;
-    return;
-  }
   this->OnState(_res);
 
   // Only subscribe to periodic updates after receiving initial state

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -702,7 +702,6 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
                   << std::endl;
           return true;
         }
-
         // TODO(anyone) Don't load models unless they have collisions
 
         // Check if parent world / model exists

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -21,8 +21,8 @@
 
 #include <chrono>
 #include <condition_variable>
-#include <set>
 #include <string>
+#include <unordered_set>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/graph/Graph.hh>
@@ -197,7 +197,7 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
   public: bool stateServiceRequest{false};
 
   /// \brief A list of async state requests
-  public: std::set<std::string> stateRequests;
+  public: std::unordered_set<std::string> stateRequests;
 };
 
 //////////////////////////////////////////////////
@@ -306,11 +306,9 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
     // process async state requests
     if (!this->dataPtr->stateRequests.empty())
     {
-      ignition::msgs::SerializedStepMap res;
-      res.CopyFrom(this->dataPtr->stepMsg);
       for (const auto &reqSrv : this->dataPtr->stateRequests)
       {
-        this->dataPtr->node->Request(reqSrv, res);
+        this->dataPtr->node->Request(reqSrv, this->dataPtr->stepMsg);
       }
       this->dataPtr->stateRequests.clear();
     }

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -78,12 +78,7 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
 
   /// \brief Callback for state service - non blocking.
   /// \param[out] _res Response containing the last available full state.
-  /// \return True if successful.
-  // public: bool StateAsyncService(ignition::msgs::Empty &_req);
-  public: void StateAsyncService(
-      // ignition::msgs::Empty &_req, ignition::msgs::Boolean &_res);
-      // ignition::msgs::Empty &_req);
-      const ignition::msgs::StringMsg &_req);
+  public: void StateAsyncService(const ignition::msgs::StringMsg &_req);
 
   /// \brief Updates the scene graph when entities are added
   /// \param[in] _manager The entity component manager

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -397,6 +397,13 @@ TEST_P(SceneBroadcasterTest, State)
     checkMsg(_res, 3);
   };
 
+  // async state request with full state response
+  std::function<void(const msgs::SerializedStepMap &)> cbAsync =
+      [&](const msgs::SerializedStepMap &_res)
+  {
+    checkMsg(_res, 16);
+  };
+
   // The request is blocking even though it's meant to be async, so we spin a
   // thread
   auto request = [&]()
@@ -428,6 +435,24 @@ TEST_P(SceneBroadcasterTest, State)
   // cppcheck-suppress knownConditionTrueFalse
   while (!received && sleep++ < maxSleep)
     IGN_SLEEP_MS(100);
+  EXPECT_TRUE(received);
+
+  // test async state request
+  received = false;
+  std::string reqSrv = "/state_async_callback_test";
+  node.Advertise(reqSrv, cbAsync);
+
+  ignition::msgs::StringMsg req;
+  req.set_data(reqSrv);
+  node.Request("/world/default/state_async", req);
+
+  sleep = 0;
+  while (!received && sleep++ < maxSleep)
+  {
+    // Run server
+    server.Run(true, 1, false);
+    IGN_SLEEP_MS(100);
+  }
   EXPECT_TRUE(received);
 }
 


### PR DESCRIPTION
The scene broadcsater system provides a synchronous state service which blocks until the state is filled in the next iteration. In normal ign gazebo usage this works fine but sometimes causes deadlock when running the [distributed_levels](https://github.com/ignitionrobotics/ign-gazebo/tree/ign-gazebo4/examples/scripts/distributed_levels) demo due to a race condition. This PR adds a new non-blocking async state service in the scene broadcaster system, and switches the GUI to call this async state service instead.

More info:

The NetworkManager classes in distributed simulation rely heavily on ign-transport for synchronizing all secondaries with the primary. The deadlock situation happens when the state service call is invoked while the secondaries are being stepped at the same time by the primary:

1. Primary sends msgs to step all Secondaries
1. A state service request is received by the scene broadcaster system in Primary and blocks until the state service is filled in the next iteration
1. step ack msgs sent back by the Secondaries are never received by the Primary because the ign-transport thread is being blocked.
1. Primary cannot step the simulation without ack msg, which means the scene broadcaster can not fill the state required by the state service call
1. Deadlock! 

Another option is to update the distributed system stepping synchronization strategy - I started with this fix and have a workaround implemented but ultimately I came back to the async fix because I think that it would be good to avoid a blocking service call in general. 

Signed-off-by: Ian Chen <ichen@osrfoundation.org>