### PR TITLE
Add msg to show the computed temperature range computed from temperature gradient

### DIFF
--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -596,6 +596,12 @@ std::string Sensors::CreateSensor(const Entity &_entity,
     double tempRange =
         std::fabs(this->dataPtr->ambientTemperatureGradient * height);
     thermalSensor->SetAmbientTemperatureRange(tempRange);
+
+    ignmsg << "Setting ambient temperature to "
+           << this->dataPtr->ambientTemperature << " Kelvin and gradient to "
+           << this->dataPtr->ambientTemperatureGradient << " K/m. "
+           << "The resulting temperature range is: " << tempRange
+           << " Kelvin." << std::endl;
   }
 
   return sensor->Name();


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

## Summary

Currently users set the temperature gradient through sdf but there is no way to know what the actual temperature range that is computed from this gradient value. This PR adds a print statement to output the computed temperature range value

## Test it

```
ign gazebo -v 4 src/ign-gazebo/examples/worlds/thermal_camera.sdf
```

and you should see the msg:

```
[Msg] Setting ambient temperature to 300 Kelvin and gradient to 0.1 K/m. The resulting temperature range is: 11.5444 Kelvin.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

