### PR TITLE
Generate valid topics everywhere (support names with spaces)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(IGN_FUEL_TOOLS_VER ${ignition-fuel_tools5_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-gui
-ign_find_package(ignition-gui4 REQUIRED VERSION 4.1)
+ign_find_package(ignition-gui4 REQUIRED VERSION 4.1.1)
 set(IGN_GUI_VER ${ignition-gui4_VERSION_MAJOR})
 ign_find_package (Qt5
   COMPONENTS

--- a/examples/worlds/spaces.sdf
+++ b/examples/worlds/spaces.sdf
@@ -1,0 +1,108 @@
+<?xml version="1.0" ?>
+<!--
+
+This demo shows that it's possible to have entities with spaces in their names.
+
+-->
+<sdf version="1.6">
+  <world name="world with spaces">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <light type="directional" name="light with spaces">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.8 0.8 0.8 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="model with spaces">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link with spaces">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision with spaces">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="visual with spaces">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/include/ignition/gazebo/Util.hh
+++ b/include/ignition/gazebo/Util.hh
@@ -139,6 +139,21 @@ namespace ignition
         const Entity &_entity,
         const EntityComponentManager &_ecm);
 
+    /// \brief Helper function to generate a valid transport topic, given
+    /// a list of topics ordered by preference. The generated topic will be,
+    /// in this order:
+    ///
+    /// 1. The first topic unchanged, if valid.
+    /// 2. A valid version of the first topic, if possible.
+    /// 3. The second topic unchanged, if valid.
+    /// 4. A valid version of the second topic, if possible.
+    /// 5. ...
+    /// 6. If no valid topics could be generated, return an empty string.
+    ///
+    /// \param[in] _topics Topics ordered by preference.
+    std::string IGNITION_GAZEBO_VISIBLE validTopic(
+        const std::vector<std::string> &_topics);
+
     /// \brief Environment variable holding resource paths.
     const std::string kResourcePathEnv{"IGN_GAZEBO_RESOURCE_PATH"};
 

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -76,8 +76,14 @@ LevelManager::LevelManager(SimulationRunner *_runner, const bool _useLevels)
   this->ReadLevelPerformerInfo();
   this->CreatePerformers();
 
-  std::string service = "/world/";
-  service += this->runner->sdfWorld->Name() + "/level/set_performer";
+  std::string service = transport::TopicUtils::AsValidTopic("/world/" +
+      this->runner->sdfWorld->Name() + "/level/set_performer");
+  if (service.empty())
+  {
+    ignerr << "Failed to generate set_performer topic for world ["
+           << this->runner->sdfWorld->Name() << "]" << std::endl;
+    return;
+  }
   this->node.Advertise(service, &LevelManager::OnSetPerformer, this);
 }
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -157,14 +157,21 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
 
   // World control
   transport::NodeOptions opts;
+  std::string ns{"/world/" + this->worldName};
   if (this->networkMgr)
   {
-    opts.SetNameSpace(this->networkMgr->Namespace() +
-                      "/world/" + this->worldName);
+    ns = this->networkMgr->Namespace() + ns;
+  }
+
+  auto validNs = transport::TopicUtils::AsValidTopic(ns);
+  if (validNs.empty())
+  {
+    ignerr << "Using invalid namespace [" << ns << "]" << std::endl;
+    opts.SetNameSpace(ns);
   }
   else
   {
-    opts.SetNameSpace("/world/" + this->worldName);
+    opts.SetNameSpace(validNs);
   }
 
   this->node = std::make_unique<transport::Node>(opts);

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -166,13 +166,11 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   auto validNs = transport::TopicUtils::AsValidTopic(ns);
   if (validNs.empty())
   {
-    ignerr << "Using invalid namespace [" << ns << "]" << std::endl;
-    opts.SetNameSpace(ns);
+    ignerr << "Invalid namespace [" << ns
+           << "], not initializing runner transport." << std::endl;
+    return;
   }
-  else
-  {
-    opts.SetNameSpace(validNs);
-  }
+  opts.SetNameSpace(validNs);
 
   this->node = std::make_unique<transport::Node>(opts);
 

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -24,6 +24,7 @@
 #endif
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/StringUtils.hh>
+#include <ignition/transport/TopicUtils.hh>
 
 #include "ignition/gazebo/components/Actor.hh"
 #include "ignition/gazebo/components/Collision.hh"
@@ -415,6 +416,27 @@ ignition::gazebo::Entity topLevelModel(const Entity &_entity,
     parentComp = _ecm.Component<components::ParentEntity>(entity);
   }
   return entity;
+}
+
+//////////////////////////////////////////////////
+std::string validTopic(const std::vector<std::string> &_topics)
+{
+  for (const auto &topic : _topics)
+  {
+    auto validTopic = transport::TopicUtils::AsValidTopic(topic);
+    if (validTopic.empty())
+    {
+      ignerr << "Topic [" << topic << "] is invalid, ignoring." << std::endl;
+      continue;
+    }
+    if (validTopic != topic)
+    {
+      igndbg << "Topic [" << topic << "] changed to valid topic ["
+             << validTopic << "]" << std::endl;
+    }
+    return validTopic;
+  }
+  return std::string();
 }
 }
 }

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -16,6 +16,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <ignition/common/Console.hh>
 #include <sdf/Actor.hh>
 #include <sdf/Light.hh>
 
