### PR TITLE
[FIX] Handle multiple logical cameras

### DIFF
--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -202,7 +202,9 @@ void LogicalCameraPrivate::UpdateLogicalCameras(
         {
           const math::Pose3d &worldPose = _worldPose->Data();
           it->second->SetPose(worldPose);
-          it->second->SetModelPoses(std::move(modelPoses));
+          // Make a copy of modelPoses s.t. SetModelPoses can take ownership
+          auto modelPoses_ = modelPoses;
+          it->second->SetModelPoses(std::move(modelPoses_));
         }
         else
         {

--- a/test/integration/logical_camera_system.cc
+++ b/test/integration/logical_camera_system.cc
@@ -105,7 +105,8 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
                 const components::Name *_name) -> bool
             {
               // Sensor 1
-              if (_name->Data() == sensorName1) {
+              if (_name->Data() == sensorName1)
+              {
                 auto sensorComp = _ecm.Component<components::Sensor>(_entity);
                 EXPECT_NE(nullptr, sensorComp);
 
@@ -118,7 +119,8 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
                 update1Checked = true;
               }
               // Sensor 2
-              else if (_name->Data() == sensorName2) {
+              else if (_name->Data() == sensorName2)
+              {
                 auto sensorComp = _ecm.Component<components::Sensor>(_entity);
                 EXPECT_NE(nullptr, sensorComp);
 

--- a/test/integration/logical_camera_system.cc
+++ b/test/integration/logical_camera_system.cc
@@ -49,18 +49,28 @@ class LogicalCameraTest : public ::testing::Test
 };
 
 std::mutex mutex;
-std::vector<msgs::LogicalCameraImage> logicalCameraMsgs;
+std::vector<msgs::LogicalCameraImage> logicalCamera1Msgs;
+std::vector<msgs::LogicalCameraImage> logicalCamera2Msgs;
 
 /////////////////////////////////////////////////
-void logicalCameraCb(const msgs::LogicalCameraImage &_msg)
+void logicalCamera1Cb(const msgs::LogicalCameraImage &_msg)
 {
   mutex.lock();
-  logicalCameraMsgs.push_back(_msg);
+  logicalCamera1Msgs.push_back(_msg);
   mutex.unlock();
 }
 
 /////////////////////////////////////////////////
-// The test checks the logical camera readings when it faces a box
+void logicalCamera2Cb(const msgs::LogicalCameraImage &_msg)
+{
+  mutex.lock();
+  logicalCamera2Msgs.push_back(_msg);
+  mutex.unlock();
+}
+
+/////////////////////////////////////////////////
+// This test checks that both logical cameras in the world can see a box
+// at the correct relative pose.
 TEST_F(LogicalCameraTest, LogicalCameraBox)
 {
   // Start server
@@ -73,14 +83,18 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
 
-  const std::string sensorName = "logical_camera";
+  const std::string sensorName1 = "logical_camera-1";
+  auto topic1 = "world/logical_camera_sensor/model/logical_camera-1/link/"
+      "logical_camera_link/sensor/logical_camera-1/logical_camera";
 
-  auto topic = "world/logical_camera_sensor/model/logical_camera/link/"
-      "logical_camera_link/sensor/logical_camera/logical_camera";
+  const std::string sensorName2 = "logical_camera-2";
+  auto topic2 = "world/logical_camera_sensor/model/logical_camera-2/link/"
+      "logical_camera_link/sensor/logical_camera-2/logical_camera";
 
-  bool updateChecked{false};
+  bool update1Checked{false};
+  bool update2Checked{false};
 
-  // Create a system that checks sensor topic
+  // Create a system that checks sensor topics
   test::Relay testSystem;
   testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
                               const gazebo::EntityComponentManager &_ecm)
@@ -90,20 +104,38 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
                 const components::LogicalCamera *,
                 const components::Name *_name) -> bool
             {
-              EXPECT_EQ(_name->Data(), sensorName);
+              // Sensor 1
+              if (_name->Data() == sensorName1) {
+                auto sensorComp = _ecm.Component<components::Sensor>(_entity);
+                EXPECT_NE(nullptr, sensorComp);
 
-              auto sensorComp = _ecm.Component<components::Sensor>(_entity);
-              EXPECT_NE(nullptr, sensorComp);
-
-              auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
-              EXPECT_NE(nullptr, topicComp);
-              if (topicComp)
-              {
-                EXPECT_EQ(topic, topicComp->Data());
+                auto topicComp =
+                    _ecm.Component<components::SensorTopic>(_entity);
+                EXPECT_NE(nullptr, topicComp);
+                if (topicComp) {
+                  EXPECT_EQ(topic1, topicComp->Data());
+                }
+                update1Checked = true;
               }
+              // Sensor 2
+              else if (_name->Data() == sensorName2) {
+                auto sensorComp = _ecm.Component<components::Sensor>(_entity);
+                EXPECT_NE(nullptr, sensorComp);
 
-              updateChecked = true;
-
+                auto topicComp =
+                    _ecm.Component<components::SensorTopic>(_entity);
+                EXPECT_NE(nullptr, topicComp);
+                if (topicComp) {
+                EXPECT_EQ(topic2, topicComp->Data());
+                }
+                update2Checked = true;
+              }
+              else
+              {
+                // We should not hit this, as it implies an unknown
+                // sensor name.
+                EXPECT_TRUE(false) << "Unknown sensor name.";
+              }
               return true;
             });
       });
@@ -113,27 +145,48 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
   // subscribe to logical camera topic
   transport::Node node;
   node.Subscribe(std::string("/world/logical_camera_sensor/") +
-      "model/logical_camera/link/logical_camera_link" +
-      "/sensor/logical_camera/logical_camera", &logicalCameraCb);
+      "model/logical_camera-1/link/logical_camera_link" +
+      "/sensor/logical_camera-1/logical_camera", &logicalCamera1Cb);
+
+  node.Subscribe(std::string("/world/logical_camera_sensor/") +
+  "model/logical_camera-2/link/logical_camera_link" +
+  "/sensor/logical_camera-2/logical_camera", &logicalCamera2Cb);
 
   // Run server and verify that we are receiving messages
   size_t iters100 = 100u;
   server.Run(true, iters100, false);
