### PR TITLE
Update key event handling

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2567,7 +2567,8 @@ bool Scene3D::eventFilter(QObject *_obj, QEvent *_event)
       renderWindow->HandleKeyRelease(keyEvent);
     }
   }
-  else if (_event->type() == ignition::gazebo::gui::events::EntitiesSelected::kType)
+  else if (_event->type() ==
+      ignition::gazebo::gui::events::EntitiesSelected::kType)
   {
     auto selectedEvent =
         reinterpret_cast<gui::events::EntitiesSelected *>(_event);

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2347,6 +2347,8 @@ void Scene3D::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
          << this->dataPtr->cameraPoseTopic << "]" << std::endl;
 
   ignition::gui::App()->findChild<
+      ignition::gui::MainWindow *>()->QuickWindow()->installEventFilter(this);
+  ignition::gui::App()->findChild<
       ignition::gui::MainWindow *>()->installEventFilter(this);
 }
 
@@ -2547,7 +2549,25 @@ void RenderWindowItem::SetScaleSnap(const math::Vector3d &_scale)
 /////////////////////////////////////////////////
 bool Scene3D::eventFilter(QObject *_obj, QEvent *_event)
 {
-  if (_event->type() == ignition::gazebo::gui::events::EntitiesSelected::kType)
+  if (_event->type() == QEvent::KeyPress)
+  {
+    QKeyEvent *keyEvent = static_cast<QKeyEvent*>(_event);
+    if (keyEvent)
+    {
+      auto renderWindow = this->PluginItem()->findChild<RenderWindowItem *>();
+      renderWindow->HandleKeyPress(keyEvent);
+    }
+  }
+  else if (_event->type() == QEvent::KeyRelease)
+  {
+    QKeyEvent *keyEvent = static_cast<QKeyEvent*>(_event);
+    if (keyEvent)
+    {
+      auto renderWindow = this->PluginItem()->findChild<RenderWindowItem *>();
+      renderWindow->HandleKeyRelease(keyEvent);
+    }
+  }
+  else if (_event->type() == ignition::gazebo::gui::events::EntitiesSelected::kType)
   {
     auto selectedEvent =
         reinterpret_cast<gui::events::EntitiesSelected *>(_event);
@@ -2817,13 +2837,13 @@ void RenderWindowItem::wheelEvent(QWheelEvent *_e)
 }
 
 ////////////////////////////////////////////////
-void RenderWindowItem::keyPressEvent(QKeyEvent *_e)
+void RenderWindowItem::HandleKeyPress(QKeyEvent *_e)
 {
   this->dataPtr->renderThread->ignRenderer.HandleKeyPress(_e);
 }
 
 ////////////////////////////////////////////////
-void RenderWindowItem::keyReleaseEvent(QKeyEvent *_e)
+void RenderWindowItem::HandleKeyRelease(QKeyEvent *_e)
 {
   this->dataPtr->renderThread->ignRenderer.HandleKeyRelease(_e);
 

--- a/src/gui/plugins/scene3d/Scene3D.hh
+++ b/src/gui/plugins/scene3d/Scene3D.hh
@@ -599,6 +599,14 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Slot called when thread is ready to be started
     public Q_SLOTS: void Ready();
 
+    /// \brief Handle key press event for snapping
+    /// \param[in] _e The key event to process.
+    public: void HandleKeyPress(QKeyEvent *_e);
+
+    /// \brief Handle key release event for snapping
+    /// \param[in] _e The key event to process.
+    public: void HandleKeyRelease(QKeyEvent *_e);
+
     // Documentation inherited
     protected: void mousePressEvent(QMouseEvent *_e) override;
 
@@ -610,12 +618,6 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 
     // Documentation inherited
     protected: void wheelEvent(QWheelEvent *_e) override;
-
-    // Documentation inherited
-    protected: void keyPressEvent(QKeyEvent *_e) override;
-
-    // Documentation inherited
-    protected: void keyReleaseEvent(QKeyEvent *_e) override;
 
     /// \brief Overrides the paint event to render the render engine
     /// camera view

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -96,6 +96,8 @@ void TransformControl::LoadConfig(const tinyxml2::XMLElement *)
 
   ignition::gui::App()->findChild<ignition::gui::MainWindow *>
       ()->installEventFilter(this);
+  ignition::gui::App()->findChild<ignition::gui::MainWindow *>
+      ()->QuickWindow()->installEventFilter(this);
 }
 
 /////////////////////////////////////////////////
@@ -232,6 +234,23 @@ bool TransformControl::eventFilter(QObject *_obj, QEvent *_event)
       this->dataPtr->snapToGrid = false;
     }
   }
