### PR TITLE
add TF/Pose_V pub in DiffDrive

### DIFF
--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -274,8 +274,12 @@ void DiffDrive::Configure(const Entity &_entity,
   this->dataPtr->odomPub = this->dataPtr->node.Advertise<msgs::Odometry>(
       odomTopic);
 
+  std::string tfTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
+    "/tf"};
+  if (_sdf->HasElement("tf_topic"))
+    tfTopic = _sdf->Get<std::string>("tf_topic");
   this->dataPtr->tfPub = this->dataPtr->node.Advertise<msgs::Pose_V>(
-      "tf");
+      tfTopic);
 
   if (_sdf->HasElement("frame_id"))
     this->dataPtr->sdfFrameId = _sdf->Get<std::string>("frame_id");
@@ -472,17 +476,16 @@ void DiffDrivePrivate::UpdateOdometry(const ignition::gazebo::UpdateInfo &_info,
   }
 
   // Construct the Pose_V/tf message and publish it.
-  msgs::Pose_V tf_msg;
-  ignition::msgs::Pose *tf_msg_pose = nullptr;
-  tf_msg_pose = tf_msg.add_pose();
-  tf_msg_pose->mutable_header()->CopyFrom(*msg.mutable_header());
-  tf_msg_pose->mutable_position()->CopyFrom(msg.mutable_pose()->position());
-  tf_msg_pose->mutable_orientation()->
-      CopyFrom(msg.mutable_pose()->orientation());
+  msgs::Pose_V tfMsg;
+  ignition::msgs::Pose *tfMsgPose = nullptr;
+  tfMsgPose = tfMsg.add_pose();
+  tfMsgPose->mutable_header()->CopyFrom(*msg.mutable_header());
+  tfMsgPose->mutable_position()->CopyFrom(msg.mutable_pose()->position());
+  tfMsgPose->mutable_orientation()->CopyFrom(msg.mutable_pose()->orientation());
 
   // Publish the messages
   this->odomPub.Publish(msg);
-  this->tfPub.Publish(tf_msg);
+  this->tfPub.Publish(tfMsg);
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -477,7 +477,8 @@ void DiffDrivePrivate::UpdateOdometry(const ignition::gazebo::UpdateInfo &_info,
   tf_msg_pose = tf_msg.add_pose();
   tf_msg_pose->mutable_header()->CopyFrom(*msg.mutable_header());
   tf_msg_pose->mutable_position()->CopyFrom(msg.mutable_pose()->position());
-  tf_msg_pose->mutable_orientation()->CopyFrom(msg.mutable_pose()->orientation());
+  tf_msg_pose->mutable_orientation()->
+      CopyFrom(msg.mutable_pose()->orientation());
 
   // Publish the messages
   this->odomPub.Publish(msg);

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -61,6 +61,22 @@ namespace systems
   /// `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
+  ///
+  /// `<tf_topic>`: Custom topic on which this system will publish the
+  /// transform from `frame_id` to `child_frame_id`. This element if optional,
+  ///  and the default value is `/model/{name_of_model}/tf`.
+  ///
+  /// `<frame_id>`: Custom `frame_id` field that this system will use as the
+  /// origin of the odometry transform in both the `<tf_topic>`
+  /// `ignition.msgs.Pose_V` message and the `<odom_topic>`
+  /// `ignition.msgs.Odometry` message. This element if optional, and the
+  /// default value is `{name_of_model}/odom`.
+  ///
+  /// `<child_frame_id>`: Custom `child_frame_id` that this system will use as
+  /// the target of the odometry trasnform in both the `<tf_topic>`
+  /// `ignition.msgs.Pose_V` message and the `<odom_topic>`
+  /// `ignition.msgs.Odometry` message. This element if optional,
+  ///  and the default value is `{name_of_model}/{name_of_link}`.
   class IGNITION_GAZEBO_VISIBLE DiffDrive
       : public System,
         public ISystemConfigure,

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -455,7 +455,7 @@ TEST_P(DiffDriveTest, Pose_VFrameId)
 
   transport::Node node;
   auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/tf", pose_VCb);
+  node.Subscribe("/model/vehicle/tf", pose_VCb);
 
   msgs::Twist msg;
   msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
@@ -514,7 +514,64 @@ TEST_P(DiffDriveTest, Pose_VCustomFrameId)
 
   transport::Node node;
   auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/tf", Pose_VCb);
+  node.Subscribe("/model/vehicle/tf", Pose_VCb);
+
+  server.Run(true, 100, false);
+
+  int sleep = 0;
+  int maxSleep = 30;
+  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_NE(maxSleep, sleep);
+
+  EXPECT_EQ(5u, odomPosesCount);
+}
+
+/////////////////////////////////////////////////
+TEST_P(DiffDriveTest, Pose_VCustomTfTopic)
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_tf_topic.sdf");
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  server.SetUpdatePeriod(0ns);
+
+  unsigned int odomPosesCount = 0;
+  std::function<void(const msgs::Pose_V &)> pose_VCb =
+    [&odomPosesCount](const msgs::Pose_V &_msg)
+    {
+      ASSERT_TRUE(_msg.pose(0).has_header());
+      ASSERT_TRUE(_msg.pose(0).header().has_stamp());
+
+      ASSERT_GT(_msg.pose(0).header().data_size(), 1);
+
+      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(), "frame_id");
+      EXPECT_STREQ(
+            _msg.pose(0).header().data(0).value().Get(0).c_str(), "vehicle/odom");
+
+      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
+      EXPECT_STREQ(
+            _msg.pose(0).header().data(1).value().Get(0).c_str(), "vehicle/chassis");
+
+      odomPosesCount++;
+    };
+
+  transport::Node node;
+  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
+  node.Subscribe("/tf_foo", pose_VCb);
+
+  msgs::Twist msg;
+  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
+  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
+
+  pub.Publish(msg);
 
   server.Run(true, 100, false);
 

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -440,13 +440,15 @@ TEST_P(DiffDriveTest, Pose_VFrameId)
 
       ASSERT_GT(_msg.pose(0).header().data_size(), 1);
 
