### PR TITLE
👩‍🌾 Fix flaky SceneBroadcaster test

### DIFF
--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -438,6 +438,7 @@ TEST_P(SceneBroadcasterTest, State)
   while (!received && sleep++ < maxSleep)
     IGN_SLEEP_MS(100);
   EXPECT_TRUE(received);
+  EXPECT_TRUE(node.Unsubscribe("/world/default/state"));
 
   // test async state request
   received = false;


### PR DESCRIPTION
Signed-off-by: Louise Poubel <louise@openrobotics.org>

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `State` test [has been flaky](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-bionic-amd64/101/testReport/(root)/ServerRepeat_SceneBroadcasterTest/State_0/history/), with this error:

```
113: /var/lib/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-bionic-amd64/ign-gazebo/test/integration/scene_broadcaster_system.cc:385: Failure
113: Expected equality of these values:
113:   _count
113:     Which is: 3
113:   _msg.state().entities_size()
113:     Which is: 16
```

I can also reproduce the flakiness locally.

What happens is that the subscriber correctly receives 3 entities, but then it remains subscribed. As the test goes on to make another full state request, which sends 16 entities, if the test lasts long enough, the subscriber often receives that too and the test fails. The solution is to unsubscribe from that topic as soon as we're done checking for the 3 entities.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

---

https://github.com/osrf/buildfarmer/issues/156