### PR TITLE
👩‍🌾 Set LD_LIBRARY_PATH on Actions CI (fix user_commands test)

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -5,6 +5,7 @@ set -e
 
 # Install (needed for some tests)
 make install
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
 # For ign-tools
 export IGN_CONFIG_PATH=/usr/local/share/ignition

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 # Search for project-specific dependencies
 #============================================================================
 
-ign_find_package(sdformat10 REQUIRED)
+ign_find_package(sdformat10 REQUIRED VERSION 10.3)
 set(SDF_VER ${sdformat10_VERSION_MAJOR})
 
 #--------------------------------------


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #634 on GitHub actions (possibly on Homebrew too?)

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The test failures on GitHub actions print:

```
Error while loading the library [/usr/local/lib/ign-gazebo-5/plugins/libignition-gazebo-sensors-system.so]: libignition-gazebo5-rendering.so.5: cannot open shared object file: No such file or directory
  [Err] [SystemLoader.cc:75] Failed to load system plugin [ignition-gazebo-sensors-system] : couldn't load library on path [/usr/local/lib/ign-gazebo-5/plugins/libignition-gazebo-sensors-system.so].
```

So it looks like all it needs is the path to where that is installed. I'm not sure why that hasn't come up before with other tests.

I also took the opportunity to increase the required SDF 10 version, which is needed since #636

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

---

https://github.com/osrf/buildfarmer/issues/161