### PR TITLE
Use a std::promise/std::future to avoid busy waiting the step ack messages in NetworkManagerPrimary

### DIFF
--- a/src/network/NetworkManagerPrimary.cc
+++ b/src/network/NetworkManagerPrimary.cc
@@ -200,7 +200,8 @@ std::map<std::string, SecondaryControl::Ptr>
 void NetworkManagerPrimary::OnStepAck(const msgs::SerializedStateMap &_msg)
 {
   this->secondaryStates.push_back(_msg);
-  if (this->secondaryStates.size() == this->secondaries.size()) {
+  if (this->secondaryStates.size() == this->secondaries.size())
+  {
     this->secondaryStatesPromise.set_value();
   }
 }
@@ -317,4 +318,3 @@ void NetworkManagerPrimary::SetAffinity(Entity _performer,
   auto newAffinity = components::PerformerAffinity(_secondary);
   this->dataPtr->ecm->CreateComponent(_performer, newAffinity);
 }
-

--- a/src/network/NetworkManagerPrimary.cc
+++ b/src/network/NetworkManagerPrimary.cc
@@ -18,6 +18,7 @@
 #include "NetworkManagerPrimary.hh"
 
 #include <algorithm>
+#include <future>
 #include <set>
 #include <string>
 #include <utility>
@@ -41,6 +42,7 @@
 
 using namespace ignition;
 using namespace gazebo;
+using namespace std::chrono_literals;
 
 //////////////////////////////////////////////////
 NetworkManagerPrimary::NetworkManagerPrimary(
@@ -142,21 +144,17 @@ bool NetworkManagerPrimary::Step(const UpdateInfo &_info)
 
   // Send step to all secondaries
   this->secondaryStates.clear();
+  this->secondaryStatesPromise = std::promise<void>{};
+  auto future = this->secondaryStatesPromise.get_future();
   this->simStepPub.Publish(step);
 
   // Block until all secondaries are done
   {
     IGN_PROFILE("Waiting for secondaries");
 
-    int sleep = 0;
-    int maxSleep = 10 * 1000 * 1000;
-    for (; sleep < maxSleep &&
-       (this->secondaryStates.size() < this->secondaries.size()); ++sleep)
-    {
-      std::this_thread::sleep_for(std::chrono::nanoseconds(1));
-    }
+    auto result = future.wait_for(10s);
 
-    if (sleep == maxSleep)
+    if (std::future_status::ready != result)
     {
       ignerr << "Waited 10 s and got only [" << this->secondaryStates.size()
              << " / " << this->secondaries.size()
@@ -202,6 +200,9 @@ std::map<std::string, SecondaryControl::Ptr>
 void NetworkManagerPrimary::OnStepAck(const msgs::SerializedStateMap &_msg)
 {
   this->secondaryStates.push_back(_msg);
+  if (this->secondaryStates.size() == this->secondaries.size()) {
+    this->secondaryStatesPromise.set_value();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/network/NetworkManagerPrimary.hh
+++ b/src/network/NetworkManagerPrimary.hh
@@ -18,6 +18,7 @@
 #define IGNITION_GAZEBO_NETWORK_NETWORKMANAGERPRIMARY_HH_
 
 #include <atomic>
+#include <future>
 #include <map>
 #include <memory>
 #include <string>
@@ -117,6 +118,9 @@ namespace ignition
 
       /// \brief Keep track of states received from secondaries.
       private: std::vector<msgs::SerializedStateMap> secondaryStates;
+
+      /// \brief Promise used to notify when all secondaryStates where received.
+      private: std::promise<void> secondaryStatesPromise;
     };
     }
   }  // namespace gazebo


### PR DESCRIPTION
Minimal improvement, mainly intended to get used to the development cycle.

This PR avoids busy waiting in a loop until all `stepAck` messages are received by instead using a std::promise/std::future as a notification mechanism.

I tested this with the `distributed_levels` example, seems to be working fine.
`colcon test` was also run locally, `INTEGRATION_diff_drive_system` and `INTEGRATION_wheel_slip` are failing but seemed unrelated (they also fail when I use `ign-gazebo4` branch).

Note: I don't have push access to the repo, so I'm working from a fork. It would be nice to get access, so I can add reviewers/labels appropriately.

maybe @mjcarroll can take a look