### PR TITLE
Change SelectedEntities to return a const ref

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,12 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Gazebo 4.x to 5.x
+
+* `ignition::gazebo::RenderUtil::SelectedEntities()` now returns a
+  `const std::vector<Entity> &` instead of forcing a copy. The calling code
+  should create a copy if it needs to modify the vector in some way.
+
 ## Ignition Gazebo 4.0.0 to 4.X.X
 
 * Ignition Gazebo 4.0.0 enabled double sided material by default but this
@@ -67,4 +73,3 @@ ignition-gazebo. To use the gui component downstream, update the find package
 call in cmake to request for the component, e.g.
 `ign_find_package(ignition-gazebo1 REQUIRED COMPONENTS gui)`, and link to the
 `libignition-gazebo1::gui` target instead of `libignition-gazebo1-gui`
-

--- a/include/ignition/gazebo/rendering/RenderUtil.hh
+++ b/include/ignition/gazebo/rendering/RenderUtil.hh
@@ -138,7 +138,7 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 
     /// \brief Get the entities currently selected, in order of selection.
     /// \return Vector of currently selected entities
-    public: std::vector<Entity> SelectedEntities() const;
+    public: const std::vector<Entity>& SelectedEntities() const;
 
     /// \brief Clears the set of selected entities and lowlights all of them.
     public: void DeselectAllEntities();

--- a/include/ignition/gazebo/rendering/RenderUtil.hh
+++ b/include/ignition/gazebo/rendering/RenderUtil.hh
@@ -138,7 +138,7 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 
     /// \brief Get the entities currently selected, in order of selection.
     /// \return Vector of currently selected entities
-    public: const std::vector<Entity>& SelectedEntities() const;
+    public: const std::vector<Entity> &SelectedEntities() const;
 
     /// \brief Clears the set of selected entities and lowlights all of them.
     public: void DeselectAllEntities();

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -615,7 +615,7 @@ void IgnRenderer::Render()
     {
       if (this->dataPtr->moveToHelper.Idle())
       {
-        std::vector<Entity> selectedEntities =
+        const std::vector<Entity> &selectedEntities =
           this->dataPtr->renderUtil.SelectedEntities();
 
         // Look at the origin if no entities are selected

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1405,7 +1405,7 @@ rendering::NodePtr RenderUtil::SelectedEntity() const
 }
 
 /////////////////////////////////////////////////
-std::vector<Entity> RenderUtil::SelectedEntities() const
+const std::vector<Entity>& RenderUtil::SelectedEntities() const
 {
   return this->dataPtr->selectedEntities;
 }

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1405,7 +1405,7 @@ rendering::NodePtr RenderUtil::SelectedEntity() const
 }
 
 /////////////////////////////////////////////////
-const std::vector<Entity>& RenderUtil::SelectedEntities() const
+const std::vector<Entity> &RenderUtil::SelectedEntities() const
 {
   return this->dataPtr->selectedEntities;
 }


### PR DESCRIPTION
Instead of returning a copy of the member variable, this PR changes this getter to return a const ref. In `Scene3D.cc`, a couple of places call the method without retaining ownership of the copied vector. This was specifically an issue here: https://github.com/ignitionrobotics/ign-gazebo/blob/bccea9087dd4355fc6d273d41a191d5c16563175/src/gui/plugins/scene3d/Scene3D.cc#L1846

In this line, because the vector is a copy, the `back()` ref operator returns a reference to an immediately deleted object, which will cause a memory read error and a subsequent segfault (in the gazebo gui).

I don't think this should break API too bad. But if someone was actually mutating the copy that was returned, then they could potentially be affected by this. I don't think it can be backported, since it breaks API and ABI. 


Signed-off-by: Stephen Brawner <brawner@gmail.com>