### PR TITLE
👩‍🌾 Improve velocity control test

### DIFF
--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -96,31 +96,21 @@ class VelocityControlTest : public ::testing::TestWithParam<int>
     // and max velocity (0.5 m/s).
     // See <max_velocity< and <max_aceleration> parameters
     // in "/test/worlds/velocity_control.sdf".
-    test::Relay velocityRamp;
     const double desiredLinVel = 10.5;
     const double desiredAngVel = 0.2;
-    velocityRamp.OnPreUpdate(
-        [&](const gazebo::UpdateInfo &/*_info*/,
-            const gazebo::EntityComponentManager &)
-        {
-          msgs::Set(msg.mutable_linear(),
-                    math::Vector3d(desiredLinVel, 0, 0));
-          msgs::Set(msg.mutable_angular(),
-                    math::Vector3d(0.0, 0, desiredAngVel));
-          pub.Publish(msg);
-        });
+    msgs::Set(msg.mutable_linear(),
+              math::Vector3d(desiredLinVel, 0, 0));
+    msgs::Set(msg.mutable_angular(),
+              math::Vector3d(0.0, 0, desiredAngVel));
+    pub.Publish(msg);
 
-    server.AddSystem(velocityRamp.systemPtr);
+    // Give some time for message to be received
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     server.Run(true, 3000, false);
 
     // Poses for 4s
     ASSERT_EQ(4000u, poses.size());
-
-    int sleep = 0;
-    int maxSleep = 30;
-
-    ASSERT_NE(maxSleep, sleep);
 
     // verify that the vehicle is moving in +x and rotating towards +y
     for (unsigned int i = 1001; i < poses.size(); ++i)

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -125,14 +125,14 @@ class VelocityControlTest : public ::testing::TestWithParam<int>
     // verify that the vehicle is moving in +x and rotating towards +y
     for (unsigned int i = 1001; i < poses.size(); ++i)
     {
-      EXPECT_GT(poses[i].Pos().X(), poses[i-1].Pos().X());
-      EXPECT_GT(poses[i].Pos().Y(), poses[i-1].Pos().Y());
+      EXPECT_GT(poses[i].Pos().X(), poses[i-1].Pos().X()) << i;
+      EXPECT_GT(poses[i].Pos().Y(), poses[i-1].Pos().Y()) << i;
       EXPECT_NEAR(poses[i].Pos().Z(), poses[i-1].Pos().Z(), 1e-5);
       EXPECT_NEAR(poses[i].Rot().Euler().X(),
-          poses[i-1].Rot().Euler().X(), 1e-5);
+          poses[i-1].Rot().Euler().X(), 1e-5) << i;
       EXPECT_NEAR(poses[i].Rot().Euler().Y(),
-          poses[i-1].Rot().Euler().Y(), 1e-5);
-      EXPECT_GT(poses[i].Rot().Euler().Z(), poses[i-1].Rot().Euler().Z());
+          poses[i-1].Rot().Euler().Y(), 1e-5) << i;
+      EXPECT_GT(poses[i].Rot().Euler().Z(), poses[i-1].Rot().Euler().Z()) << i;
     }
   }
 };


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `PublishCmd` test is slightly flaky, it failed [1 of the last 15 builds](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-bionic-amd64/96/testReport/junit/(root)/ServerRepeat_VelocityControlTest/PublishCmd_0/history/) with:

```
127: /var/lib/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-bionic-amd64/ign-gazebo/test/integration/velocity_control_system.cc:128: Failure
127: Expected: (poses[i].Pos().X()) > (poses[i-1].Pos().X()), actual: 2.12913e-10 vs 2.13556e-10
127: /var/lib/jenkins/workspace/ignition_gazebo-ci-ign-gazebo3-bionic-amd64/ign-gazebo/test/integration/velocity_control_system.cc:129: Failure
127: Expected: (poses[i].Pos().Y()) > (poses[i-1].Pos().Y()), actual: 2 vs 2
```

I suspect this may happen when the message is received a bit too late and the first iteration misses the command. I added a little sleep for the lack of some better check. The test isn't very flaky, so this may be just enough.

I also cleaned up the test a bit. The `sleep` / `maxSleep` weren't being used, and there's no need to create a system to publish the message.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [ ] ~~`codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))~~
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

---

https://github.com/osrf/buildfarmer/issues/156