### PR TITLE
Add /image suffix to thermal camera topic name

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -11,6 +11,13 @@ release will remove the deprecated code.
   `const std::vector<Entity> &` instead of forcing a copy. The calling code
   should create a copy if it needs to modify the vector in some way.
 
+* Default generated topic name for thermal cameras now includes the `/image`
+  suffix. The `camera_info` topic has also been fixed to include the sensor
+  name in the generated topic string. The naming scheme should be consistent
+  with a normal camera sensor. Topic changes:
+    * `/<prefix>/<sensor_name>` -> `/<prefix>/<sensor_name>/image`
+    * `/<prefix>/camera_info` -> `/<prefix>/<sensor_name>/camera_info`
+
 ## Ignition Gazebo 4.0.0 to 4.X.X
 
 * Ignition Gazebo 4.0.0 enabled double sided material by default but this

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -645,7 +645,7 @@ void RenderUtilPrivate::CreateRenderingEntities(
   const std::string cameraSuffix{"/image"};
   const std::string depthCameraSuffix{"/depth_image"};
   const std::string rgbdCameraSuffix{""};
-  const std::string thermalCameraSuffix{""};
+  const std::string thermalCameraSuffix{"/image"};
   const std::string gpuLidarSuffix{"/scan"};
 
   // Treat all pre-existent entities as new at startup


### PR DESCRIPTION
Adding `/image` suffix to make the topic name consistent with a normal camera sensor. This also fixes the `camera_info` topic name that's generated on the ign-sensors side. 

Topic changes:
    * `/<prefix>/<sensor_name>` -> `/<prefix>/<sensor_name>/image`
    * `/<prefix>/camera_info` -> `/<prefix>/<sensor_name>/camera_info`


Signed-off-by: Ian Chen <ichen@osrfoundation.org>