-      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(), "frame_id");
-      EXPECT_STREQ(
-            _msg.pose(0).header().data(0).value().Get(0).c_str(), "vehicle/odom");
+      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(),
+                   "frame_id");
+      EXPECT_STREQ(_msg.pose(0).header().data(0).value().Get(0).c_str(),
+                   "vehicle/odom");
 
-      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
-      EXPECT_STREQ(
-            _msg.pose(0).header().data(1).value().Get(0).c_str(), "vehicle/chassis");
+      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(),
+                   "child_frame_id");
+      EXPECT_STREQ(_msg.pose(0).header().data(1).value().Get(0).c_str(),
+                   "vehicle/chassis");
 
       odomPosesCount++;
     };
@@ -497,12 +499,15 @@ TEST_P(DiffDriveTest, Pose_VCustomFrameId)
 
       ASSERT_GT(_msg.pose(0).header().data_size(), 1);
 
-      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(), "frame_id");
-      EXPECT_STREQ(_msg.pose(0).header().data(0).value().Get(0).c_str(), "odom");
+      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(),
+                   "frame_id");
+      EXPECT_STREQ(_msg.pose(0).header().data(0).value().Get(0).c_str(),
+                   "odom");
 
-      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
-      EXPECT_STREQ(
-            _msg.pose(0).header().data(1).value().Get(0).c_str(), "base_footprint");
+      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(),
+                   "child_frame_id");
+      EXPECT_STREQ(_msg.pose(0).header().data(1).value().Get(0).c_str(),
+            "base_footprint");
 
       odomPosesCount++;
     };

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -566,11 +566,14 @@ TEST_P(DiffDriveTest, Pose_VCustomTfTopic)
 
       EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(), "frame_id");
       EXPECT_STREQ(
-            _msg.pose(0).header().data(0).value().Get(0).c_str(), "vehicle/odom");
+            _msg.pose(0).header().data(0).value().Get(0).c_str(),
+            "vehicle/odom");
 
-      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
       EXPECT_STREQ(
-            _msg.pose(0).header().data(1).value().Get(0).c_str(), "vehicle/chassis");
+            _msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
+      EXPECT_STREQ(
+            _msg.pose(0).header().data(1).value().Get(0).c_str(),
+            "vehicle/chassis");
 
       odomPosesCount++;
     };

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -404,6 +404,12 @@ TEST_P(DiffDriveTest, OdomCustomFrameId)
   auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
   node.Subscribe("/model/vehicle/odometry", odomCb);
 
+  msgs::Twist msg;
+  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
+  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
+
+  pub.Publish(msg);
+
   server.Run(true, 100, false);
 
   int sleep = 0;
@@ -515,6 +521,12 @@ TEST_P(DiffDriveTest, Pose_VCustomFrameId)
   transport::Node node;
   auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
   node.Subscribe("/model/vehicle/tf", Pose_VCb);
+
+  msgs::Twist msg;
+  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
+  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
+
+  pub.Publish(msg);
 
   server.Run(true, 100, false);
 

--- a/test/worlds/diff_drive_custom_tf_topic.sdf
+++ b/test/worlds/diff_drive_custom_tf_topic.sdf
@@ -1,0 +1,244 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="diff_drive">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name='vehicle'>
+      <pose>0 0 0.325 0 -0 0</pose>
+
+      <link name='chassis'>
+        <pose>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1.0 1</ambient>
+            <diffuse>0.5 0.5 1.0 1</diffuse>
+            <specular>0.0 0.0 1.0 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='left_wheel'>
+        <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='right_wheel'>
+        <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='caster'>
+        <pose>-0.957138 -0 -0.125 0 -0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name='left_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='right_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='caster_wheel' type='ball'>
+        <parent>chassis</parent>
+        <child>caster</child>
+      </joint>
+
+      <plugin
+        filename="ignition-gazebo-diff-drive-system"
+        name="ignition::gazebo::systems::DiffDrive">
+        <left_joint>left_wheel_joint</left_joint>
+        <right_joint>right_wheel_joint</right_joint>
+        <wheel_separation>1.25</wheel_separation>
+        <wheel_radius>0.3</wheel_radius>
+        <max_acceleration>1</max_acceleration>
+        <max_velocity>0.5</max_velocity>
+        <tf_topic>tf_foo</tf_topic>
+        <!-- no odom_publisher_frequency defaults to 50 Hz -->
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-joint-state-publisher-system"
+        name="ignition::gazebo::systems::JointStatePublisher">
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>
+


### PR DESCRIPTION
Solves https://github.com/ignitionrobotics/ros_ign/issues/131
With this PR, there is only `/tf@tf2_msgs/TFMessage@ignition.msgs.Pose_V` to add to the args of the `ros_ign_bridge parameter_bridge` node to get similar TF publishing behavior as in Gazebo Classic DiffDrive plugin.
Once merged I can PR `ros_ign_gazebo_demos` if needed with the additional `/tf@tf2_msgs/TFMessage@ignition.msgs.Pose_V`.

I did the most straightforward implementation. Improvement to discuss:

- Variable naming: `tfPub`, `tf_msg` or `pose_VPub` and `pose_V_msg` ?
- Ign topic for `frame_id -> child_frame_id` transform: `tf` or something else ?
- TF/Pose_V always on, or enable/disable for instance through `_sdf->HasElement("publish_tf")` (or other name)