### PR TITLE
Set thermal camera sensor ambient temperature range using temperature gradient

### DIFF
--- a/examples/worlds/thermal_camera.sdf
+++ b/examples/worlds/thermal_camera.sdf
@@ -121,7 +121,14 @@
     </light>
 
     <atmosphere type="adiabatic">
-      <temperature>310</temperature>
+      <temperature>290</temperature>
+      <!--
+        This is a more exaggerated temperature gradient, which produces a
+        temperature range of ~11.5 kelvin for objects in the thermal camera
+        view. Typical temperature gradient is -0.0065 K/m which produces a
+        temperature range of 0.75 kelvin
+      -->
+      <temperature_gradient>0.1</temperature_gradient>
     </atmosphere>
 
     <model name="ground_plane">
@@ -334,5 +341,6 @@
       <name>phone</name>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Samsung J8 Black Heat Signature</uri>
     </include>
+
   </world>
 </sdf>

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -78,6 +78,10 @@ class ignition::gazebo::systems::SensorsPrivate
   /// sea level
   public: double ambientTemperature = 288.15;
 
+  /// \brief Temperature gradient with respect to increasing altitude at sea
+  /// level in units of K/m.
+  public: double ambientTemperatureGradient = -0.0065;
+
   /// \brief Keep track of cameras, in case we need to handle stereo cameras.
   /// Key: Camera's parent scoped name
   /// Value: Pointer to camera
@@ -386,6 +390,8 @@ void Sensors::Configure(const Entity &/*_id*/,
     {
       auto atmosphereSdf = atmosphere->Data();
       this->dataPtr->ambientTemperature = atmosphereSdf.Temperature().Kelvin();
+      this->dataPtr->ambientTemperatureGradient =
+          atmosphereSdf.TemperatureGradient();
     }
 
     // Set render engine if specified from command line
@@ -564,6 +570,21 @@ std::string Sensors::CreateSensor(const Entity &_entity,
   if (nullptr != thermalSensor)
   {
     thermalSensor->SetAmbientTemperature(this->dataPtr->ambientTemperature);
+
+    // temperature gradient is in kelvin per meter - typically change in
+    // temperature over change in altitude). However the implementation of
+    // thermal sensor in ign-sensors varies temperature for all objects in its
+    // view. So we will do an approximation based on camera view's vertical
+    // distance.
+    auto camSdf = _sdf.CameraSensor();
+    double farClip = camSdf->FarClip();
+    double angle = camSdf->HorizontalFov().Radian();
+    double aspect = camSdf->ImageWidth() / camSdf->ImageHeight();
+    double vfov = 2.0 * atan(tan(angle / 2.0) / aspect);
+    double height = tan(vfov / 2.0) * farClip * 2.0;
+    double tempRange =
+        std::fabs(this->dataPtr->ambientTemperatureGradient * height);
+    thermalSensor->SetAmbientTemperatureRange(tempRange);
   }
 
   return sensor->Name();


### PR DESCRIPTION
depends on pull request #498 and https://github.com/ignitionrobotics/ign-rendering/pull/211

Objects without a temperature value or heat signature were all given a fixed ambient temperature value. This PR adds support for setting a temperature range so that all other non-heat source objects will now have some variations in their temperature readings.

Here's an example of inserting a backpack to the thermal_camera.sdf world. It relies on a new feature in https://github.com/ignitionrobotics/ign-rendering/pull/211 that simulates some variation in temperature values based on object's color.

![rgb_to_temperature](https://user-images.githubusercontent.com/4000684/105568841-72555200-5cf1-11eb-8d46-da7f3af44ce1.png)


Signed-off-by: Ian Chen <ichen@osrfoundation.org>