### PR TITLE
Fix finding PBR materials

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -458,7 +458,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
       std::string roughnessMap = metal->RoughnessMap();
       if (!roughnessMap.empty())
       {
-        std::string fullPath = common::findFile(roughnessMap);
+        std::string fullPath = common::findFile(
+            asFullPath(roughnessMap, _material.FilePath()));
         if (!fullPath.empty())
           material->SetRoughnessMap(fullPath);
         else
@@ -469,7 +470,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
       std::string metalnessMap = metal->MetalnessMap();
       if (!metalnessMap.empty())
       {
-        std::string fullPath = common::findFile(metalnessMap);
+        std::string fullPath = common::findFile(
+            asFullPath(metalnessMap, _material.FilePath()));
         if (!fullPath.empty())
           material->SetMetalnessMap(fullPath);
         else
@@ -487,7 +489,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
     std::string albedoMap = workflow->AlbedoMap();
     if (!albedoMap.empty())
     {
-      std::string fullPath = common::findFile(albedoMap);
+      std::string fullPath = common::findFile(
+          asFullPath(albedoMap, _material.FilePath()));
       if (!fullPath.empty())
       {
         material->SetTexture(fullPath);
@@ -502,7 +505,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
     std::string normalMap = workflow->NormalMap();
     if (!normalMap.empty())
     {
-      std::string fullPath = common::findFile(normalMap);
+      std::string fullPath = common::findFile(
+          asFullPath(normalMap, _material.FilePath()));
       if (!fullPath.empty())
         material->SetNormalMap(fullPath);
       else
@@ -514,7 +518,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
     std::string environmentMap = workflow->EnvironmentMap();
     if (!environmentMap.empty())
     {
-      std::string fullPath = common::findFile(environmentMap);
+      std::string fullPath = common::findFile(
+          asFullPath(environmentMap, _material.FilePath()));
       if (!fullPath.empty())
         material->SetEnvironmentMap(fullPath);
       else
@@ -525,7 +530,8 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
     std::string emissiveMap = workflow->EmissiveMap();
     if (!emissiveMap.empty())
     {
-      std::string fullPath = common::findFile(emissiveMap);
+      std::string fullPath = common::findFile(
+          asFullPath(emissiveMap, _material.FilePath()));
       if (!fullPath.empty())
         material->SetEmissiveMap(fullPath);
       else


### PR DESCRIPTION
While loading https://app.ignitionrobotics.org/OpenRobotics/fuel/models/DronePlatformX1 I would see the following errors:

```
[Err] [SystemPaths.cc:444] Could not resolve file [./materials/textures/DronePlatformX1_Roughness.jpg]
[Err] [SceneManager.cc:465] Unable to find file [./materials/textures/DronePlatformX1_Roughness.jpg]
[Err] [SystemPaths.cc:444] Could not resolve file [./materials/textures/DronePlatformX1_Albedo.jpg]
[Err] [SceneManager.cc:498] Unable to find file [./materials/textures/DronePlatformX1_Albedo.jpg]
[Err] [SystemPaths.cc:444] Could not resolve file [./materials/textures/DronePlatformX1_Normal.jpg]
[Err] [SceneManager.cc:509] Unable to find file [./materials/textures/DronePlatformX1_Normal.jpg]
```

This resolves those errors.

Signed-off-by: Nate Koenig <nate@openrobotics.org>