### PR TITLE
Validity check for user defined topics in JointPositionController

### DIFF
--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -147,8 +147,8 @@ void JointController::Configure(const Entity &_entity,
 
     if (topic.empty())
     {
-      ignerr << "Failed to create topic [" << this->dataPtr->jointName
-             << "]" << " for joint [" << _sdf->Get<std::string>("topic")
+      ignerr << "Failed to create topic [" << _sdf->Get<std::string>("topic")
+             << "]" << " for joint [" << this->dataPtr->jointName
              << "]" << std::endl;
       return;
     }

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -158,7 +158,16 @@ void JointPositionController::Configure(const Entity &_entity,
   }
   if (_sdf->HasElement("topic"))
   {
-    topic = _sdf->Get<std::string>("topic");
+    topic = transport::TopicUtils::AsValidTopic(
+        _sdf->Get<std::string>("topic"));
+
+    if (topic.empty())
+    {
+      ignerr << "Failed to create topic [" << _sdf->Get<std::string>("topic")
+             << "]" << " for joint [" << this->dataPtr->jointName
+             << "]" << std::endl;
+      return;
+    }
   }
   this->dataPtr->node.Subscribe(
       topic, &JointPositionControllerPrivate::OnCmdPos, this->dataPtr.get());


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #624

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
1. The user-defined topics for joint position controllers are checked for validity using `AsValidTopic`.
2. Fixes the topic error message in JointController.