### PR TITLE
Fix visibility macro names when used by a different component (Windows)

### DIFF
--- a/include/ignition/gazebo/gui/Gui.hh
+++ b/include/ignition/gazebo/gui/Gui.hh
@@ -60,7 +60,8 @@ namespace gui
   /// IGN_HOMEDIR/.ignition/gazebo/gui.config will be used.
   /// \param[in] _loadPluginsFromSdf If true, plugins specified in the world
   /// SDFormat file will get loaded.
-  IGNITION_GAZEBO_GUI_VISIBLE std::unique_ptr<ignition::gui::Application> createGui(
+  IGNITION_GAZEBO_GUI_VISIBLE
+  std::unique_ptr<ignition::gui::Application> createGui(
       int &_argc, char **_argv, const char *_guiConfig,
       const char *_defaultGuiConfig = nullptr, bool _loadPluginsFromSdf = true);
 

--- a/include/ignition/gazebo/gui/Gui.hh
+++ b/include/ignition/gazebo/gui/Gui.hh
@@ -22,7 +22,7 @@
 #include <ignition/gui/Application.hh>
 
 #include "ignition/gazebo/config.hh"
-#include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/gui/Export.hh"
 
 namespace ignition
 {
@@ -41,7 +41,7 @@ namespace gui
   /// ign-tools. Set to the name of the application if using ign-tools)
   /// \param[in] _guiConfig The GUI configuration file. If nullptr, the default
   /// configuration from IGN_HOMEDIR/.ignition/gazebo/gui.config will be used.
-  IGNITION_GAZEBO_VISIBLE int runGui(int &_argc, char **_argv,
+  IGNITION_GAZEBO_GUI_VISIBLE int runGui(int &_argc, char **_argv,
                                      const char *_guiConfig);
 
   /// \brief Create a Gazebo GUI application
@@ -60,7 +60,7 @@ namespace gui
   /// IGN_HOMEDIR/.ignition/gazebo/gui.config will be used.
   /// \param[in] _loadPluginsFromSdf If true, plugins specified in the world
   /// SDFormat file will get loaded.
-  IGNITION_GAZEBO_VISIBLE std::unique_ptr<ignition::gui::Application> createGui(
+  IGNITION_GAZEBO_GUI_VISIBLE std::unique_ptr<ignition::gui::Application> createGui(
       int &_argc, char **_argv, const char *_guiConfig,
       const char *_defaultGuiConfig = nullptr, bool _loadPluginsFromSdf = true);
 

--- a/include/ignition/gazebo/gui/GuiRunner.hh
+++ b/include/ignition/gazebo/gui/GuiRunner.hh
@@ -25,7 +25,7 @@
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/EntityComponentManager.hh"
-#include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/gui/Export.hh"
 
 namespace ignition
 {
@@ -35,7 +35,7 @@ namespace gazebo
 inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 /// \brief Responsible for running GUI systems as new states are received from
 /// the backend.
-class IGNITION_GAZEBO_VISIBLE GuiRunner : public QObject
+class IGNITION_GAZEBO_GUI_VISIBLE GuiRunner : public QObject
 {
   Q_OBJECT
 

--- a/include/ignition/gazebo/rendering/MarkerManager.hh
+++ b/include/ignition/gazebo/rendering/MarkerManager.hh
@@ -20,6 +20,8 @@
 #include <memory>
 #include <string>
 
+#include <ignition/gazebo/rendering/Export.hh>
+
 #include "ignition/rendering/RenderTypes.hh"
 
 namespace ignition
@@ -32,7 +34,7 @@ class MarkerManagerPrivate;
 
 /// \brief Creates, deletes, and maintains marker visuals. Only the
 /// Scene class should instantiate and use this class.
-class IGNITION_GAZEBO_VISIBLE MarkerManager
+class IGNITION_GAZEBO_RENDERING_VISIBLE MarkerManager
 {
   /// \brief Constructor
   public: MarkerManager();

--- a/include/ignition/gazebo/rendering/RenderUtil.hh
+++ b/include/ignition/gazebo/rendering/RenderUtil.hh
@@ -24,7 +24,7 @@
 #include <sdf/Sensor.hh>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/rendering/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 #include "ignition/gazebo/rendering/SceneManager.hh"
@@ -41,7 +41,7 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
   class RenderUtilPrivate;
 
   /// \class RenderUtil RenderUtil.hh ignition/gazebo/gui/plugins/RenderUtil.hh
-  class IGNITION_GAZEBO_VISIBLE RenderUtil
+  class IGNITION_GAZEBO_RENDERING_VISIBLE RenderUtil
   {
     /// \brief Constructor
     public: explicit RenderUtil();

--- a/include/ignition/gazebo/rendering/SceneManager.hh
+++ b/include/ignition/gazebo/rendering/SceneManager.hh
@@ -38,7 +38,7 @@
 
 #include <ignition/gazebo/config.hh>
 #include <ignition/gazebo/Entity.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/rendering/Export.hh>
 
 namespace ignition
 {
@@ -84,7 +84,7 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
   };
 
   /// \brief Scene manager class for loading and managing objects in the scene
-  class IGNITION_GAZEBO_VISIBLE SceneManager
+  class IGNITION_GAZEBO_RENDERING_VISIBLE SceneManager
   {
     /// \brief Constructor
     public: SceneManager();

--- a/src/systems/air_pressure/AirPressure.hh
+++ b/src/systems/air_pressure/AirPressure.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/air-pressure-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +35,7 @@ namespace systems
   /// \class AirPressure AirPressure.hh ignition/gazebo/systems/AirPressure.hh
   /// \brief An air pressure sensor that reports vertical position and velocity
   /// readings over ign transport
-  class IGNITION_GAZEBO_AIR_PRESSURE_SYSTEM_VISIBLE AirPressure:
+  class AirPressure:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/air_pressure/AirPressure.hh
+++ b/src/systems/air_pressure/AirPressure.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/air-pressure-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +36,7 @@ namespace systems
   /// \class AirPressure AirPressure.hh ignition/gazebo/systems/AirPressure.hh
   /// \brief An air pressure sensor that reports vertical position and velocity
   /// readings over ign transport
-  class IGNITION_GAZEBO_VISIBLE AirPressure:
+  class IGNITION_GAZEBO_AIR_PRESSURE_SYSTEM_VISIBLE AirPressure:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/altimeter/Altimeter.hh
+++ b/src/systems/altimeter/Altimeter.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/altimeter-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +35,7 @@ namespace systems
   /// \class Altimeter Altimeter.hh ignition/gazebo/systems/Altimeter.hh
   /// \brief An altimeter sensor that reports vertical position and velocity
   /// readings over ign transport
-  class IGNITION_GAZEBO_ALTIMETER_SYSTEM_VISIBLE Altimeter:
+  class Altimeter:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/altimeter/Altimeter.hh
+++ b/src/systems/altimeter/Altimeter.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/altimeter-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +36,7 @@ namespace systems
   /// \class Altimeter Altimeter.hh ignition/gazebo/systems/Altimeter.hh
   /// \brief An altimeter sensor that reports vertical position and velocity
   /// readings over ign transport
-  class IGNITION_GAZEBO_VISIBLE Altimeter:
+  class IGNITION_GAZEBO_ALTIMETER_SYSTEM_VISIBLE Altimeter:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/apply_joint_force/ApplyJointForce.hh
+++ b/src/systems/apply_joint_force/ApplyJointForce.hh
@@ -17,7 +17,6 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_APPLYJOINTFORCE_HH_
 #define IGNITION_GAZEBO_SYSTEMS_APPLYJOINTFORCE_HH_
 
-#include <ignition/gazebo/apply-joint-force-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -33,7 +32,7 @@ namespace systems
   class ApplyJointForcePrivate;
 
   /// \brief This system applies a force to the first axis of a specified joint.
-  class IGNITION_GAZEBO_APPLY_JOINT_FORCE_SYSTEM_VISIBLE ApplyJointForce
+  class ApplyJointForce
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/apply_joint_force/ApplyJointForce.hh
+++ b/src/systems/apply_joint_force/ApplyJointForce.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_APPLYJOINTFORCE_HH_
 #define IGNITION_GAZEBO_SYSTEMS_APPLYJOINTFORCE_HH_
 
+#include <ignition/gazebo/apply-joint-force-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -32,7 +33,7 @@ namespace systems
   class ApplyJointForcePrivate;
 
   /// \brief This system applies a force to the first axis of a specified joint.
-  class IGNITION_GAZEBO_VISIBLE ApplyJointForce
+  class IGNITION_GAZEBO_APPLY_JOINT_FORCE_SYSTEM_VISIBLE ApplyJointForce
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/battery_plugin/LinearBatteryPlugin.hh
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.hh
@@ -24,7 +24,6 @@
 
 #include <ignition/common/Battery.hh>
 
-#include <ignition/gazebo/linearbatteryplugin-system/Export.hh>
 #include "ignition/gazebo/System.hh"
 
 namespace ignition
@@ -59,7 +58,7 @@ namespace systems
   ///                 (Required if <enable_recharge> is set to true)
   /// <fix_issue_225> True to change the battery behavior to fix some issues
   /// described in https://github.com/ignitionrobotics/ign-gazebo/issues/225.
-  class IGNITION_GAZEBO_LINEARBATTERYPLUGIN_SYSTEM_VISIBLE LinearBatteryPlugin
+  class LinearBatteryPlugin
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/battery_plugin/LinearBatteryPlugin.hh
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.hh
@@ -24,6 +24,7 @@
 
 #include <ignition/common/Battery.hh>
 
+#include <ignition/gazebo/linearbatteryplugin-system/Export.hh>
 #include "ignition/gazebo/System.hh"
 
 namespace ignition
@@ -58,7 +59,7 @@ namespace systems
   ///                 (Required if <enable_recharge> is set to true)
   /// <fix_issue_225> True to change the battery behavior to fix some issues
   /// described in https://github.com/ignitionrobotics/ign-gazebo/issues/225.
-  class IGNITION_GAZEBO_VISIBLE LinearBatteryPlugin
+  class IGNITION_GAZEBO_LINEARBATTERYPLUGIN_SYSTEM_VISIBLE LinearBatteryPlugin
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/breadcrumbs/Breadcrumbs.hh
+++ b/src/systems/breadcrumbs/Breadcrumbs.hh
@@ -17,8 +17,8 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_BREADCRUMBS_HH_
 #define IGNITION_GAZEBO_SYSTEMS_BREADCRUMBS_HH_
 
-#include <optional>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <vector>

--- a/src/systems/breadcrumbs/Breadcrumbs.hh
+++ b/src/systems/breadcrumbs/Breadcrumbs.hh
@@ -30,7 +30,6 @@
 #include <ignition/transport/Node.hh>
 #include <ignition/math/Pose3.hh>
 
-#include <ignition/gazebo/breadcrumbs-system/Export.hh>
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
 #include "ignition/gazebo/System.hh"
@@ -81,7 +80,7 @@ namespace systems
   /// Defaults to false.
   /// `<breadcrumb>`: This is the model used as a template for deploying
   /// breadcrumbs.
-  class IGNITION_GAZEBO_BREADCRUMBS_SYSTEM_VISIBLE Breadcrumbs
+  class Breadcrumbs
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/breadcrumbs/Breadcrumbs.hh
+++ b/src/systems/breadcrumbs/Breadcrumbs.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_BREADCRUMBS_HH_
 #define IGNITION_GAZEBO_SYSTEMS_BREADCRUMBS_HH_
 
+#include <optional>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -29,6 +30,7 @@
 #include <ignition/transport/Node.hh>
 #include <ignition/math/Pose3.hh>
 
+#include <ignition/gazebo/breadcrumbs-system/Export.hh>
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
 #include "ignition/gazebo/System.hh"
@@ -79,7 +81,7 @@ namespace systems
   /// Defaults to false.
   /// `<breadcrumb>`: This is the model used as a template for deploying
   /// breadcrumbs.
-  class IGNITION_GAZEBO_VISIBLE Breadcrumbs
+  class IGNITION_GAZEBO_BREADCRUMBS_SYSTEM_VISIBLE Breadcrumbs
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -17,7 +17,6 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_BUOYANCY_HH_
 #define IGNITION_GAZEBO_SYSTEMS_BUOYANCY_HH_
 
-#include <ignition/gazebo/buoyancy-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -58,7 +57,7 @@ namespace systems
   /// ```
   /// ign gazebo -v 4 buoyancy.sdf
   /// ```
-  class IGNITION_GAZEBO_BUOYANCY_SYSTEM_VISIBLE Buoyancy
+  class Buoyancy
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_BUOYANCY_HH_
 #define IGNITION_GAZEBO_SYSTEMS_BUOYANCY_HH_
 
+#include <ignition/gazebo/buoyancy-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -57,7 +58,7 @@ namespace systems
   /// ```
   /// ign gazebo -v 4 buoyancy.sdf
   /// ```
-  class IGNITION_GAZEBO_VISIBLE Buoyancy
+  class IGNITION_GAZEBO_BUOYANCY_SYSTEM_VISIBLE Buoyancy
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.hh
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/camera-video-recorder-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.hh
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/camera-video-recorder-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -41,7 +41,7 @@ namespace systems
   ///              not specified, the topic defaults to:
   ///              /world/<world_name/model/<model_name>/link/<link_name>/
   ///                  sensor/<sensor_name>/record_video
-  class IGNITION_GAZEBO_VISIBLE CameraVideoRecorder:
+  class IGNITION_GAZEBO_CAMERA_VIDEO_RECORDER_SYSTEM_VISIBLE CameraVideoRecorder:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.hh
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.hh
@@ -41,7 +41,9 @@ namespace systems
   ///              not specified, the topic defaults to:
   ///              /world/<world_name/model/<model_name>/link/<link_name>/
   ///                  sensor/<sensor_name>/record_video
-  class IGNITION_GAZEBO_CAMERA_VIDEO_RECORDER_SYSTEM_VISIBLE CameraVideoRecorder:
+  class
+  IGNITION_GAZEBO_CAMERA_VIDEO_RECORDER_SYSTEM_VISIBLE
+  CameraVideoRecorder:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.hh
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.hh
@@ -41,7 +41,6 @@ namespace systems
   ///              /world/<world_name/model/<model_name>/link/<link_name>/
   ///                  sensor/<sensor_name>/record_video
   class
-  IGNITION_GAZEBO_CAMERA_VIDEO_RECORDER_SYSTEM_VISIBLE
   CameraVideoRecorder:
     public System,
     public ISystemConfigure,

--- a/src/systems/contact/Contact.hh
+++ b/src/systems/contact/Contact.hh
@@ -18,7 +18,6 @@
 #define IGNITION_GAZEBO_SYSTEMS_CONTACT_HH_
 
 #include <memory>
-#include <ignition/gazebo/contact-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -37,7 +36,7 @@ namespace systems
   **/
   /// \brief Contact sensor system which manages all contact sensors in
   /// simulation
-  class IGNITION_GAZEBO_CONTACT_SYSTEM_VISIBLE Contact :
+  class Contact :
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/contact/Contact.hh
+++ b/src/systems/contact/Contact.hh
@@ -18,7 +18,7 @@
 #define IGNITION_GAZEBO_SYSTEMS_CONTACT_HH_
 
 #include <memory>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/contact-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -37,7 +37,7 @@ namespace systems
   **/
   /// \brief Contact sensor system which manages all contact sensors in
   /// simulation
-  class IGNITION_GAZEBO_VISIBLE Contact :
+  class IGNITION_GAZEBO_CONTACT_SYSTEM_VISIBLE Contact :
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/detachable_joint/DetachableJoint.hh
+++ b/src/systems/detachable_joint/DetachableJoint.hh
@@ -24,6 +24,7 @@
 #include <string>
 #include <ignition/transport/Node.hh>
 
+#include "ignition/gazebo/detachable-joint-system/Export.hh"
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/System.hh"
 
@@ -54,7 +55,7 @@ namespace systems
   /// will not print a warning message if a child model does not exist yet.
   /// Otherwise, a warning message is printed. Defaults to false.
 
-  class IGNITION_GAZEBO_VISIBLE DetachableJoint
+  class IGNITION_GAZEBO_DETACHABLE_JOINT_SYSTEM_VISIBLE DetachableJoint
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/detachable_joint/DetachableJoint.hh
+++ b/src/systems/detachable_joint/DetachableJoint.hh
@@ -24,7 +24,6 @@
 #include <string>
 #include <ignition/transport/Node.hh>
 
-#include "ignition/gazebo/detachable-joint-system/Export.hh"
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/System.hh"
 
@@ -55,7 +54,7 @@ namespace systems
   /// will not print a warning message if a child model does not exist yet.
   /// Otherwise, a warning message is printed. Defaults to false.
 
-  class IGNITION_GAZEBO_DETACHABLE_JOINT_SYSTEM_VISIBLE DetachableJoint
+  class DetachableJoint
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 
-#include <ignition/gazebo/diff-drive-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -62,7 +61,7 @@ namespace systems
   /// `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
-  class IGNITION_GAZEBO_DIFF_DRIVE_SYSTEM_VISIBLE DiffDrive
+  class DiffDrive
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -19,6 +19,7 @@
 
 #include <memory>
 
+#include <ignition/gazebo/diff-drive-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -61,7 +62,7 @@ namespace systems
   /// `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
-  class IGNITION_GAZEBO_VISIBLE DiffDrive
+  class IGNITION_GAZEBO_DIFF_DRIVE_SYSTEM_VISIBLE DiffDrive
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/diff_drive/SpeedLimiter.hh
+++ b/src/systems/diff_drive/SpeedLimiter.hh
@@ -42,6 +42,7 @@
 
 #include <memory>
 
+#include <ignition/gazebo/diff-drive-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -57,7 +58,7 @@ namespace systems
 
   /// \brief Class to limit velocity, acceleration and jerk.
   /// \ref https://github.com/ros-controls/ros_controllers/tree/melodic-devel/diff_drive_controller
-  class IGNITION_GAZEBO_VISIBLE SpeedLimiter
+  class IGNITION_GAZEBO_DIFF_DRIVE_SYSTEM_VISIBLE SpeedLimiter
   {
     /// \brief Constructor.
     /// \param [in] _hasVelocityLimits     if true, applies velocity limits.

--- a/src/systems/diff_drive/SpeedLimiter.hh
+++ b/src/systems/diff_drive/SpeedLimiter.hh
@@ -42,7 +42,6 @@
 
 #include <memory>
 
-#include <ignition/gazebo/diff-drive-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -58,7 +57,7 @@ namespace systems
 
   /// \brief Class to limit velocity, acceleration and jerk.
   /// \ref https://github.com/ros-controls/ros_controllers/tree/melodic-devel/diff_drive_controller
-  class IGNITION_GAZEBO_DIFF_DRIVE_SYSTEM_VISIBLE SpeedLimiter
+  class SpeedLimiter
   {
     /// \brief Constructor.
     /// \param [in] _hasVelocityLimits     if true, applies velocity limits.

--- a/src/systems/follow_actor/FollowActor.hh
+++ b/src/systems/follow_actor/FollowActor.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/follow-actor-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -54,7 +53,7 @@ namespace systems
   /// <animation_x_vel>: Velocity of the animation on the X axis. Used to
   ///                    coordinate translational motion with the actor's
   ///                    animation.
-  class IGNITION_GAZEBO_FOLLOW_ACTOR_SYSTEM_VISIBLE FollowActor:
+  class FollowActor:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate

--- a/src/systems/follow_actor/FollowActor.hh
+++ b/src/systems/follow_actor/FollowActor.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/follow-actor-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -54,7 +54,7 @@ namespace systems
   /// <animation_x_vel>: Velocity of the animation on the X axis. Used to
   ///                    coordinate translational motion with the actor's
   ///                    animation.
-  class IGNITION_GAZEBO_VISIBLE FollowActor:
+  class IGNITION_GAZEBO_FOLLOW_ACTOR_SYSTEM_VISIBLE FollowActor:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate

--- a/src/systems/imu/Imu.hh
+++ b/src/systems/imu/Imu.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/imu-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -37,7 +36,7 @@ namespace systems
   /// \brief This system manages all IMU sensors in simulation.
   /// Each IMU sensor eports vertical position, angular velocity
   /// and lienar acceleration readings over Ignition Transport.
-  class IGNITION_GAZEBO_IMU_SYSTEM_VISIBLE Imu:
+  class Imu:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/imu/Imu.hh
+++ b/src/systems/imu/Imu.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/imu-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -37,7 +37,7 @@ namespace systems
   /// \brief This system manages all IMU sensors in simulation.
   /// Each IMU sensor eports vertical position, angular velocity
   /// and lienar acceleration readings over Ignition Transport.
-  class IGNITION_GAZEBO_VISIBLE Imu:
+  class IGNITION_GAZEBO_IMU_SYSTEM_VISIBLE Imu:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_JOINTCONTROLLER_HH_
 #define IGNITION_GAZEBO_SYSTEMS_JOINTCONTROLLER_HH_
 
+#include <ignition/gazebo/joint-controller-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -69,7 +70,7 @@ namespace systems
   ///
   /// `<cmd_offset>` Command offset (feed-forward) of the PID.
   /// The default value is 0.
-  class IGNITION_GAZEBO_VISIBLE JointController
+  class IGNITION_GAZEBO_JOINT_CONTROLLER_SYSTEM_VISIBLE JointController
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -17,7 +17,6 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_JOINTCONTROLLER_HH_
 #define IGNITION_GAZEBO_SYSTEMS_JOINTCONTROLLER_HH_
 
-#include <ignition/gazebo/joint-controller-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -70,7 +69,7 @@ namespace systems
   ///
   /// `<cmd_offset>` Command offset (feed-forward) of the PID.
   /// The default value is 0.
-  class IGNITION_GAZEBO_JOINT_CONTROLLER_SYSTEM_VISIBLE JointController
+  class JointController
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -18,7 +18,6 @@
 #define IGNITION_GAZEBO_SYSTEMS_JOINTPOSITIONCONTROLLER_HH_
 
 #include <memory>
-#include <ignition/gazebo/joint-position-controller-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -18,6 +18,7 @@
 #define IGNITION_GAZEBO_SYSTEMS_JOINTPOSITIONCONTROLLER_HH_
 
 #include <memory>
+#include <ignition/gazebo/joint-position-controller-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -71,7 +72,7 @@ namespace systems
   ///
   /// `<cmd_offset>` Command offset (feed-forward) of the PID. Optional
   /// parameter. The default value is 0.
-  class IGNITION_GAZEBO_VISIBLE JointPositionController
+  class IGNITION_GAZEBO_JOINT_POSITION_CONTROLLER_SYSTEM_VISIBLE JointPositionController
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -72,7 +72,9 @@ namespace systems
   ///
   /// `<cmd_offset>` Command offset (feed-forward) of the PID. Optional
   /// parameter. The default value is 0.
-  class IGNITION_GAZEBO_JOINT_POSITION_CONTROLLER_SYSTEM_VISIBLE JointPositionController
+  class
+  IGNITION_GAZEBO_JOINT_POSITION_CONTROLLER_SYSTEM_VISIBLE
+  JointPositionController
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -71,9 +71,7 @@ namespace systems
   ///
   /// `<cmd_offset>` Command offset (feed-forward) of the PID. Optional
   /// parameter. The default value is 0.
-  class
-  IGNITION_GAZEBO_JOINT_POSITION_CONTROLLER_SYSTEM_VISIBLE
-  JointPositionController
+  class JointPositionController
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -20,7 +20,6 @@
 
 #include <memory>
 #include <set>
-#include <ignition/gazebo/joint-state-publisher-system/Export.hh>
 #include <ignition/gazebo/Model.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/gazebo/System.hh>
@@ -46,7 +45,7 @@ namespace systems
   /// `<joint_name>`: Name of a joint to publish. This parameter can be
   /// specified multiple times, and is optional. All joints in a model will
   /// be published if joint names are not specified.
-  class IGNITION_GAZEBO_JOINT_STATE_PUBLISHER_SYSTEM_VISIBLE JointStatePublisher
+  class JointStatePublisher
       : public System,
         public ISystemConfigure,
         public ISystemPostUpdate

--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <set>
+#include <ignition/gazebo/joint-state-publisher-system/Export.hh>
 #include <ignition/gazebo/Model.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/gazebo/System.hh>
@@ -45,7 +46,7 @@ namespace systems
   /// `<joint_name>`: Name of a joint to publish. This parameter can be
   /// specified multiple times, and is optional. All joints in a model will
   /// be published if joint names are not specified.
-  class IGNITION_GAZEBO_VISIBLE JointStatePublisher
+  class IGNITION_GAZEBO_JOINT_STATE_PUBLISHER_SYSTEM_VISIBLE JointStatePublisher
       : public System,
         public ISystemConfigure,
         public ISystemPostUpdate

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -19,7 +19,6 @@
 #define IGNITION_GAZEBO_SYSTEMS_LIFT_DRAG_HH_
 
 #include <memory>
-#include <ignition/gazebo/lift-drag-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -60,7 +59,7 @@ namespace systems
   ///               coefficient curve.
   /// cda_stall   : The ratio of coefficient of drag and alpha slope after
   ///               stall.
-  class IGNITION_GAZEBO_LIFT_DRAG_SYSTEM_VISIBLE LiftDrag
+  class LiftDrag
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -19,6 +19,7 @@
 #define IGNITION_GAZEBO_SYSTEMS_LIFT_DRAG_HH_
 
 #include <memory>
+#include <ignition/gazebo/lift-drag-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -59,7 +60,7 @@ namespace systems
   ///               coefficient curve.
   /// cda_stall   : The ratio of coefficient of drag and alpha slope after
   ///               stall.
-  class IGNITION_GAZEBO_VISIBLE LiftDrag
+  class IGNITION_GAZEBO_LIFT_DRAG_SYSTEM_VISIBLE LiftDrag
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/log/LogPlayback.hh
+++ b/src/systems/log/LogPlayback.hh
@@ -20,7 +20,7 @@
 #include <memory>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/log-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -37,7 +37,7 @@ namespace systems
   /// \class LogPlayback LogPlayback.hh
   ///   ignition/gazebo/systems/log/LogPlayback.hh
   /// \brief Log state playback
-  class IGNITION_GAZEBO_VISIBLE LogPlayback:
+  class IGNITION_GAZEBO_LOG_SYSTEM_VISIBLE LogPlayback:
     public System,
     public ISystemConfigure,
     public ISystemUpdate

--- a/src/systems/log/LogPlayback.hh
+++ b/src/systems/log/LogPlayback.hh
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/log-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -37,7 +36,7 @@ namespace systems
   /// \class LogPlayback LogPlayback.hh
   ///   ignition/gazebo/systems/log/LogPlayback.hh
   /// \brief Log state playback
-  class IGNITION_GAZEBO_LOG_SYSTEM_VISIBLE LogPlayback:
+  class LogPlayback:
     public System,
     public ISystemConfigure,
     public ISystemUpdate

--- a/src/systems/log/LogRecord.hh
+++ b/src/systems/log/LogRecord.hh
@@ -20,7 +20,7 @@
 #include <memory>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/log-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +36,7 @@ namespace systems
 
   /// \class LogRecord LogRecord.hh ignition/gazebo/systems/log/LogRecord.hh
   /// \brief Log state recorder
-  class IGNITION_GAZEBO_VISIBLE LogRecord:
+  class IGNITION_GAZEBO_LOG_SYSTEM_VISIBLE LogRecord:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate,

--- a/src/systems/log/LogRecord.hh
+++ b/src/systems/log/LogRecord.hh
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/log-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +35,7 @@ namespace systems
 
   /// \class LogRecord LogRecord.hh ignition/gazebo/systems/log/LogRecord.hh
   /// \brief Log state recorder
-  class IGNITION_GAZEBO_LOG_SYSTEM_VISIBLE LogRecord:
+  class LogRecord:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate,

--- a/src/systems/log_video_recorder/LogVideoRecorder.hh
+++ b/src/systems/log_video_recorder/LogVideoRecorder.hh
@@ -20,7 +20,6 @@
 #include <memory>
 #include <vector>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/log-video-recorder-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -50,7 +49,7 @@ namespace systems
   /// When recording is finished. An `end` string will be published to the
   /// `/log_video_recorder/status` topic and the videos are saved to a
   /// timestamped directory
-  class IGNITION_GAZEBO_LOG_VIDEO_RECORDER_SYSTEM_VISIBLE LogVideoRecorder:
+  class LogVideoRecorder:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/log_video_recorder/LogVideoRecorder.hh
+++ b/src/systems/log_video_recorder/LogVideoRecorder.hh
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/log-video-recorder-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -50,7 +50,7 @@ namespace systems
   /// When recording is finished. An `end` string will be published to the
   /// `/log_video_recorder/status` topic and the videos are saved to a
   /// timestamped directory
-  class IGNITION_GAZEBO_VISIBLE LogVideoRecorder:
+  class IGNITION_GAZEBO_LOG_VIDEO_RECORDER_SYSTEM_VISIBLE LogVideoRecorder:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudio.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudio.hh
@@ -41,7 +41,6 @@ namespace logical_audio
   /// device with a higher detection threshold.
   /// \return true if the listening device can detect volume at _volumeLevel,
   /// false otherwise.
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   bool detect(double _volumeLevel, double _volumeDetectionThreshold);
 
   /// \brief Computes the volume level of an audio source at a certain location.
@@ -62,7 +61,6 @@ namespace logical_audio
   /// \return The volume level at this location.
   /// If the attenuation function or shape is undefined, -1.0 is returned.
   /// If the source is not playing, 0.0 is returned.
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   double computeVolume(bool _playing,
       AttenuationFunction _attenuationFunc,
       AttenuationShape _attenuationShape,
@@ -85,7 +83,6 @@ namespace logical_audio
   /// the calculated attenuation function.
   /// \param[in] _str A string that should map to a value in
   /// AttenuationFunction.
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void setAttenuationFunction(AttenuationFunction &_attenuationFunc,
       std::string _str);
 
@@ -101,7 +98,6 @@ namespace logical_audio
   /// calculated attenuation shape.
   /// \param[in] _str A string that should map to a value in
   ///   AttenuationShape.
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void setAttenuationShape(AttenuationShape &_attenuationShape,
       std::string _str);
 
@@ -114,7 +110,6 @@ namespace logical_audio
   /// source. This value must be greater than _innerRadius.
   /// If _falloffDistance < _innerRadius, _falloffDistance will be set to
   /// _innerRadius + 1 (assuming that _innerRadius is valid).
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void validateInnerRadiusAndFalloffDistance(double &_innerRadius,
       double &_falloffDistance);
 
@@ -122,7 +117,6 @@ namespace logical_audio
   /// \param[in,out] _volumeLevel The volume the source should play at.
   /// This parameter is checked (and possibly clipped) to ensure that it falls
   /// between 0.0 (0% volume) and 1.0 (100% volume).
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void validateVolumeLevel(double &_volumeLevel);
 }
 }

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudio.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudio.hh
@@ -21,6 +21,7 @@
 
 #include <ignition/gazebo/components/LogicalAudio.hh>
 #include <ignition/gazebo/config.hh>
+#include <ignition/gazebo/logicalaudiosensorplugin-system/Export.hh>
 #include <ignition/math/Pose3.hh>
 
 namespace ignition
@@ -41,6 +42,7 @@ namespace logical_audio
   /// device with a higher detection threshold.
   /// \return true if the listening device can detect volume at _volumeLevel,
   /// false otherwise.
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   bool detect(double _volumeLevel, double _volumeDetectionThreshold);
 
   /// \brief Computes the volume level of an audio source at a certain location.
@@ -61,6 +63,7 @@ namespace logical_audio
   /// \return The volume level at this location.
   /// If the attenuation function or shape is undefined, -1.0 is returned.
   /// If the source is not playing, 0.0 is returned.
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   double computeVolume(bool _playing,
       AttenuationFunction _attenuationFunc,
       AttenuationShape _attenuationShape,
@@ -83,6 +86,7 @@ namespace logical_audio
   /// the calculated attenuation function.
   /// \param[in] _str A string that should map to a value in
   /// AttenuationFunction.
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void setAttenuationFunction(AttenuationFunction &_attenuationFunc,
       std::string _str);
 
@@ -98,6 +102,7 @@ namespace logical_audio
   /// calculated attenuation shape.
   /// \param[in] _str A string that should map to a value in
   ///   AttenuationShape.
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void setAttenuationShape(AttenuationShape &_attenuationShape,
       std::string _str);
 
@@ -110,6 +115,7 @@ namespace logical_audio
   /// source. This value must be greater than _innerRadius.
   /// If _falloffDistance < _innerRadius, _falloffDistance will be set to
   /// _innerRadius + 1 (assuming that _innerRadius is valid).
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void validateInnerRadiusAndFalloffDistance(double &_innerRadius,
       double &_falloffDistance);
 
@@ -117,6 +123,7 @@ namespace logical_audio
   /// \param[in,out] _volumeLevel The volume the source should play at.
   /// This parameter is checked (and possibly clipped) to ensure that it falls
   /// between 0.0 (0% volume) and 1.0 (100% volume).
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
   void validateVolumeLevel(double &_volumeLevel);
 }
 }

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudio.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudio.hh
@@ -21,7 +21,6 @@
 
 #include <ignition/gazebo/components/LogicalAudio.hh>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/logicalaudiosensorplugin-system/Export.hh>
 #include <ignition/math/Pose3.hh>
 
 namespace ignition

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 
-#include <ignition/gazebo/logicalaudiosensorplugin-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
@@ -128,9 +128,7 @@ namespace systems
   /// <PREFIX>/mic_<id>/detection topic, where <PREFIX> is the scoped name
   /// for the microphone - see ignition::gazebo::scopedName for more details -
   /// and <id> is the value specified in the microphone's <id> tag from the SDF.
-  class
-  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
-  LogicalAudioSensorPlugin :
+  class LogicalAudioSensorPlugin :
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate,

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
@@ -19,6 +19,7 @@
 
 #include <memory>
 
+#include <ignition/gazebo/logicalaudiosensorplugin-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -128,7 +129,7 @@ namespace systems
   /// <PREFIX>/mic_<id>/detection topic, where <PREFIX> is the scoped name
   /// for the microphone - see ignition::gazebo::scopedName for more details -
   /// and <id> is the value specified in the microphone's <id> tag from the SDF.
-  class IGNITION_GAZEBO_VISIBLE LogicalAudioSensorPlugin :
+  class IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE LogicalAudioSensorPlugin :
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate,

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
@@ -129,7 +129,9 @@ namespace systems
   /// <PREFIX>/mic_<id>/detection topic, where <PREFIX> is the scoped name
   /// for the microphone - see ignition::gazebo::scopedName for more details -
   /// and <id> is the value specified in the microphone's <id> tag from the SDF.
-  class IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE LogicalAudioSensorPlugin :
+  class
+  IGNITION_GAZEBO_LOGICALAUDIOSENSORPLUGIN_SYSTEM_VISIBLE
+  LogicalAudioSensorPlugin :
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate,

--- a/src/systems/logical_camera/LogicalCamera.hh
+++ b/src/systems/logical_camera/LogicalCamera.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/logical-camera-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -38,7 +38,7 @@ namespace systems
   **/
   /// \brief A logical camera sensor that reports objects detected within its
   /// frustum readings over ign transport
-  class IGNITION_GAZEBO_VISIBLE LogicalCamera:
+  class IGNITION_GAZEBO_LOGICAL_CAMERA_SYSTEM_VISIBLE LogicalCamera:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/logical_camera/LogicalCamera.hh
+++ b/src/systems/logical_camera/LogicalCamera.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/logical-camera-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -38,7 +37,7 @@ namespace systems
   **/
   /// \brief A logical camera sensor that reports objects detected within its
   /// frustum readings over ign transport
-  class IGNITION_GAZEBO_LOGICAL_CAMERA_SYSTEM_VISIBLE LogicalCamera:
+  class LogicalCamera:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/magnetometer/Magnetometer.hh
+++ b/src/systems/magnetometer/Magnetometer.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/magnetometer-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +36,7 @@ namespace systems
   /// \class Magnetometer Magnetometer.hh
   /// \brief An magnetometer sensor that reports the magnetic field in its
   /// current location.
-  class IGNITION_GAZEBO_VISIBLE Magnetometer:
+  class IGNITION_GAZEBO_MAGNETOMETER_SYSTEM_VISIBLE Magnetometer:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/magnetometer/Magnetometer.hh
+++ b/src/systems/magnetometer/Magnetometer.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/magnetometer-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +35,7 @@ namespace systems
   /// \class Magnetometer Magnetometer.hh
   /// \brief An magnetometer sensor that reports the magnetic field in its
   /// current location.
-  class IGNITION_GAZEBO_MAGNETOMETER_SYSTEM_VISIBLE Magnetometer:
+  class Magnetometer:
     public System,
     public ISystemPreUpdate,
     public ISystemPostUpdate

--- a/src/systems/multicopter_control/Common.hh
+++ b/src/systems/multicopter_control/Common.hh
@@ -19,6 +19,7 @@
 #define IGNITION_GAZEBO_SYSTEMS_MULTICOPTERVELOCITYCONTROL_COMMON_HH_
 
 #include <Eigen/Geometry>
+#include <optional>
 #include <vector>
 
 #include <sdf/sdf.hh>

--- a/src/systems/multicopter_control/LeeVelocityController.hh
+++ b/src/systems/multicopter_control/LeeVelocityController.hh
@@ -20,7 +20,6 @@
 
 #include <Eigen/Geometry>
 #include <memory>
-#include "ignition/gazebo/multicopter-control-system/Export.hh"
 #include "ignition/gazebo/config.hh"
 
 #include "Common.hh"
@@ -50,7 +49,7 @@ namespace multicopter_control
   /// https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_control/include/rotors_control/lee_position_controller.h
   /// The controller can be used to command linear velocity and yaw angle
   /// velocity expressed in the body frame.
-  class IGNITION_GAZEBO_MULTICOPTER_CONTROL_SYSTEM_VISIBLE LeeVelocityController
+  class LeeVelocityController
   {
     /// \brief Factory function to create LeeVelocityController objects
     /// \param[in] _controllerParams Controller parameteres

--- a/src/systems/multicopter_control/LeeVelocityController.hh
+++ b/src/systems/multicopter_control/LeeVelocityController.hh
@@ -20,6 +20,7 @@
 
 #include <Eigen/Geometry>
 #include <memory>
+#include "ignition/gazebo/multicopter-control-system/Export.hh"
 #include "ignition/gazebo/config.hh"
 
 #include "Common.hh"
@@ -49,7 +50,7 @@ namespace multicopter_control
   /// https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_control/include/rotors_control/lee_position_controller.h
   /// The controller can be used to command linear velocity and yaw angle
   /// velocity expressed in the body frame.
-  class LeeVelocityController
+  class IGNITION_GAZEBO_MULTICOPTER_CONTROL_SYSTEM_VISIBLE LeeVelocityController
   {
     /// \brief Factory function to create LeeVelocityController objects
     /// \param[in] _controllerParams Controller parameteres

--- a/src/systems/multicopter_control/MulticopterVelocityControl.hh
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.hh
@@ -146,9 +146,7 @@ namespace systems
   /// # Examples
   /// See examples/worlds/quadcopter.sdf for a demonstration.
   ///
-  class
-  IGNITION_GAZEBO_MULTICOPTER_CONTROL_SYSTEM_VISIBLE
-  MulticopterVelocityControl
+  class MulticopterVelocityControl
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/multicopter_control/MulticopterVelocityControl.hh
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.hh
@@ -146,7 +146,9 @@ namespace systems
   /// # Examples
   /// See examples/worlds/quadcopter.sdf for a demonstration.
   ///
-  class IGNITION_GAZEBO_MULTICOPTER_CONTROL_SYSTEM_VISIBLE MulticopterVelocityControl
+  class
+  IGNITION_GAZEBO_MULTICOPTER_CONTROL_SYSTEM_VISIBLE
+  MulticopterVelocityControl
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/multicopter_control/MulticopterVelocityControl.hh
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.hh
@@ -146,7 +146,7 @@ namespace systems
   /// # Examples
   /// See examples/worlds/quadcopter.sdf for a demonstration.
   ///
-  class IGNITION_GAZEBO_VISIBLE MulticopterVelocityControl
+  class IGNITION_GAZEBO_MULTICOPTER_CONTROL_SYSTEM_VISIBLE MulticopterVelocityControl
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
@@ -34,7 +34,9 @@ namespace systems
 
   /// \brief This system applies a thrust force to models with spinning
   /// propellers. See examples/worlds/quadcopter.sdf for a demonstration.
-  class IGNITION_GAZEBO_MULTICOPTER_MOTOR_MODEL_SYSTEM_VISIBLE MulticopterMotorModel
+  class
+  IGNITION_GAZEBO_MULTICOPTER_MOTOR_MODEL_SYSTEM_VISIBLE
+  MulticopterMotorModel
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_MULTICOPTERMOTORMODEL_HH_
 #define IGNITION_GAZEBO_SYSTEMS_MULTICOPTERMOTORMODEL_HH_
 
+#include "ignition/gazebo/multicopter-motor-model-system/Export.hh"
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -33,7 +34,7 @@ namespace systems
 
   /// \brief This system applies a thrust force to models with spinning
   /// propellers. See examples/worlds/quadcopter.sdf for a demonstration.
-  class IGNITION_GAZEBO_VISIBLE MulticopterMotorModel
+  class IGNITION_GAZEBO_MULTICOPTER_MOTOR_MODEL_SYSTEM_VISIBLE MulticopterMotorModel
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
@@ -33,9 +33,7 @@ namespace systems
 
   /// \brief This system applies a thrust force to models with spinning
   /// propellers. See examples/worlds/quadcopter.sdf for a demonstration.
-  class
-  IGNITION_GAZEBO_MULTICOPTER_MOTOR_MODEL_SYSTEM_VISIBLE
-  MulticopterMotorModel
+  class MulticopterMotorModel
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.hh
@@ -17,7 +17,6 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_MULTICOPTERMOTORMODEL_HH_
 #define IGNITION_GAZEBO_SYSTEMS_MULTICOPTERMOTORMODEL_HH_
 
-#include "ignition/gazebo/multicopter-motor-model-system/Export.hh"
 #include <ignition/gazebo/System.hh>
 #include <memory>
 

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
@@ -19,7 +19,7 @@
 #define IGNITION_GAZEBO_SYSTEMS_OPTICAL_TACTILE_PLUGIN_HH_
 
 #include <memory>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/opticaltactileplugin-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include "Visualization.hh"
 
@@ -66,7 +66,7 @@ namespace systems
     /// <visualize_sensor> Whether to visualize the sensor or not. This element
     /// is optional, and the default value is false.
 
-    class IGNITION_GAZEBO_VISIBLE OpticalTactilePlugin :
+    class IGNITION_GAZEBO_OPTICALTACTILEPLUGIN_SYSTEM_VISIBLE OpticalTactilePlugin :
       public System,
       public ISystemConfigure,
       public ISystemPreUpdate,

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
@@ -66,7 +66,9 @@ namespace systems
     /// <visualize_sensor> Whether to visualize the sensor or not. This element
     /// is optional, and the default value is false.
 
-    class IGNITION_GAZEBO_OPTICALTACTILEPLUGIN_SYSTEM_VISIBLE OpticalTactilePlugin :
+    class
+    IGNITION_GAZEBO_OPTICALTACTILEPLUGIN_SYSTEM_VISIBLE
+    OpticalTactilePlugin :
       public System,
       public ISystemConfigure,
       public ISystemPreUpdate,

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
@@ -19,7 +19,6 @@
 #define IGNITION_GAZEBO_SYSTEMS_OPTICAL_TACTILE_PLUGIN_HH_
 
 #include <memory>
-#include <ignition/gazebo/opticaltactileplugin-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include "Visualization.hh"
 

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
@@ -65,9 +65,7 @@ namespace systems
     /// <visualize_sensor> Whether to visualize the sensor or not. This element
     /// is optional, and the default value is false.
 
-    class
-    IGNITION_GAZEBO_OPTICALTACTILEPLUGIN_SYSTEM_VISIBLE
-    OpticalTactilePlugin :
+    class OpticalTactilePlugin :
       public System,
       public ISystemConfigure,
       public ISystemPreUpdate,

--- a/src/systems/optical_tactile_plugin/Visualization.hh
+++ b/src/systems/optical_tactile_plugin/Visualization.hh
@@ -22,7 +22,6 @@
 #include <string>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition

--- a/src/systems/performer_detector/PerformerDetector.hh
+++ b/src/systems/performer_detector/PerformerDetector.hh
@@ -25,6 +25,7 @@
 
 #include <ignition/transport/Node.hh>
 
+#include "ignition/gazebo/performer-detector-system/Export.hh"
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/System.hh"
 
@@ -77,7 +78,7 @@ namespace systems
   /// contents are interpreted as strings. Keys value pairs are stored in a
   /// map, which means the keys are unique.
 
-  class IGNITION_GAZEBO_VISIBLE PerformerDetector
+  class IGNITION_GAZEBO_PERFORMER_DETECTOR_SYSTEM_VISIBLE PerformerDetector
       : public System,
         public ISystemConfigure,
         public ISystemPostUpdate

--- a/src/systems/performer_detector/PerformerDetector.hh
+++ b/src/systems/performer_detector/PerformerDetector.hh
@@ -25,7 +25,6 @@
 
 #include <ignition/transport/Node.hh>
 
-#include "ignition/gazebo/performer-detector-system/Export.hh"
 #include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/System.hh"
 
@@ -78,7 +77,7 @@ namespace systems
   /// contents are interpreted as strings. Keys value pairs are stored in a
   /// map, which means the keys are unique.
 
-  class IGNITION_GAZEBO_PERFORMER_DETECTOR_SYSTEM_VISIBLE PerformerDetector
+  class PerformerDetector
       : public System,
         public ISystemConfigure,
         public ISystemPostUpdate

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -46,7 +46,6 @@
 #include <ignition/physics/sdf/ConstructWorld.hh>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/physics-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -62,7 +61,7 @@ namespace systems
 
   /// \class Physics Physics.hh ignition/gazebo/systems/Physics.hh
   /// \brief Base class for a System.
-  class IGNITION_GAZEBO_PHYSICS_SYSTEM_VISIBLE Physics:
+  class Physics:
     public System,
     public ISystemConfigure,
     public ISystemUpdate

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -46,7 +46,7 @@
 #include <ignition/physics/sdf/ConstructWorld.hh>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/physics-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -62,7 +62,7 @@ namespace systems
 
   /// \class Physics Physics.hh ignition/gazebo/systems/Physics.hh
   /// \brief Base class for a System.
-  class IGNITION_GAZEBO_VISIBLE Physics:
+  class IGNITION_GAZEBO_PHYSICS_SYSTEM_VISIBLE Physics:
     public System,
     public ISystemConfigure,
     public ISystemUpdate

--- a/src/systems/pose_publisher/PosePublisher.hh
+++ b/src/systems/pose_publisher/PosePublisher.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/pose-publisher-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -63,7 +62,7 @@ namespace systems
   ///                             negative frequency publishes as fast as
   ///                             possible (i.e, at the rate of the simulation
   ///                             step).
-  class IGNITION_GAZEBO_POSE_PUBLISHER_SYSTEM_VISIBLE PosePublisher
+  class PosePublisher
       : public System,
         public ISystemConfigure,
         public ISystemPostUpdate

--- a/src/systems/pose_publisher/PosePublisher.hh
+++ b/src/systems/pose_publisher/PosePublisher.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/pose-publisher-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -63,7 +63,7 @@ namespace systems
   ///                             negative frequency publishes as fast as
   ///                             possible (i.e, at the rate of the simulation
   ///                             step).
-  class IGNITION_GAZEBO_VISIBLE PosePublisher
+  class IGNITION_GAZEBO_POSE_PUBLISHER_SYSTEM_VISIBLE PosePublisher
       : public System,
         public ISystemConfigure,
         public ISystemPostUpdate

--- a/src/systems/scene_broadcaster/SceneBroadcaster.hh
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.hh
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/scene-broadcaster-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -38,7 +38,7 @@ namespace systems
   **/
   /// \brief System which periodically publishes an ignition::msgs::Scene
   /// message with updated information.
-  class IGNITION_GAZEBO_VISIBLE SceneBroadcaster:
+  class IGNITION_GAZEBO_SCENE_BROADCASTER_SYSTEM_VISIBLE SceneBroadcaster:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/scene_broadcaster/SceneBroadcaster.hh
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.hh
@@ -20,7 +20,6 @@
 #include <memory>
 #include <vector>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/scene-broadcaster-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -38,7 +37,7 @@ namespace systems
   **/
   /// \brief System which periodically publishes an ignition::msgs::Scene
   /// message with updated information.
-  class IGNITION_GAZEBO_SCENE_BROADCASTER_SYSTEM_VISIBLE SceneBroadcaster:
+  class SceneBroadcaster:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/sensors/Sensors.hh
+++ b/src/systems/sensors/Sensors.hh
@@ -21,7 +21,7 @@
 #include <string>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/sensors-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <sdf/Sensor.hh>
 
@@ -39,7 +39,7 @@ namespace systems
   /// \class Sensors Sensors.hh ignition/gazebo/systems/Sensors.hh
   /// \brief TODO(louise) Have one system for all sensors, or one per
   /// sensor / sensor type?
-  class IGNITION_GAZEBO_VISIBLE Sensors:
+  class IGNITION_GAZEBO_SENSORS_SYSTEM_VISIBLE Sensors:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/sensors/Sensors.hh
+++ b/src/systems/sensors/Sensors.hh
@@ -21,7 +21,6 @@
 #include <string>
 
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/sensors-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <sdf/Sensor.hh>
 
@@ -39,7 +38,7 @@ namespace systems
   /// \class Sensors Sensors.hh ignition/gazebo/systems/Sensors.hh
   /// \brief TODO(louise) Have one system for all sensors, or one per
   /// sensor / sensor type?
-  class IGNITION_GAZEBO_SENSORS_SYSTEM_VISIBLE Sensors:
+  class Sensors:
     public System,
     public ISystemConfigure,
     public ISystemPostUpdate

--- a/src/systems/thermal/Thermal.hh
+++ b/src/systems/thermal/Thermal.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/thermal-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -34,7 +34,7 @@ namespace systems
   class ThermalPrivate;
 
   /// \brief A thermal plugin that sets the temperature for the parent entity
-  class IGNITION_GAZEBO_VISIBLE Thermal:
+  class IGNITION_GAZEBO_THERMAL_SYSTEM_VISIBLE Thermal:
     public System,
     public ISystemConfigure
   {

--- a/src/systems/thermal/Thermal.hh
+++ b/src/systems/thermal/Thermal.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/thermal-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -34,7 +33,7 @@ namespace systems
   class ThermalPrivate;
 
   /// \brief A thermal plugin that sets the temperature for the parent entity
-  class IGNITION_GAZEBO_THERMAL_SYSTEM_VISIBLE Thermal:
+  class Thermal:
     public System,
     public ISystemConfigure
   {

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -19,7 +19,6 @@
 #define IGNITION_GAZEBO_SYSTEMS_TOUCH_PLUGIN_HH_
 
 #include <memory>
-#include "ignition/gazebo/touchplugin-system/Export.hh"
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -58,7 +57,7 @@ namespace systems
   ///
   /// <enabled> Set this to true so the plugin works from the start and doesn't
   ///           need to be enabled.
-  class IGNITION_GAZEBO_TOUCHPLUGIN_SYSTEM_VISIBLE TouchPlugin
+  class TouchPlugin
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -19,6 +19,7 @@
 #define IGNITION_GAZEBO_SYSTEMS_TOUCH_PLUGIN_HH_
 
 #include <memory>
+#include "ignition/gazebo/touchplugin-system/Export.hh"
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -57,7 +58,7 @@ namespace systems
   ///
   /// <enabled> Set this to true so the plugin works from the start and doesn't
   ///           need to be enabled.
-  class IGNITION_GAZEBO_VISIBLE TouchPlugin
+  class IGNITION_GAZEBO_TOUCHPLUGIN_SYSTEM_VISIBLE TouchPlugin
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -17,6 +17,7 @@
 
 #include "TriggeredPublisher.hh"
 
+#include <google/protobuf/message.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 
@@ -26,6 +27,11 @@
 #include <ignition/common/Profiler.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/plugin/Register.hh>
+
+// bug https://github.com/protocolbuffers/protobuf/issues/5051
+#ifdef _WIN32
+#undef GetMessage
+#endif
 
 using namespace ignition;
 using namespace gazebo;

--- a/src/systems/triggered_publisher/TriggeredPublisher.hh
+++ b/src/systems/triggered_publisher/TriggeredPublisher.hh
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 
-#include <ignition/gazebo/triggered-publisher-system/Export.hh>
 #include <ignition/transport/Node.hh>
 #include "ignition/gazebo/System.hh"
 

--- a/src/systems/triggered_publisher/TriggeredPublisher.hh
+++ b/src/systems/triggered_publisher/TriggeredPublisher.hh
@@ -154,8 +154,11 @@ namespace systems
   /// The current implementation of this system does not support specifying a
   /// subfield of a repeated field in the "field" attribute. i.e, if
   /// `field="f1.f2"`, `f1` cannot be a repeated field.
-  class IGNITION_GAZEBO_TRIGGERED_PUBLISHER_SYSTEM_VISIBLE TriggeredPublisher : public System,
-                                                     public ISystemConfigure
+  class
+  IGNITION_GAZEBO_TRIGGERED_PUBLISHER_SYSTEM_VISIBLE
+  TriggeredPublisher :
+    public System,
+    public ISystemConfigure
   {
     /// \brief Constructor
     public: TriggeredPublisher() = default;

--- a/src/systems/triggered_publisher/TriggeredPublisher.hh
+++ b/src/systems/triggered_publisher/TriggeredPublisher.hh
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <ignition/gazebo/triggered-publisher-system/Export.hh>
 #include <ignition/transport/Node.hh>
 #include "ignition/gazebo/System.hh"
 
@@ -153,7 +154,7 @@ namespace systems
   /// The current implementation of this system does not support specifying a
   /// subfield of a repeated field in the "field" attribute. i.e, if
   /// `field="f1.f2"`, `f1` cannot be a repeated field.
-  class IGNITION_GAZEBO_VISIBLE TriggeredPublisher : public System,
+  class IGNITION_GAZEBO_TRIGGERED_PUBLISHER_SYSTEM_VISIBLE TriggeredPublisher : public System,
                                                      public ISystemConfigure
   {
     /// \brief Constructor

--- a/src/systems/triggered_publisher/TriggeredPublisher.hh
+++ b/src/systems/triggered_publisher/TriggeredPublisher.hh
@@ -153,9 +153,7 @@ namespace systems
   /// The current implementation of this system does not support specifying a
   /// subfield of a repeated field in the "field" attribute. i.e, if
   /// `field="f1.f2"`, `f1` cannot be a repeated field.
-  class
-  IGNITION_GAZEBO_TRIGGERED_PUBLISHER_SYSTEM_VISIBLE
-  TriggeredPublisher :
+  class TriggeredPublisher :
     public System,
     public ISystemConfigure
   {

--- a/src/systems/user_commands/UserCommands.hh
+++ b/src/systems/user_commands/UserCommands.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/user-commands-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -55,7 +54,7 @@ namespace systems
   /// * **Response type*: ignition.msgs.Boolean
   ///
   /// Try some examples described on examples/worlds/empty.sdf
-  class IGNITION_GAZEBO_USER_COMMANDS_SYSTEM_VISIBLE UserCommands:
+  class UserCommands:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate

--- a/src/systems/user_commands/UserCommands.hh
+++ b/src/systems/user_commands/UserCommands.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/user-commands-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -55,7 +55,7 @@ namespace systems
   /// * **Response type*: ignition.msgs.Boolean
   ///
   /// Try some examples described on examples/worlds/empty.sdf
-  class IGNITION_GAZEBO_VISIBLE UserCommands:
+  class IGNITION_GAZEBO_USER_COMMANDS_SYSTEM_VISIBLE UserCommands:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate

--- a/src/systems/velocity_control/VelocityControl.hh
+++ b/src/systems/velocity_control/VelocityControl.hh
@@ -20,7 +20,6 @@
 #include <memory>
 #include <optional>
 
-#include <ignition/gazebo/velocity-control-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -36,7 +35,7 @@ namespace systems
 
   /// \brief Linear and angular velocity controller
   /// which is directly set on a model.
-  class IGNITION_GAZEBO_VELOCITY_CONTROL_SYSTEM_VISIBLE VelocityControl
+  class VelocityControl
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/velocity_control/VelocityControl.hh
+++ b/src/systems/velocity_control/VelocityControl.hh
@@ -18,7 +18,9 @@
 #define IGNITION_GAZEBO_SYSTEMS_VELOCITYCONTROL_HH_
 
 #include <memory>
+#include <optional>
 
+#include <ignition/gazebo/velocity-control-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -34,7 +36,7 @@ namespace systems
 
   /// \brief Linear and angular velocity controller
   /// which is directly set on a model.
-  class IGNITION_GAZEBO_VISIBLE VelocityControl
+  class IGNITION_GAZEBO_VELOCITY_CONTROL_SYSTEM_VISIBLE VelocityControl
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,

--- a/src/systems/wheel_slip/WheelSlip.hh
+++ b/src/systems/wheel_slip/WheelSlip.hh
@@ -18,7 +18,6 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_WHEELSLIP_HH_
 #define IGNITION_GAZEBO_SYSTEMS_WHEELSLIP_HH_
 
-#include <ignition/gazebo/wheel-slip-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -105,7 +104,7 @@ namespace systems
     </plugin>
    \endverbatim */
 
-  class IGNITION_GAZEBO_WHEEL_SLIP_SYSTEM_VISIBLE WheelSlip
+  class WheelSlip
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/wheel_slip/WheelSlip.hh
+++ b/src/systems/wheel_slip/WheelSlip.hh
@@ -18,6 +18,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMS_WHEELSLIP_HH_
 #define IGNITION_GAZEBO_SYSTEMS_WHEELSLIP_HH_
 
+#include <ignition/gazebo/wheel-slip-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 #include <memory>
 
@@ -104,7 +105,7 @@ namespace systems
     </plugin>
    \endverbatim */
 
-  class IGNITION_GAZEBO_VISIBLE WheelSlip
+  class IGNITION_GAZEBO_WHEEL_SLIP_SYSTEM_VISIBLE WheelSlip
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate

--- a/src/systems/wind_effects/WindEffects.hh
+++ b/src/systems/wind_effects/WindEffects.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/Export.hh>
+#include <ignition/gazebo/wind-effects-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -87,7 +87,7 @@ namespace systems
   /// <vertical><noise>
   /// Parameters for the noise that is added to the vertical wind velocity
   /// magnitude.
-  class IGNITION_GAZEBO_VISIBLE WindEffects:
+  class IGNITION_GAZEBO_WIND_EFFECTS_SYSTEM_VISIBLE WindEffects:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate

--- a/src/systems/wind_effects/WindEffects.hh
+++ b/src/systems/wind_effects/WindEffects.hh
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/wind-effects-system/Export.hh>
 #include <ignition/gazebo/System.hh>
 
 namespace ignition
@@ -87,7 +86,7 @@ namespace systems
   /// <vertical><noise>
   /// Parameters for the noise that is added to the vertical wind velocity
   /// magnitude.
-  class IGNITION_GAZEBO_WIND_EFFECTS_SYSTEM_VISIBLE WindEffects:
+  class WindEffects:
     public System,
     public ISystemConfigure,
     public ISystemPreUpdate


### PR DESCRIPTION
The PR solves a critical problem: when building a new component (new shared object) the visibility keyword can not be the same than a library it links to. This translated means: our systems and components can not use `IGNITION_GAZEBO_VISIBLE` but the custom name created by ign-cmake in the form of `IGNITION_GAZEBO_${COMPONENT_NAME}_VISIBLE`. Otherwise there is a nice list of fanky linker errors all around.