### PR TITLE
Fix pose of plane visual with non-default normal vector

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -258,16 +258,11 @@ rendering::VisualPtr SceneManager::CreateVisual(Entity _id,
     /// In general, this can be used to store any local transforms between the
     /// parent Visual and geometry.
     rendering::VisualPtr geomVis;
-    if (localPose != math::Pose3d::Zero)
-    {
-      geomVis = this->dataPtr->scene->CreateVisual(name + "_geom");
-      geomVis->SetUserData("gazebo-entity", static_cast<int>(_id));
-      geomVis->SetUserData("pause-update", static_cast<int>(0));
-      geomVis->SetLocalPose(_visual.RawPose() * localPose);
-      visualVis = geomVis;
-    }
+    geomVis = this->dataPtr->scene->CreateVisual(name + "_geom");
+    geomVis->AddGeometry(geom);
+    geomVis->SetLocalPose(localPose);
 
-    visualVis->AddGeometry(geom);
+    visualVis->AddChild(geomVis);
     visualVis->SetLocalScale(scale);
 
     // set material

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -257,12 +257,19 @@ rendering::VisualPtr SceneManager::CreateVisual(Entity _id,
     /// localPose is currently used to handle the normal vector in plane visuals
     /// In general, this can be used to store any local transforms between the
     /// parent Visual and geometry.
-    rendering::VisualPtr geomVis;
-    geomVis = this->dataPtr->scene->CreateVisual(name + "_geom");
-    geomVis->AddGeometry(geom);
-    geomVis->SetLocalPose(localPose);
+    if (localPose != math::Pose3d::Zero)
+    {
+      rendering::VisualPtr geomVis =
+          this->dataPtr->scene->CreateVisual(name + "_geom");
+      geomVis->AddGeometry(geom);
+      geomVis->SetLocalPose(localPose);
+      visualVis->AddChild(geomVis);
+    }
+    else
+    {
+      visualVis->AddGeometry(geom);
+    }
 
-    visualVis->AddChild(geomVis);
     visualVis->SetLocalScale(scale);
 
     // set material


### PR DESCRIPTION
Trying to verify my [comment](https://github.com/ignitionrobotics/ign-gazebo/pull/474#discussion_r561220629) led me to this bug. It looks like the rotation due to a plane's normal vector is accounted for during the creation of the visual but not in pose update. The creation is in: https://github.com/ignitionrobotics/ign-gazebo/blob/ddd7fcda563b1f8c47c92610181a2d5f797c80bc/src/rendering/SceneManager.cc#L261-L267  and the pose update  is done in: https://github.com/ignitionrobotics/ign-gazebo/blob/ddd7fcda563b1f8c47c92610181a2d5f797c80bc/src/rendering/RenderUtil.cc#L860  https://github.com/ignitionrobotics/ign-gazebo/blob/ddd7fcda563b1f8c47c92610181a2d5f797c80bc/src/rendering/RenderUtil.cc#L425

To test this, run the `shapes.sdf` example and set the plane visual's normal to `1 0 0`. 
<details>

```diff
diff --git a/examples/worlds/shapes.sdf b/examples/worlds/shapes.sdf
index 5dec565b..2136df07 100644
--- a/examples/worlds/shapes.sdf
+++ b/examples/worlds/shapes.sdf
@@ -35,3 +35,3 @@ Try moving a model:
             <plane>
-              <normal>0 0 1</normal>
+              <normal>1 0 0</normal>
             </plane>
@@ -42,3 +42,3 @@ Try moving a model:
             <plane>
-              <normal>0 0 1</normal>
+              <normal>1 0 0</normal>
               <size>100 100</size>
```

</details>

The plane should intersect with the shapes like so 
![image](https://user-images.githubusercontent.com/206116/105247262-214f2d80-5b3a-11eb-9c05-7b86098ac1cb.png)

Without this patch, the plane is not affected
![image](https://user-images.githubusercontent.com/206116/105247487-78550280-5b3a-11eb-8882-e90a5bf99708.png)


I believe this fixes #26.