### PR TITLE
Depend on ignition-utils1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,11 @@ ign_find_package(ignition-tools
                  PKGCONFIG "ignition-tools")
 
 #--------------------------------------
+# Find ignition-utils
+ign_find_package(ignition-utils1 REQUIRED)
+set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
+
+#--------------------------------------
 # Find protobuf
 # Module is needed to use the PROTOBUF_GENERATE_CPP
 set(protobuf_MODULE_COMPATIBLE TRUE)


### PR DESCRIPTION
Part of https://github.com/ignitionrobotics/ign-gazebo/issues/568

I didn't bother linking to the library in this PR, so this can focus on adding the dependency and getting CI turning.

I'll make a follow up PR that will actually use `ign-utils`.