### PR TITLE
Publish all periodic change components in Scene Broadcaster

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -487,6 +487,12 @@ namespace ignition
       /// \return True if there are any components with one-time changes.
       public: bool HasOneTimeComponentChanges() const;
 
+      /// \brief Get the components that are marked as periodic changes.
+      /// \return All the components that at least one entity marked as
+      /// periodic changes.
+      public: std::unordered_set<ComponentTypeId>
+          GetPeriodicChangedComponents() const;
+
       /// \brief Set the absolute state of the ECM from a serialized message.
       /// Entities / components that are in the new state but not in the old
       /// one will be created.

--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -487,11 +487,11 @@ namespace ignition
       /// \return True if there are any components with one-time changes.
       public: bool HasOneTimeComponentChanges() const;
 
-      /// \brief Get the components that are marked as periodic changes.
+      /// \brief Get the components types that are marked as periodic changes.
       /// \return All the components that at least one entity marked as
       /// periodic changes.
       public: std::unordered_set<ComponentTypeId>
-          GetPeriodicChangedComponents() const;
+          ComponentTypesWithPeriodicChanges() const;
 
       /// \brief Set the absolute state of the ECM from a serialized message.
       /// Entities / components that are in the new state but not in the old

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -398,7 +398,7 @@ bool EntityComponentManager::HasOneTimeComponentChanges() const
 
 /////////////////////////////////////////////////
 std::unordered_set<ComponentTypeId>
-    EntityComponentManager::GetPeriodicChangedComponents() const
+    EntityComponentManager::ComponentTypesWithPeriodicChanges() const
 {
   std::unordered_set<ComponentTypeId> periodicComponents;
   for (const auto& compPair : this->dataPtr->periodicChangedComponents)

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -397,6 +397,18 @@ bool EntityComponentManager::HasOneTimeComponentChanges() const
 }
 
 /////////////////////////////////////////////////