@@ -36,8 +37,16 @@
 using namespace ignition;
 using namespace gazebo;
 
+class UtilTest : public ::testing::Test
+{
+  protected: void SetUp() override
+  {
+    common::Console::SetVerbosity(4);
+  }
+};
+
 /////////////////////////////////////////////////
-TEST(UtilTest, ScopedName)
+TEST_F(UtilTest, ScopedName)
 {
   EntityComponentManager ecm;
 
@@ -219,7 +228,7 @@ TEST(UtilTest, ScopedName)
 }
 
 /////////////////////////////////////////////////
-TEST(UtilTest, EntityTypeId)
+TEST_F(UtilTest, EntityTypeId)
 {
   EntityComponentManager ecm;
 
@@ -264,7 +273,7 @@ TEST(UtilTest, EntityTypeId)
 }
 
 /////////////////////////////////////////////////
-TEST(UtilTest, EntityTypeStr)
+TEST_F(UtilTest, EntityTypeStr)
 {
   EntityComponentManager ecm;
 
@@ -309,7 +318,7 @@ TEST(UtilTest, EntityTypeStr)
 }
 
 /////////////////////////////////////////////////
-TEST(UtilTest, RemoveParentScopedName)
+TEST_F(UtilTest, RemoveParentScopedName)
 {
   EXPECT_EQ(removeParentScope("world/world_name", "/"), "world_name");
   EXPECT_EQ(removeParentScope("world::world_name::light::lightA_name", "::"),
@@ -324,7 +333,7 @@ TEST(UtilTest, RemoveParentScopedName)
 }
 
 /////////////////////////////////////////////////
-TEST(UtilTest, AsFullPath)
+TEST_F(UtilTest, AsFullPath)
 {
   const std::string relativeUriUnix{"meshes/collision.dae"};
   const std::string relativeUriWindows{"meshes\\collision.dae"};
@@ -408,7 +417,7 @@ TEST(UtilTest, AsFullPath)
 }
 
 /////////////////////////////////////////////////
-TEST(UtilTest, TopLevelModel)
+TEST_F(UtilTest, TopLevelModel)
 {
   EntityComponentManager ecm;
 
@@ -462,4 +471,28 @@ TEST(UtilTest, TopLevelModel)
 
   // model C should have itself as the top level entity
   EXPECT_EQ(modelCEntity, topLevelModel(modelCEntity, ecm));
+}
+
+/////////////////////////////////////////////////
+TEST_F(UtilTest, ValidTopic)
+{
+  std::string good{"good"};
+  std::string fixable{"not bad~"};
+  std::string invalid{"@~@~@~"};
+
+  EXPECT_EQ("good", validTopic({good}));
+  EXPECT_EQ("not_bad", validTopic({fixable}));
+  EXPECT_EQ("", validTopic({invalid}));
+
+  EXPECT_EQ("good", validTopic({good, fixable}));
+  EXPECT_EQ("not_bad", validTopic({fixable, good}));
+
+  EXPECT_EQ("good", validTopic({good, invalid}));
+  EXPECT_EQ("good", validTopic({invalid, good}));
+
+  EXPECT_EQ("not_bad", validTopic({fixable, invalid}));
+  EXPECT_EQ("not_bad", validTopic({invalid, fixable}));
+
+  EXPECT_EQ("not_bad", validTopic({fixable, invalid, good}));
+  EXPECT_EQ("good", validTopic({invalid, good, fixable}));
 }

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -37,8 +37,10 @@
 using namespace ignition;
 using namespace gazebo;
 
+/// \brief Tests for Util.hh
 class UtilTest : public ::testing::Test
 {
+  // Documentation inherited
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -210,9 +210,14 @@ std::unique_ptr<ignition::gui::Application> createGui(
         executed = node.Request(service, timeout, res, result);
 
         if (!executed)
-          ignerr << "Service call timed out for [" << service << "]" << std::endl;
+        {
+          ignerr << "Service call timed out for [" << service << "]"
+                 << std::endl;
+        }
         else if (!result)
+        {
           ignerr << "Service call failed for [" << service << "]" << std::endl;
+        }
       }
 
       // GUI runner

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -194,18 +194,26 @@ std::unique_ptr<ignition::gui::Application> createGui(
 
       // Request GUI info for each world
       result = false;
-      service = std::string("/world/" + worldName + "/gui/info");
-
-      igndbg << "Requesting GUI from [" << service << "]..." << std::endl;
-
-      // Request and block
       ignition::msgs::GUI res;
-      executed = node.Request(service, timeout, res, result);
+      service = transport::TopicUtils::AsValidTopic("/world/" + worldName +
+          "/gui/info");
+      if (service.empty())
+      {
+        ignerr << "Failed to generate valid service for world [" << worldName
+               << "]" << std::endl;
+      }
+      else
+      {
+        igndbg << "Requesting GUI from [" << service << "]..." << std::endl;
 
-      if (!executed)
-        ignerr << "Service call timed out for [" << service << "]" << std::endl;
-      else if (!result)
-        ignerr << "Service call failed for [" << service << "]" << std::endl;
+        // Request and block
+        executed = node.Request(service, timeout, res, result);
+
+        if (!executed)
+          ignerr << "Service call timed out for [" << service << "]" << std::endl;
+        else if (!result)
+          ignerr << "Service call failed for [" << service << "]" << std::endl;
+      }
 
       // GUI runner
       auto runner = new ignition::gazebo::GuiRunner(worldName);

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -73,7 +73,8 @@ void GuiRunner::RequestState()
   auto reqSrvValid = transport::TopicUtils::AsValidTopic(reqSrv);
   if (reqSrvValid.empty())
   {
-    ignerr << "Failed to generate valid service [" << reqSrv << "]" << std::endl;
+    ignerr << "Failed to generate valid service [" << reqSrv << "]"
+           << std::endl;
     return;
   }
   reqSrv = reqSrvValid;

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -40,7 +40,14 @@ GuiRunner::GuiRunner(const std::string &_worldName)
   winWorldNames.append(QString::fromStdString(_worldName));
   win->setProperty("worldNames", winWorldNames);
 
-  this->stateTopic = "/world/" + _worldName + "/state";
+  this->stateTopic = transport::TopicUtils::AsValidTopic("/world/" +
+      _worldName + "/state");
+  if (this->stateTopic.empty())
+  {
+    ignerr << "Failed to generate valid topic for world [" << _worldName << "]"
+           << std::endl;
+    return;
+  }
 
   common::addFindFileURICallback([] (common::URI _uri)
   {
@@ -63,6 +70,14 @@ void GuiRunner::RequestState()
   std::string id = std::to_string(gui::App()->applicationPid());
   std::string reqSrv =
       this->node.Options().NameSpace() + "/" + id + "/state_async";
+  auto reqSrvValid = transport::TopicUtils::AsValidTopic(reqSrv);
+  if (reqSrvValid.empty())
+  {
+    ignerr << "Failed to generate valid service [" << reqSrv << "]" << std::endl;
+    return;
+  }
+  reqSrv = reqSrvValid;
+
   this->node.Advertise(reqSrv, &GuiRunner::OnStateAsyncService, this);
   ignition::msgs::StringMsg req;
   req.set_data(reqSrv);

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1029,6 +1029,15 @@ void IgnRenderer::HandleModelPlacement()
       this->dataPtr->createCmdService = "/world/" + this->worldName
           + "/create";
     }
+    this->dataPtr->createCmdService = transport::TopicUtils::AsValidTopic(
+        this->dataPtr->createCmdService);
+    if (this->dataPtr->createCmdService.empty())
+    {
+      ignerr << "Failed to create valid create command service for world ["
+             << this->worldName <<"]" << std::endl;
+      return;
+    }
+
     this->dataPtr->node.Request(this->dataPtr->createCmdService, req, cb);
     this->dataPtr->isPlacing = false;
     this->dataPtr->mouseDirty = false;
@@ -1246,6 +1255,14 @@ void IgnRenderer::HandleMouseTransformControl()
           {
             this->dataPtr->poseCmdService = "/world/" + this->worldName
                 + "/set_pose";
+          }
+          this->dataPtr->poseCmdService = transport::TopicUtils::AsValidTopic(
+              this->dataPtr->poseCmdService);
+          if (this->dataPtr->poseCmdService.empty())
+          {
+            ignerr << "Failed to create valid pose command service for world ["
+                   << this->worldName <<"]" << std::endl;
+            return;
           }
           this->dataPtr->node.Request(this->dataPtr->poseCmdService, req, cb);
         }

--- a/src/systems/apply_joint_force/ApplyJointForce.cc
+++ b/src/systems/apply_joint_force/ApplyJointForce.cc
@@ -25,6 +25,7 @@
 
 #include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -93,8 +94,15 @@ void ApplyJointForce::Configure(const Entity &_entity,
   }
 
   // Subscribe to commands
-  std::string topic{"/model/" + this->dataPtr->model.Name(_ecm) + "/joint/" +
-                    this->dataPtr->jointName + "/cmd_force"};
+  auto topic = transport::TopicUtils::AsValidTopic("/model/" +
+      this->dataPtr->model.Name(_ecm) + "/joint/" + this->dataPtr->jointName +
+      "/cmd_force");
+  if (topic.empty())
+  {
+    ignerr << "Failed to create valid topic for [" << this->dataPtr->jointName
+           << "]" << std::endl;
+    return;
+  }
   this->dataPtr->node.Subscribe(topic, &ApplyJointForcePrivate::OnCmdForce,
                                 this->dataPtr.get());
 

--- a/src/systems/breadcrumbs/Breadcrumbs.cc
+++ b/src/systems/breadcrumbs/Breadcrumbs.cc
@@ -42,6 +42,7 @@
 #include "ignition/gazebo/components/Performer.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/Util.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -132,11 +133,15 @@ void Breadcrumbs::Configure(const Entity &_entity,
   }
 
   // Subscribe to commands
-  std::string topic{"/model/" + this->model.Name(_ecm) + "/breadcrumbs/" +
-                    this->modelRoot.ModelByIndex(0)->Name() + "/deploy"};
-
+  std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))
-    topic = _sdf->Get<std::string>("topic");
+  {
+    topics.push_back(_sdf->Get<std::string>("topic"));
+  }
+  topics.push_back("/model/" +
+      this->model.Name(_ecm) + "/breadcrumbs/" +
+      this->modelRoot.ModelByIndex(0)->Name() + "/deploy");
+  auto topic = validTopic(topics);
 
   this->node.Subscribe(topic, &Breadcrumbs::OnDeploy, this);
   this->remainingPub = this->node.Advertise<msgs::Int32>(topic + "/remaining");

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.cc
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.cc
@@ -200,7 +200,13 @@ void CameraVideoRecorder::Configure(
   // video recorder service topic name
   if (_sdf->HasElement("service"))
   {
-    this->dataPtr->service = _sdf->Get<std::string>("service");
+    this->dataPtr->service = transport::TopicUtils::AsValidTopic(
+        _sdf->Get<std::string>("service"));
+    if (this->dataPtr->service.empty())
+    {
+      ignerr << "Service [" << _sdf->Get<std::string>("service")
+             << "] not valid. Ignoring." << std::endl;
+    }
   }
   this->dataPtr->eventMgr = &_eventMgr;
 
@@ -208,7 +214,15 @@ void CameraVideoRecorder::Configure(
   sdf::Sensor sensorSdf = cameraEntComp->Data();
   std::string topic  = sensorSdf.Topic();
   if (topic.empty())
-    topic = scopedName(_entity, _ecm) + "/image";
+  {
+    auto scoped = scopedName(_entity, _ecm);
+    topic = transport::TopicUtils::AsValidTopic(scoped + "/image");
+    if (topic.empty())
+    {
+      ignerr << "Failed to generate valid topic for entity [" << scoped
+             << "]" << std::endl;
+    }
+  }
   this->dataPtr->sensorTopic = topic;
 }
 
@@ -363,8 +377,15 @@ void CameraVideoRecorder::PostUpdate(const UpdateInfo &,
 
   if (this->dataPtr->service.empty())
   {
-    this->dataPtr->service = scopedName(this->dataPtr->entity, _ecm) +
-      "/record_video";
+    auto scoped = scopedName(this->dataPtr->entity, _ecm);
+    this->dataPtr->service = transport::TopicUtils::AsValidTopic(scoped +
+        "/record_video");
+    if (this->dataPtr->service.empty())
+    {
+      ignerr << "Failed to create valid service for [" << scoped << "]"
+             << std::endl;
+    }
+    return;
   }
 
   this->dataPtr->node.Advertise(this->dataPtr->service,

--- a/src/systems/detachable_joint/DetachableJoint.cc
+++ b/src/systems/detachable_joint/DetachableJoint.cc
@@ -22,13 +22,14 @@
 
 #include <sdf/Element.hh>
 
-#include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/components/DetachableJoint.hh"
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
 
 #include "DetachableJoint.hh"
 
@@ -93,9 +94,14 @@ void DetachableJoint::Configure(const Entity &_entity,
   }
 
   // Setup detach topic
-  std::string defaultTopic{"/model/" + this->model.Name(_ecm) +
-                             "/detachable_joint/detach"};
-  this->topic = _sdf->Get<std::string>("topic", defaultTopic).first;
+  std::vector<std::string> topics;
+  if (_sdf->HasElement("topic"))
+  {
+    topics.push_back(_sdf->Get<std::string>("topic"));
+  }
+  topics.push_back("/model/" + this->model.Name(_ecm) +
+      "/detachable_joint/detach");
+  this->topic = validTopic(topics);
 
   this->suppressChildWarning =
       _sdf->Get<bool>("suppress_child_warning", this->suppressChildWarning)

--- a/src/systems/detachable_joint/DetachableJoint.cc
+++ b/src/systems/detachable_joint/DetachableJoint.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <vector>
+
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
 

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -259,7 +259,7 @@ void DiffDrive::Configure(const Entity &_entity,
   {
     topics.push_back(_sdf->Get<std::string>("topic"));
   }
-  topics.push_back("/world/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+  topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
   auto topic = validTopic(topics);
 
   this->dataPtr->node.Subscribe(topic, &DiffDrivePrivate::OnCmdVel,
@@ -270,7 +270,8 @@ void DiffDrive::Configure(const Entity &_entity,
   {
     odomTopics.push_back(_sdf->Get<std::string>("odom_topic"));
   }
-  odomTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/odometry");
+  odomTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
+      "/odometry");
   auto odomTopic = validTopic(odomTopics);
 
   this->dataPtr->odomPub = this->dataPtr->node.Advertise<msgs::Odometry>(

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -36,6 +36,7 @@
 #include "ignition/gazebo/components/JointVelocityCmd.hh"
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
 
 #include "SpeedLimiter.hh"
 
@@ -253,16 +254,25 @@ void DiffDrive::Configure(const Entity &_entity,
       this->dataPtr->wheelRadius, this->dataPtr->wheelRadius);
 
   // Subscribe to commands
-  std::string topic{"/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel"};
+  std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))
-    topic = _sdf->Get<std::string>("topic");
+  {
+    topics.push_back(_sdf->Get<std::string>("topic"));
+  }
+  topics.push_back("/world/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+  auto topic = validTopic(topics);
+
   this->dataPtr->node.Subscribe(topic, &DiffDrivePrivate::OnCmdVel,
       this->dataPtr.get());
 
-  std::string odomTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
-    "/odometry"};
+  std::vector<std::string> odomTopics;
   if (_sdf->HasElement("odom_topic"))
-    odomTopic = _sdf->Get<std::string>("odom_topic");
+  {
+    odomTopics.push_back(_sdf->Get<std::string>("odom_topic"));
+  }
+  odomTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/odometry");
+  auto odomTopic = validTopic(odomTopics);
+
   this->dataPtr->odomPub = this->dataPtr->node.Advertise<msgs::Odometry>(
       odomTopic);
 

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -131,8 +131,15 @@ void JointController::Configure(const Entity &_entity,
   }
 
   // Subscribe to commands
-  std::string topic{"/model/" + this->dataPtr->model.Name(_ecm) + "/joint/" +
-                    this->dataPtr->jointName + "/cmd_vel"};
+  std::string topic = transport::TopicUtils::AsValidTopic("/model/" +
+      this->dataPtr->model.Name(_ecm) + "/joint/" + this->dataPtr->jointName +
+      "/cmd_vel");
+  if (topic.empty())
+  {
+    ignerr << "Failed to create topic for joint [" << this->dataPtr->jointName
+           << "]" << std::endl;
+    return;
+  }
   this->dataPtr->node.Subscribe(topic, &JointControllerPrivate::OnCmdVel,
                                 this->dataPtr.get());
 

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -147,9 +147,15 @@ void JointPositionController::Configure(const Entity &_entity,
   this->dataPtr->posPid.Init(p, i, d, iMax, iMin, cmdMax, cmdMin, cmdOffset);
 
   // Subscribe to commands
-  std::string topic{"/model/" + this->dataPtr->model.Name(_ecm) +
-                    "/joint/" + this->dataPtr->jointName + "/" +
-                    std::to_string(this->dataPtr->jointIndex) + "/cmd_pos"};
+  std::string topic = transport::TopicUtils::AsValidTopic("/model/" +
+      this->dataPtr->model.Name(_ecm) + "/joint/" + this->dataPtr->jointName +
+      "/" + std::to_string(this->dataPtr->jointIndex) + "/cmd_pos");
+  if (topic.empty())
+  {
+    ignerr << "Failed to create topic for joint [" << this->dataPtr->jointName
+           << "]" << std::endl;
+    return;
+  }
   this->dataPtr->node.Subscribe(
       topic, &JointPositionControllerPrivate::OnCmdPos, this->dataPtr.get());
 

--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -291,11 +291,31 @@ bool LogRecordPrivate::Start(const std::string &_logPath,
 
   // Use directory basename as topic name, to be able to retrieve at playback
   std::string sdfTopic = "/" + common::basename(this->logPath) + "/sdf";
-  this->sdfPub = this->node.Advertise(sdfTopic, this->sdfMsg.GetTypeName());
+  auto validSdfTopic = transport::TopicUtils::AsValidTopic(sdfTopic);
+  if (!validSdfTopic.empty())
+  {
+    this->sdfPub = this->node.Advertise(validSdfTopic,
+        this->sdfMsg.GetTypeName());
+  }
+  else
+  {
+    ignerr << "Failed to generate valid topic to publish SDF. Tried ["
+           << sdfTopic << "]." << std::endl;
+  }
 
   // TODO(louise) Combine with SceneBroadcaster's state topic
   std::string stateTopic = "/world/" + this->worldName + "/changed_state";
-  this->statePub = this->node.Advertise<msgs::SerializedStateMap>(stateTopic);
+  auto validStateTopic = transport::TopicUtils::AsValidTopic(stateTopic);
+  if (!validStateTopic.empty())
+  {
+    this->statePub = this->node.Advertise<msgs::SerializedStateMap>(
+        validStateTopic);
+  }
+  else
+  {
+    ignerr << "Failed to generate valid topic to publish state. Tried ["
+           << stateTopic << "]." << std::endl;
+  }
 
   // Append file name
   std::string dbPath = common::joinPaths(this->logPath, "state.tlog");

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
@@ -403,14 +403,21 @@ void LogicalAudioSensorPluginPrivate::CreateAudioSource(
     };
 
   // create services for this source
-  const auto full_name = scopedName(entity, _ecm);
-  if (!this->node.Advertise(full_name + "/play", playSrvCb))
+  const auto fullName = scopedName(entity, _ecm);
+  auto validName = transport::TopicUtils::AsValidTopic(fullName);
+  if (validName.empty())
+  {
+    ignerr << "Failed to create valid topics with entity scoped name ["
+           << fullName << "]" << std::endl;
+    return;
+  }
+  if (!this->node.Advertise(validName + "/play", playSrvCb))
   {
     ignerr << "Error advertising the play source service for source "
       << id << " in entity " << _parent << ". " << kSourceSkipMsg;
     return;
   }
-  if (!this->node.Advertise(full_name + "/stop", stopSrvCb))
+  if (!this->node.Advertise(validName + "/stop", stopSrvCb))
   {
     ignerr << "Error advertising the stop source service for source "
       << id << " in entity " << _parent << ". " << kSourceSkipMsg;

--- a/src/systems/multicopter_control/MulticopterVelocityControl.cc
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.cc
@@ -259,8 +259,15 @@ void MulticopterVelocityControl::Configure(const Entity &_entity,
 
   if (sdfClone->HasElement("robotNamespace"))
   {
-    this->robotNamespace =
-        sdfClone->Get<std::string>("robotNamespace");
+    this->robotNamespace = transport::TopicUtils::AsValidTopic(
+        sdfClone->Get<std::string>("robotNamespace"));
+    if (this->robotNamespace.empty())
+    {
+      ignerr << "Robot namespace ["
+             << sdfClone->Get<std::string>("robotNamespace") <<"] is invalid."
+             << std::endl;
+      return;
+    }
   }
   else
   {
@@ -270,9 +277,23 @@ void MulticopterVelocityControl::Configure(const Entity &_entity,
 
   sdfClone->Get<std::string>("commandSubTopic",
       this->commandSubTopic, this->commandSubTopic);
+  this->commandSubTopic = transport::TopicUtils::AsValidTopic(
+      this->commandSubTopic);
+  if (this->commandSubTopic.empty())
+  {
+    ignerr << "Invalid command sub-topic." << std::endl;
+    return;
+  }
 
   sdfClone->Get<std::string>("enableSubTopic",
       this->enableSubTopic, this->enableSubTopic);
+  this->enableSubTopic = transport::TopicUtils::AsValidTopic(
+      this->enableSubTopic);
+  if (this->enableSubTopic.empty())
+  {
+    ignerr << "Invalid enable sub-topic." << std::endl;
+    return;
+  }
 
   // Subscribe to actuator command messages
   std::string topic{this->robotNamespace + "/" + this->commandSubTopic};

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -357,8 +357,14 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
           this->dataPtr->refMotorInput);
 
   // Subscribe to actuator command messages
-  std::string topic{this->dataPtr->robotNamespace + "/"
-                  + this->dataPtr->commandSubTopic};
+  std::string topic = transport::TopicUtils::AsValidTopic(
+      this->dataPtr->robotNamespace + "/" + this->dataPtr->commandSubTopic);
+  if (topic.empty())
+  {
+    ignerr << "Failed to create topic for [" << this->dataPtr->robotNamespace
+           << "]" << std::endl;
+    return;
+  }
   this->dataPtr->node.Subscribe(topic,
       &MulticopterMotorModelPrivate::OnActuatorMsg, this->dataPtr.get());
 }

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -444,8 +444,16 @@ void SceneBroadcasterPrivate::PoseUpdate(const UpdateInfo &_info,
 //////////////////////////////////////////////////
 void SceneBroadcasterPrivate::SetupTransport(const std::string &_worldName)
 {
+  auto ns = transport::TopicUtils::AsValidTopic("/world/" + _worldName);
+  if (ns.empty())
+  {
+    ignerr << "Failed to create valid namespace for world [" << _worldName
+           << "]" << std::endl;
+    return;
+  }
+
   transport::NodeOptions opts;
-  opts.SetNameSpace("/world/" + _worldName);
+  opts.SetNameSpace(ns);
   this->node = std::make_unique<transport::Node>(opts);
 
   // Scene info service
@@ -487,7 +495,7 @@ void SceneBroadcasterPrivate::SetupTransport(const std::string &_worldName)
          << stateAsyncService << "]" << std::endl;
 
   // Scene info topic
-  std::string sceneTopic{"/world/" + _worldName + "/scene/info"};
+  std::string sceneTopic{ns + "/scene/info"};
 
   this->scenePub = this->node->Advertise<ignition::msgs::Scene>(sceneTopic);
 
@@ -495,7 +503,7 @@ void SceneBroadcasterPrivate::SetupTransport(const std::string &_worldName)
          << "]" << std::endl;
 
   // Entity deletion publisher
-  std::string deletionTopic{"/world/" + _worldName + "/scene/deletion"};
+  std::string deletionTopic{ns + "/scene/deletion"};
 
   this->deletionPub =
       this->node->Advertise<ignition::msgs::UInt32_V>(deletionTopic);
@@ -504,7 +512,7 @@ void SceneBroadcasterPrivate::SetupTransport(const std::string &_worldName)
          << std::endl;
 
   // State topic
-  std::string stateTopic{"/world/" + _worldName + "/state"};
+  std::string stateTopic{ns + "/state"};
 
   this->statePub =
       this->node->Advertise<ignition::msgs::SerializedStepMap>(stateTopic);

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -163,14 +163,14 @@ void TouchPluginPrivate::Load(const EntityComponentManager &_ecm,
     ignerr << "Missing required parameter <namespace>" << std::endl;
     return;
   }
-  this->ns = _sdf->Get<std::string>("namespace");
-  auto validNs = transport::TopicUtils::AsValidTopic(this->ns);
-  if (validNs.empty())
+  this->ns = transport::TopicUtils::AsValidTopic(_sdf->Get<std::string>(
+      "namespace"));
+  if (this->ns.empty())
   {
-    ignerr << "<namespace> [" << this->ns << "] is invalid." << std::endl;
+    ignerr << "<namespace> [" << _sdf->Get<std::string>("namespace")
+           << "] is invalid." << std::endl;
     return;
   }
-  this->ns = validNs;
 
   // Target time
   if (!_sdf->HasElement("time"))

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -164,6 +164,13 @@ void TouchPluginPrivate::Load(const EntityComponentManager &_ecm,
     return;
   }
   this->ns = _sdf->Get<std::string>("namespace");
+  auto validNs = transport::TopicUtils::AsValidTopic(this->ns);
+  if (validNs.empty())
+  {
+    ignerr << "<namespace> [" << this->ns << "] is invalid." << std::endl;
+    return;
+  }
+  this->ns = validNs;
 
   // Target time
   if (!_sdf->HasElement("time"))

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -486,10 +486,11 @@ void TriggeredPublisher::Configure(const Entity &,
       return;
     }
 
-    this->inputTopic = inputElem->Get<std::string>("topic");
+    auto inTopic = inputElem->Get<std::string>("topic");
+    this->inputTopic = transport::TopicUtils::AsValidTopic(inTopic);
     if (this->inputTopic.empty())
     {
-      ignerr << "Input topic cannot be empty\n";
+      ignerr << "Invalid input topic [" << inTopic << "]" << std::endl;
       return;
     }
 
@@ -538,10 +539,11 @@ void TriggeredPublisher::Configure(const Entity &,
         ignerr << "Output message type cannot be empty\n";
         continue;
       }
-      info.topic = outputElem->Get<std::string>("topic");
+      auto topic = outputElem->Get<std::string>("topic");
+      info.topic = transport::TopicUtils::AsValidTopic(topic);
       if (info.topic.empty())
       {
-        ignerr << "Output topic cannot be empty\n";
+        ignerr << "Invalid topic [" << topic << "]" << std::endl;
         continue;
       }
       const std::string msgStr = outputElem->Get<std::string>();

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -238,7 +238,8 @@ void UserCommands::Configure(const Entity &_entity,
       &UserCommandsPrivate::CreateService, this->dataPtr.get());
 
   // Create service for EntityFactory_V
-  std::string createServiceMultiple{"/world/" + validWorldName + "/create_multiple"};
+  std::string createServiceMultiple{"/world/" + validWorldName +
+      "/create_multiple"};
   this->dataPtr->node.Advertise(createServiceMultiple,
       &UserCommandsPrivate::CreateServiceMultiple, this->dataPtr.get());
 

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -223,27 +223,36 @@ void UserCommands::Configure(const Entity &_entity,
   const components::Name *constCmp = _ecm.Component<components::Name>(_entity);
   const std::string &worldName = constCmp->Data();
 
+  auto validWorldName = transport::TopicUtils::AsValidTopic(worldName);
+  if (validWorldName.empty())
+  {
+    ignerr << "World name [" << worldName
+           << "] doesn't work well with transport, services not advertised."
+           << std::endl;
+    return;
+  }
+
   // Create service
-  std::string createService{"/world/" + worldName + "/create"};
+  std::string createService{"/world/" + validWorldName + "/create"};
   this->dataPtr->node.Advertise(createService,
       &UserCommandsPrivate::CreateService, this->dataPtr.get());
 
   // Create service for EntityFactory_V
-  std::string createServiceMultiple{"/world/" + worldName + "/create_multiple"};
+  std::string createServiceMultiple{"/world/" + validWorldName + "/create_multiple"};
   this->dataPtr->node.Advertise(createServiceMultiple,
       &UserCommandsPrivate::CreateServiceMultiple, this->dataPtr.get());
 
   ignmsg << "Create service on [" << createService << "]" << std::endl;
 
   // Remove service
-  std::string removeService{"/world/" + worldName + "/remove"};
+  std::string removeService{"/world/" + validWorldName + "/remove"};
   this->dataPtr->node.Advertise(removeService,
       &UserCommandsPrivate::RemoveService, this->dataPtr.get());
 
   ignmsg << "Remove service on [" << removeService << "]" << std::endl;
 
   // Pose service
-  std::string poseService{"/world/" + worldName + "/set_pose"};
+  std::string poseService{"/world/" + validWorldName + "/set_pose"};
   this->dataPtr->node.Advertise(poseService,
       &UserCommandsPrivate::PoseService, this->dataPtr.get());
 

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -26,6 +26,7 @@
 #include "ignition/gazebo/components/AngularVelocityCmd.hh"
 #include "ignition/gazebo/components/LinearVelocityCmd.hh"
 #include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
 
 #include "VelocityControl.hh"
 
@@ -87,9 +88,13 @@ void VelocityControl::Configure(const Entity &_entity,
   }
 
   // Subscribe to commands
-  std::string topic{"/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel"};
+  std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))
-    topic = _sdf->Get<std::string>("topic");
+  {
+    topics.push_back(_sdf->Get<std::string>("topic"));
+  }
+  topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+  auto topic = validTopic(topics);
   this->dataPtr->node.Subscribe(
     topic, &VelocityControlPrivate::OnCmdVel, this->dataPtr.get());
 

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>

--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -305,12 +305,20 @@ void WindEffectsPrivate::Load(EntityComponentManager &_ecm,
 //////////////////////////////////////////////////
 void WindEffectsPrivate::SetupTransport(const std::string &_worldName)
 {
+  auto validWorldName = transport::TopicUtils::AsValidTopic(_worldName);
+  if (validWorldName.empty())
+  {
+    ignerr << "Failed to setup transport, invalid world name [" << _worldName
+           << "]" << std::endl;
+    return;
+  }
+
   // Wind seed velocity topic
-  this->node.Subscribe("/world/" + _worldName + "/wind",
+  this->node.Subscribe("/world/" + validWorldName + "/wind",
                        &WindEffectsPrivate::OnWindMsg, this);
 
   // Wind info service
-  this->node.Advertise("/world/" + _worldName + "/wind_info",
+  this->node.Advertise("/world/" + validWorldName + "/wind_info",
                        &WindEffectsPrivate::WindInfoService, this);
 }
 


### PR DESCRIPTION
This wraps up #239.

I went through the codebase and updated any topics and services I found to convert topics to valid ones if possible.

The `spaces.sdf` world has some entities with empty spaces, and wouldn't work correctly without this PR, mainly because of the spaces in the world name.

I also added the `validTopic` helper function which is handy to use when we have fallbacks for the topic. For example, when we accept a `<topic>` option from SDF, and fallback to a name-generated topic in case none is provided on SDF. Both these topics need to be validated, so the function helps with that.

We need to be mindful of this when adding new topics and plugins!