+  else if (_event->type() == QEvent::KeyPress)
+  {
+    QKeyEvent *keyEvent = static_cast<QKeyEvent*>(_event);
+    if (keyEvent->key() == Qt::Key_T)
+    {
+      this->activateTranslate();
+    }
+    else if (keyEvent->key() == Qt::Key_R)
+    {
+      this->activateRotate();
+    }
+    else if (keyEvent->key() == Qt::Key_Escape)
+    {
+      this->activateSelect();
+    }
+  }
+
   return QObject::eventFilter(_obj, _event);
 }
 

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -245,7 +245,11 @@ bool TransformControl::eventFilter(QObject *_obj, QEvent *_event)
     {
       this->activateRotate();
     }
-    else if (keyEvent->key() == Qt::Key_Escape)
+  }
+  else if (_event->type() == QEvent::KeyRelease)
+  {
+    QKeyEvent *keyEvent = static_cast<QKeyEvent*>(_event);
+    if (keyEvent->key() == Qt::Key_Escape)
     {
       this->activateSelect();
     }

--- a/src/gui/plugins/transform_control/TransformControl.hh
+++ b/src/gui/plugins/transform_control/TransformControl.hh
@@ -133,6 +133,15 @@ namespace gazebo
     /// \brief Notify that new snapping values have been set.
     signals: void newSnapValues();
 
+    /// \brief Notify that selection has been activated
+    signals: void activateSelect();
+
+    /// \brief Notify that translation has been activated
+    signals: void activateTranslate();
+
+    /// \brief Notify that rotation has been activated
+    signals: void activateRotate();
+
     /// \internal
     /// \brief Pointer to private data.
     private: std::unique_ptr<TransformControlPrivate> dataPtr;

--- a/src/gui/plugins/transform_control/TransformControl.qml
+++ b/src/gui/plugins/transform_control/TransformControl.qml
@@ -91,25 +91,19 @@ ToolBar {
     onNewSnapValues: updateSnapValues();
   }
 
-  // TODO(anyone) enable scale button when support is added in ign-physics
-  // Shortcut {
-  //   sequence: "S"
-  //   onActivated: activateScale()
-  // }
-
-  Shortcut {
-    sequence: "T"
-    onActivated: activateTranslate()
+  Connections {
+    target: TransformControl
+    onActivateSelect: activateSelect();
   }
 
-  Shortcut {
-    sequence: "R"
-    onActivated: activateRotate()
+  Connections {
+    target: TransformControl
+    onActivateTranslate: activateTranslate();
   }
 
-  Shortcut {
-    sequence: "Esc"
-    onActivated: activateSelect()
+  Connections {
+    target: TransformControl
+    onActivateRotate: activateRotate();
   }
 
   RowLayout {


### PR DESCRIPTION
Updates `Scene3D` so that it doesn't consume key events but rather processes them and passes them on.

Also updates the `Transform Control` plugin so that the key handling is done on the cpp side rather than the usage of `Shortcut`s in qml which automatically consumes any key event matching the shortcut specified.

`keyPressEvent` was removed from `Scene3D.cc` since it is only called when the `Scene3D` is focused.  This leads to finnicky behavior if the user wishes to use a hotkey for something within `Scene3D` or `Transform Control` while having a separate area of the Ignition gui focused.  This PR is basically to say that we should recommend all button processing and handling should occur within `eventFilter` rather than the usage of `Shortcut`s in qml, we should likely outright ban `Shortcut`s from being used.

Note: I tested this out with the `IgnSpinBox`s and the `TextField` and it seems like `eventFilter` still captures the inputs regardless of if the user is typing into a text field.  There's not a specific way to manually "capture" the input key presses in qml so we may have to leave it up to each individual plugin to capture the key press (returning `true` from `eventFilter` after the key event is handled).  It also seems like certain qml structures capture key input under the hood.  In particular, `Entity Tree` uses a `TreeView` which uses the escape key under the hood to deselect any currently selected entities in the tree.  It actually captures the escape key press if there is currently entities being deselected via the escape key.  For that reason, we should also advise for plugins to use the key release event for using the escape key since the `TreeView` captures the key press but not the key release.

Solves https://github.com/ignitionrobotics/ign-gazebo/issues/369

Signed-off-by: John Shepherd <john@openrobotics.org>