### PR TITLE
Fix build with latest sdformat11 branch

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -277,8 +277,8 @@ msgs::Material ignition::gazebo::convert(const sdf::Material &_in)
   auto pbr = _in.PbrMaterial();
   if (pbr)
   {
-    msgs::Material::PBR *pbrMsg = out.mutable_pbr();
-    sdf::PbrWorkflow *workflow = pbr->Workflow(sdf::PbrWorkflowType::METAL);
+    auto pbrMsg = out.mutable_pbr();
+    auto workflow = pbr->Workflow(sdf::PbrWorkflowType::METAL);
     if (workflow)
       pbrMsg->set_type(msgs::Material_PBR_WorkflowType_METAL);
     else

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -274,7 +274,7 @@ msgs::Material ignition::gazebo::convert(const sdf::Material &_in)
   out.set_lighting(_in.Lighting());
   out.set_double_sided(_in.DoubleSided());
 
-  sdf::Pbr *pbr = _in.PbrMaterial();
+  auto pbr = _in.PbrMaterial();
   if (pbr)
   {
     msgs::Material::PBR *pbrMsg = out.mutable_pbr();

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -268,10 +268,9 @@ TEST(Conversions, Material)
   EXPECT_TRUE(newMaterial.DoubleSided());
   EXPECT_DOUBLE_EQ(2.5, newMaterial.RenderOrder());
 
-  sdf::Pbr *newPbrMaterial = newMaterial.PbrMaterial();
+  auto newPbrMaterial = newMaterial.PbrMaterial();
   ASSERT_NE(nullptr, newPbrMaterial);
-  sdf::PbrWorkflow *newWorkflow =
-      newPbrMaterial->Workflow(sdf::PbrWorkflowType::METAL);
+  auto newWorkflow = newPbrMaterial->Workflow(sdf::PbrWorkflowType::METAL);
   ASSERT_NE(nullptr, newWorkflow);
   EXPECT_EQ("albedo_map.png", newWorkflow->AlbedoMap());
   EXPECT_EQ("normal_map.png", newWorkflow->NormalMap());

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -33,7 +33,8 @@ class ignition::gazebo::ModelPrivate
   public: Entity id{kNullEntity};
 };
 
-using namespace ignition::gazebo;
+using namespace ignition;
+using namespace gazebo;
 
 //////////////////////////////////////////////////
 Model::Model(gazebo::Entity _entity)

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -542,9 +542,9 @@ bool CreateCommand::Execute()
   }
   else if (isLight && isRoot)
   {
-    auto light = root.Light();
-    light->SetName(desiredName);
-    entity = this->iface->creator->CreateEntities(light);
+    auto light = *root.Light();
+    light.SetName(desiredName);
+    entity = this->iface->creator->CreateEntities(&light);
   }
   else if (isLight)
   {

--- a/test/integration/components.cc
+++ b/test/integration/components.cc
@@ -1054,10 +1054,9 @@ TEST_F(ComponentsTest, Material)
   EXPECT_EQ(math::Color(1, 1, 1, 1), comp3.Data().Emissive());
   EXPECT_FALSE(comp3.Data().Lighting());
 
-  sdf::Pbr *newPbrMaterial = comp3.Data().PbrMaterial();
+  auto newPbrMaterial = comp3.Data().PbrMaterial();
   ASSERT_NE(nullptr, newPbrMaterial);
-  sdf::PbrWorkflow *newWorkflow =
-      newPbrMaterial->Workflow(sdf::PbrWorkflowType::METAL);
+  auto newWorkflow = newPbrMaterial->Workflow(sdf::PbrWorkflowType::METAL);
   ASSERT_NE(nullptr, newWorkflow);
   EXPECT_EQ("albedo_map.png", newWorkflow->AlbedoMap());
   EXPECT_EQ("normal_map.png", newWorkflow->NormalMap());

--- a/test/plugins/Null.cc
+++ b/test/plugins/Null.cc
@@ -15,6 +15,7 @@
  *
 */
 #include "Null.hh"
+#include <ignition/gazebo/Entity.hh>
 #include <ignition/plugin/Register.hh>
 
 using namespace ignition::gazebo::systems;


### PR DESCRIPTION
The const-correctness introduced in https://github.com/osrf/sdformat/pull/474 broke `ign-gazebo`. I originally thought this was a Windows-only issue, but it turns out it manifested first on Windows because CI builds SDFormat from source.