### PR TITLE
Also use Ignition GUI render event

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -836,10 +836,16 @@ void IgnRenderer::Render()
 
   if (ignition::gui::App())
   {
-    gui::events::Render event;
+    ignition::gui::events::Render event;
     ignition::gui::App()->sendEvent(
         ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
         &event);
+
+    // This will be deprecated on v5 and removed on v6
+    ignition::gazebo::gui::events::Render oldEvent;
+    ignition::gui::App()->sendEvent(
+        ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
+        &oldEvent);
   }
 
   // only has an effect in video recording lockstep mode


### PR DESCRIPTION
The render event was ported from `ign-gazebo` to `ign-gui` on https://github.com/ignitionrobotics/ign-gui/issues/68 but `ign-gazebo` isn't making use of the GUI event yet.

The plan is to:

* Emit both events on Citadel and Dome
* Deprecate `ign-gazebo`'s render event on Edifice (see #595 )
* Remove `ign-gazebo`'s render event on Ign-F

This PR accomplishes the 1st bullet point.

This way, users can write `ign-gui` plugins that work both with `ignition::gui::Scene3D` and `ignition::gazebo::Scene3D`.