### PR TITLE
Backport state update changes from pull request #486

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1236,8 +1236,22 @@ void EntityComponentManager::SetState(
       {
         std::istringstream istr(compMsg.component());
         comp->Deserialize(istr);
-        this->SetChanged(entity, compIter.first,
-            ComponentState::OneTimeChange);
+        // \todo(anyone) Note on merging forward:
+        // `has_one_time_component` field is available in Edifice so this
+        // workaround can be removed
+        auto flag = ComponentState::PeriodicChange;
+        for (int i = 0; i < _stateMsg.header().data_size(); ++i)
+        {
+          if (_stateMsg.header().data(i).key() ==
+              "has_one_time_component_changes")
+          {
+            int v = stoi(_stateMsg.header().data(i).value(0));
+            if (v)
+              flag = ComponentState::OneTimeChange;
+            break;
+          }
+        }
+        this->SetChanged(entity, compIter.first, flag);
       }
     }
   }

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1236,9 +1236,9 @@ void EntityComponentManager::SetState(
       {
         std::istringstream istr(compMsg.component());
         comp->Deserialize(istr);
-        // \todo(anyone) Note on merging forward:
-        // `has_one_time_component` field is available in Edifice so this
-        // workaround can be removed
+        // Note on merging forward:
+        // `has_one_time_component_changes` field is available in Edifice so
+        // this workaround can be removed
         auto flag = ComponentState::PeriodicChange;
         for (int i = 0; i < _stateMsg.header().data_size(); ++i)
         {

--- a/src/network/NetworkManagerSecondary.cc
+++ b/src/network/NetworkManagerSecondary.cc
@@ -167,9 +167,9 @@ void NetworkManagerSecondary::OnStep(
   msgs::SerializedStateMap stateMsg;
   if (!entities.empty())
     this->dataPtr->ecm->State(stateMsg, entities);
-  // \todo(anyone) Note on merging forward:
-  // `has_one_time_component` field is available in Edifice so this workaround
-  // can be removed
+  // Note on merging forward:
+  // `has_one_time_component_changes` field is available in Edifice so this
+  // workaround can be removed
   auto data = stateMsg.mutable_header()->add_data();
   data->set_key("has_one_time_component_changes");
   data->add_value(this->dataPtr->ecm->HasOneTimeComponentChanges() ? "1" : "0");

--- a/src/network/NetworkManagerSecondary.cc
+++ b/src/network/NetworkManagerSecondary.cc
@@ -167,6 +167,12 @@ void NetworkManagerSecondary::OnStep(
   msgs::SerializedStateMap stateMsg;
   if (!entities.empty())
     this->dataPtr->ecm->State(stateMsg, entities);
+  // \todo(anyone) Note on merging forward:
+  // `has_one_time_component` field is available in Edifice so this workaround
+  // can be removed
+  auto data = stateMsg.mutable_header()->add_data();
+  data->set_key("has_one_time_component_changes");
+  data->add_value(this->dataPtr->ecm->HasOneTimeComponentChanges() ? "1" : "0");
 
   this->stepAckPub.Publish(stateMsg);
 


### PR DESCRIPTION
pull request #486 had to be targeted at Edifice because of the new `has_one_time_component_changes` field added in ign-msgs7. This PR uses a hacky workaround for storing that field in the msg header so we can backport to Citadel. 

With this change, I'm getting close to ~100% RTF running the distributed_levels.sdf example locally in distributed sim mode, compared to ~30-40% before the change.

On thing I noticed is that the [SetChanged](https://github.com/ignitionrobotics/ign-gazebo/blob/b6b57322252a645b9d7fa7a0122936e9077400d0/src/EntityComponentManager.cc#L1254) call in EntityComponentManager.cc is not reached in standalone mode so this change may not be affect normal ign-gazebo usage (?)

Signed-off-by: Ian Chen <ichen@osrfoundation.org>