### PR TITLE
Codecheck - initialize primitive in LogicalAudio component

### DIFF
--- a/include/ignition/gazebo/components/LogicalAudio.hh
+++ b/include/ignition/gazebo/components/LogicalAudio.hh
@@ -91,7 +91,7 @@ namespace logical_audio
     }
 
     /// \brief Whether the source is currently playing or not
-    bool playing;
+    bool playing{false};
 
     /// \brief How long the source should play for, in seconds.
     /// Setting this to 0 means the source has a play duration of infinity


### PR DESCRIPTION
As described in the title, I'm adding in a default initializer to a component's primitive (from #401) to remove all warnings from codecheck to keep the cleanliness introduced by #499.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>