### PR TITLE
4.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo4 VERSION 4.3.0)
+project(ignition-gazebo4 VERSION 4.4.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@
 1. Add about dialog
     * [Pull Request 609](https://github.com/ignitionrobotics/ign-gazebo/pull/609)
 
-1. Add thermal sensor syste for configuring thermal camera properties
+1. Add thermal sensor system for configuring thermal camera properties
     * [Pull Request 614](https://github.com/ignitionrobotics/ign-gazebo/pull/614)
 
 ### Ignition Gazebo 4.3.0 (2020-02-02)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,22 @@
 ## Ignition Gazebo 4.x
 
+### Ignition Gazebo 4.4.0 (2020-02-10)
+
+1. Added issue and PR templates
+    * [Pull Request 613](https://github.com/ignitionrobotics/ign-gazebo/pull/613)
+
+1. Fix segfault in SetRemovedComponentsMsgs method
+    * [Pull Request 495](https://github.com/ignitionrobotics/ign-gazebo/pull/495)
+
+1. Make topics configurable for joint controllers
+    * [Pull Request 584](https://github.com/ignitionrobotics/ign-gazebo/pull/584)
+
+1. Add about dialog
+    * [Pull Request 609](https://github.com/ignitionrobotics/ign-gazebo/pull/609)
+
+1. Add thermal sensor syste for configuring thermal camera properties
+    * [Pull Request 614](https://github.com/ignitionrobotics/ign-gazebo/pull/614)
+
 ### Ignition Gazebo 4.3.0 (2020-02-02)
 
 1. Non-blocking paths request.


### PR DESCRIPTION
Prepare for `4.4.0` release.

Comparison to `4.3.0`: https://github.com/ignitionrobotics/ign-gazebo/compare/ignition-gazebo4_4.3.0...ign-gazebo4

---

**Question for reviewers:** (cc @iche033) since #614 doesn't require users to have the recent `ign-gui4.2.0`, `ign-sensors4.1.0`, and `ign-rendering4.4.0` releases (users can keep using 16-bit thermal cameras as they have been prior to this release if they wish), we don't need to bump the dependencies on those libraries, right? Or do we need to bump those dependencies since users can't use the 8-bit option introduced in #614 without `ign-gui4.2.0`, `ign-sensors4.1.0`, and `ign-rendering4.4.0`?

---

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

**Note to maintainers**: Remember to use **Squash-Merge**
