### PR TITLE
Fix tests that use Fuel paths with uppercase letters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ set(IGN_COMMON_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-fuel_tools
-ign_find_package(ignition-fuel_tools4 REQUIRED VERSION 4.1)
+ign_find_package(ignition-fuel_tools4 REQUIRED VERSION 4.3)
 set(IGN_FUEL_TOOLS_VER ${ignition-fuel_tools4_VERSION_MAJOR})
 
 #--------------------------------------

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -1742,8 +1742,8 @@ TEST_F(LogSystemTest, LogResources)
   // Recorded models should exist
   EXPECT_GT(entryCount(recordPath), 2);
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "OpenRobotics",
-      "models", "X2 Config 1")));
+      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      "models", "x2 config 1")));
 
   // Remove artifacts. Recreate new directory
   this->RemoveLogsDir();
@@ -1777,8 +1777,8 @@ TEST_F(LogSystemTest, LogResources)
   EXPECT_GT(entryCount(recordPath), 1);
 #endif
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "OpenRobotics",
-      "models", "X2 Config 1")));
+      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      "models", "x2 config 1")));
 
   // Revert environment variable after test is done
   EXPECT_EQ(setenv(IGN_HOMEDIR, homeOrig.c_str(), 1), 0);

--- a/test/integration/sdf_include.cc
+++ b/test/integration/sdf_include.cc
@@ -38,6 +38,6 @@ TEST(SdfInclude, DownloadFromFuel)
   gazebo::Server server(serverConfig);
 
   EXPECT_TRUE(common::exists(path +
-        "/fuel.ignitionrobotics.org/OpenRobotics/models/ground plane" +
+        "/fuel.ignitionrobotics.org/openrobotics/models/ground plane" +
         "/1/model.sdf"));
 }


### PR DESCRIPTION
As of https://github.com/ignitionrobotics/ign-fuel-tools/pull/130, fuel paths use all lowercase letters. This fixes some tests that had uppercase letters.