-  EXPECT_TRUE(updateChecked);
+  EXPECT_TRUE(update1Checked);
+  EXPECT_TRUE(update2Checked);
   mutex.lock();
-  EXPECT_GT(logicalCameraMsgs.size(), 0u);
+  EXPECT_GT(logicalCamera1Msgs.size(), 0u);
   mutex.unlock();
 
-  // Sensor should see box
+  mutex.lock();
+  EXPECT_GT(logicalCamera2Msgs.size(), 0u);
+  mutex.unlock();
+
+  // Sensor 1 should see box
   std::string boxName = "box";
   math::Pose3d boxPose(1, 0, 0.5, 0, 0, 0);
-  math::Pose3d sensorPose(0.05, 0.05, 0.55, 0, 0, 0);
+  math::Pose3d sensor1Pose(0.05, 0.05, 0.55, 0, 0, 0);
   mutex.lock();
-  ignition::msgs::LogicalCameraImage img = logicalCameraMsgs.back();
-  EXPECT_EQ(sensorPose, ignition::msgs::Convert(img.pose()));
-  EXPECT_EQ(1, img.model().size());
-  EXPECT_EQ(boxName, img.model(0).name());
-  ignition::math::Pose3d boxPoseCameraFrame = boxPose - sensorPose;
-  EXPECT_EQ(boxPoseCameraFrame, ignition::msgs::Convert(img.model(0).pose()));
+  ignition::msgs::LogicalCameraImage img1 = logicalCamera1Msgs.back();
+  EXPECT_EQ(sensor1Pose, ignition::msgs::Convert(img1.pose()));
+  EXPECT_EQ(1, img1.model().size());
+  EXPECT_EQ(boxName, img1.model(0).name());
+  ignition::math::Pose3d boxPoseCamera1Frame = boxPose - sensor1Pose;
+  EXPECT_EQ(boxPoseCamera1Frame, ignition::msgs::Convert(img1.model(0).pose()));
   mutex.unlock();
+
+  // Sensor 2 should see box too - note different sensor pose.
+  math::Pose3d sensor2Pose(0.05, -0.45, 0.55, 0, 0, 0);
+  mutex.lock();
+  ignition::msgs::LogicalCameraImage img2 = logicalCamera2Msgs.back();
+  EXPECT_EQ(sensor2Pose, ignition::msgs::Convert(img2.pose()));
+  EXPECT_EQ(1, img2.model().size());
+  EXPECT_EQ(boxName, img2.model(0).name());
+  ignition::math::Pose3d boxPoseCamera2Frame = boxPose - sensor2Pose;
+  EXPECT_EQ(boxPoseCamera2Frame, ignition::msgs::Convert(img2.model(0).pose()));
+  mutex.unlock();
+
 }

--- a/test/worlds/logical_camera_sensor.sdf
+++ b/test/worlds/logical_camera_sensor.sdf
@@ -96,7 +96,7 @@
       </link>
     </model>
 
-    <model name="logical_camera">
+    <model name="logical_camera-1">
       <static>true</static>
       <pose>0 0 0.5 0 0 0.0 </pose>
       <link name="logical_camera_link">
@@ -115,7 +115,39 @@
             </box>
           </geometry>
         </visual>
-        <sensor name='logical_camera' type='logical_camera'>"
+        <sensor name='logical_camera-1' type='logical_camera'>"
+          <update_rate>10</update_rate>
+          <logical_camera>
+            <near>0.55</near>
+            <far>5</far>
+            <horizontal_fov>1.04719755</horizontal_fov>
+            <aspect_ratio>1.778</aspect_ratio>
+          </logical_camera>
+          <alwaysOn>1</alwaysOn>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+    <model name="logical_camera-2">
+      <static>true</static>
+      <pose>0 -0.5 0.5 0 0 0.0 </pose>
+      <link name="logical_camera_link">
+        <pose>0.05 0.05 0.05 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='logical_camera-2' type='logical_camera'>"
           <update_rate>10</update_rate>
           <logical_camera>
             <near>0.55</near>


### PR DESCRIPTION
I found a small issue with running multiple logical cameras: only the first one that's defined in the SDF reports seeing any models.

The proposed fix is simple, though there might be better solutions (e.g. not moving `modelPoses` into the `setModelPoses` but modifying that function to take a const reference and changing the logic in the sensor implementation accordingly).

[Here](https://gist.github.com/JaldertVicarious/2800fda7fc8d52f019c6f58757b150cb) is a simple SDF to test it out.

Without the proposed fix, you'll only see one camera (`logical_camera_1`) publishing the pose of the box (`box-1`) it sees, and with the fix both cameras work as expected.


```
ign gazebo multi_logical_camera.sdf -r
```

```
#  In a second terminal
ign topic -t /logical_camera_1 -e
```

```
#  In a third terminal
ign topic -t /logical_camera_2 -e
```
