### PR TITLE
Use double sided field in material msg

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -272,12 +272,7 @@ msgs::Material ignition::gazebo::convert(const sdf::Material &_in)
   msgs::Set(out.mutable_emissive(), _in.Emissive());
   out.set_render_order(_in.RenderOrder());
   out.set_lighting(_in.Lighting());
-
-  // todo(anyone) add double_sided field to msgs::Material
-  auto data = out.mutable_header()->add_data();
-  data->set_key("double_sided");
-  std::string *value = data->add_value();
-  *value = std::to_string(_in.DoubleSided());
+  out.set_double_sided(_in.DoubleSided());
 
   sdf::Pbr *pbr = _in.PbrMaterial();
   if (pbr)
@@ -333,14 +328,7 @@ sdf::Material ignition::gazebo::convert(const msgs::Material &_in)
   out.SetEmissive(msgs::Convert(_in.emissive()));
   out.SetRenderOrder(_in.render_order());
   out.SetLighting(_in.lighting());
-
-  // todo(anyone) add double_sided field to msgs::Material
-  for (int i = 0; i < _in.header().data_size(); ++i)
-  {
-    const auto &data = _in.header().data(i);
-    if (data.key() == "double_sided" && data.value_size() > 0)
-      out.SetDoubleSided(math::parseInt(data.value(0)));
-  }
+  out.SetDoubleSided(_in.double_sided());
 
   if (_in.has_pbr())
   {

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -206,8 +206,6 @@ TEST(Conversions, Material)
   material.SetEmissive(ignition::math::Color(1.3f, 1.4f, 1.5f, 1.6f));
   material.SetLighting(true);
   material.SetRenderOrder(2.5);
-
-  // todo(anyone) add double_sided field to msgs::Material
   material.SetDoubleSided(true);
 
   sdf::Pbr pbr;
@@ -239,11 +237,7 @@ TEST(Conversions, Material)
       msgs::Convert(materialMsg.emissive()));
   EXPECT_TRUE(materialMsg.lighting());
   EXPECT_DOUBLE_EQ(2.5, materialMsg.render_order());
-
-  // todo(anyone) double_sided is temporarily stored in header
-  // Need to add double_sided field to msgs::Material
-  bool doubleSided = math::parseInt(materialMsg.header().data(0).value(0));
-  EXPECT_TRUE(doubleSided);
+  EXPECT_TRUE(materialMsg.double_sided());
 
   EXPECT_TRUE(materialMsg.has_pbr());
   const auto &pbrMsg = materialMsg.pbr();


### PR DESCRIPTION
depends on https://github.com/ignitionrobotics/ign-msgs/pull/130

Addresses a todo items in Conversions.cc for serializing material data. A new `double_sided` field is added in ign-msgs7 in https://github.com/ignitionrobotics/ign-msgs/pull/130 and this PR updates the conversion code to use that field.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>