+std::unordered_set<ComponentTypeId>
+    EntityComponentManager::GetPeriodicChangedComponents() const
+{
+  std::unordered_set<ComponentTypeId> periodicComponents;
+  for (const auto& compPair : this->dataPtr->periodicChangedComponents)
+  {
+    periodicComponents.insert(compPair.first);
+  }
+  return periodicComponents;
+}
+
+/////////////////////////////////////////////////
 bool EntityComponentManager::HasEntity(const Entity _entity) const
 {
   auto vertex = this->dataPtr->entities.VertexFromId(_entity);

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2082,6 +2082,7 @@ TEST_P(EntityComponentManagerFixture, SetChanged)
   auto c2 = manager.CreateComponent<IntComponent>(e2, IntComponent(456));
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
+  EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(ComponentState::OneTimeChange,
       manager.ComponentState(e1, c1.first));
   EXPECT_EQ(ComponentState::OneTimeChange,
@@ -2093,6 +2094,7 @@ TEST_P(EntityComponentManagerFixture, SetChanged)
   // updated
   manager.RunSetAllComponentsUnchanged();
   EXPECT_FALSE(manager.HasOneTimeComponentChanges());
+  EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(ComponentState::NoChange,
       manager.ComponentState(e1, c1.first));
   EXPECT_EQ(ComponentState::NoChange,
@@ -2103,6 +2105,9 @@ TEST_P(EntityComponentManagerFixture, SetChanged)
   manager.SetChanged(e2, c2.first, ComponentState::OneTimeChange);
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
+  // Expect a single component type to be marked as PeriodicChange
+  ASSERT_EQ(1u, manager.ComponentTypesWithPeriodicChanges().size());
+  EXPECT_EQ(IntComponent().TypeId(), *manager.ComponentTypesWithPeriodicChanges().begin());
   EXPECT_EQ(ComponentState::PeriodicChange,
       manager.ComponentState(e1, c1.first));
   EXPECT_EQ(ComponentState::OneTimeChange,
@@ -2112,6 +2117,7 @@ TEST_P(EntityComponentManagerFixture, SetChanged)
   EXPECT_TRUE(manager.RemoveComponent(e1, c1.first));
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
+  EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(ComponentState::NoChange,
       manager.ComponentState(e1, c1.first));
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2107,7 +2107,8 @@ TEST_P(EntityComponentManagerFixture, SetChanged)
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
   // Expect a single component type to be marked as PeriodicChange
   ASSERT_EQ(1u, manager.ComponentTypesWithPeriodicChanges().size());
-  EXPECT_EQ(IntComponent().TypeId(), *manager.ComponentTypesWithPeriodicChanges().begin());
+  EXPECT_EQ(IntComponent().TypeId(),
+      *manager.ComponentTypesWithPeriodicChanges().begin());
   EXPECT_EQ(ComponentState::PeriodicChange,
       manager.ComponentState(e1, c1.first));
   EXPECT_EQ(ComponentState::OneTimeChange,

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2102,6 +2102,24 @@ TEST_P(EntityComponentManagerFixture, SetChanged)
 
   // Mark as changed
   manager.SetChanged(e1, c1.first, ComponentState::PeriodicChange);
+
+  // check that only e1 c1 is serialized into a message
+  msgs::SerializedStateMap stateMsg;
+  manager.State(stateMsg);
+  {
+    ASSERT_EQ(1, stateMsg.entities_size());
+
+    auto iter = stateMsg.entities().find(e1);
+    const auto &e1Msg = iter->second;
+    EXPECT_EQ(e1, e1Msg.id());
+    ASSERT_EQ(1, e1Msg.components_size());
+
+    auto compIter = e1Msg.components().begin();
+    const auto &e1c1Msg = compIter->second;
+    EXPECT_EQ(IntComponent::typeId, e1c1Msg.type());
+    EXPECT_EQ(123, std::stoi(e1c1Msg.component()));
+  }
+
   manager.SetChanged(e2, c2.first, ComponentState::OneTimeChange);
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -297,7 +297,7 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
     else
     {
       IGN_PROFILE("SceneBroadcast::PostUpdate UpdateState");
-      auto periodicComponents = _manager.GetPeriodicChangedComponents();
+      auto periodicComponents = _manager.ComponentTypesWithPeriodicChanges();
       _manager.State(*this->dataPtr->stepMsg.mutable_state(),
           {}, periodicComponents);
     }

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -293,12 +293,13 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
     {
       _manager.State(*this->dataPtr->stepMsg.mutable_state(), {}, {}, true);
     }
-    // Otherwise publish just selected components
+    // Otherwise publish just periodic change components
     else
     {
       IGN_PROFILE("SceneBroadcast::PostUpdate UpdateState");
+      auto periodicComponents = _manager.GetPeriodicChangedComponents();
       _manager.State(*this->dataPtr->stepMsg.mutable_state(),
-          {}, {components::Pose::typeId});
+          {}, periodicComponents);
     }
 
     // Full state on demand


### PR DESCRIPTION
As reported in #529, the only way users have to have components published regularly is to specify them as `OneTimeChanged`, but this incurs in the large overhead of re-serializing and publishing the whole simulation state.

When looking at the code I noticed that a component being marked as `PeriodicChange` didn't seem to have any effect on the SceneBroadcaster since it only published `Pose` components at regular intervals.
Also, I ran a quick `grep` in the code:

```
luca@luca-focal:~/ws_dome/src/ign-gazebo$ grep -r . -e PeriodicChange
./include/ignition/gazebo/Types.hh:      PeriodicChange = 1,
./src/EntityComponentManager_TEST.cc:  manager.SetChanged(e1, c1.first, ComponentState::PeriodicChange);
./src/EntityComponentManager_TEST.cc:  EXPECT_EQ(ComponentState::PeriodicChange,
./src/EntityComponentManager.cc:    result = ComponentState::PeriodicChange;
./src/EntityComponentManager.cc:  if (_c == ComponentState::PeriodicChange)
./src/systems/wheel_slip/WheelSlip.cc:                      ComponentState::PeriodicChange);
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange);
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange);
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                  ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/physics/Physics.cc:                ComponentState::PeriodicChange :
./src/systems/multicopter_control/MulticopterVelocityControl.cc:                     ? ComponentState::PeriodicChange
./src/systems/log/LogPlayback.cc:        ComponentState::PeriodicChange);

```

 I noticed that the vast majority of PeriodicChange components are indeed `Pose` components in [Physics](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/src/systems/physics/Physics.cc#L1806-L1807)  (unless users create Linear / Angular Velocity / Acceleration components), with a few exceptions in [MulticopterVelocityControl](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/src/systems/multicopter_control/MulticopterVelocityControl.cc#L439-L441) (Actuator component) and [WheelSlip](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/src/systems/wheel_slip/WheelSlip.cc#L289-L290) (SlipComplianceCmd component).

With this in mind, I decided to just change the periodic publishing of SceneBroadcaster from only `Pose` components to all the components that have been marked as PeriodicChange.

From a performance point of view, this should have no impact in a default simulation, since entities by default only have a `Pose` component. The overhead will appear when the user marks any component as `PeriodicChange`, loads a `MulticopterVelocityControl` or `WheelSlip` system or creates a `LinearVelocity`, `AngularVelocity`, `LinearAcceleration`, `AngularAcceleration` or their `World` variant components, since any of those will also be added at the 60Hz SceneBroadcaster publisher.