### PR TITLE
Deprecate TmpIface: it's leftover from prototyping

### DIFF
--- a/include/ignition/gazebo/gui/TmpIface.hh
+++ b/include/ignition/gazebo/gui/TmpIface.hh
@@ -41,7 +41,7 @@ namespace ignition
       Q_OBJECT
 
       /// \brief Constructor: advertize services and topics
-      public: TmpIface();
+      public: IGN_DEPRECATED(5.0) TmpIface();
 
       /// \brief Destructor
       public: ~TmpIface() override = default;
@@ -74,9 +74,6 @@ namespace ignition
 
       /// \brief Communication node
       private: transport::Node node;
-
-      /// \brief Publisher
-      private: transport::Node::Publisher worldStatsPub;
     };
   }
 }

--- a/src/cmd/ign.cc
+++ b/src/cmd/ign.cc
@@ -26,7 +26,6 @@
 
 #include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/gui/GuiRunner.hh"
-#include "ignition/gazebo/gui/TmpIface.hh"
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/ServerConfig.hh"
 #include "ign.hh"
@@ -218,9 +217,6 @@ extern "C" int runGui(const char *_guiConfig)
   ignmsg << "Ignition Gazebo GUI    v" << IGNITION_GAZEBO_VERSION_FULL
          << std::endl;
 
-  // Temporary transport interface
-  auto tmp = std::make_unique<ignition::gazebo::TmpIface>();
-
   int argc = 0;
   char **argv = nullptr;
 
@@ -242,10 +238,6 @@ extern "C" int runGui(const char *_guiConfig)
   auto mainWin = app.findChild<ignition::gui::MainWindow *>();
   auto win = mainWin->QuickWindow();
   win->setProperty("title", "Gazebo");
-
-  // Let QML files use TmpIface' functions and properties
-  auto context = new QQmlContext(app.Engine()->rootContext());
-  context->setContextProperty("TmpIface", tmp.get());
 
   // Instantiate GazeboDrawer.qml file into a component
   QQmlComponent component(app.Engine(), ":/Gazebo/GazeboDrawer.qml");

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -22,7 +22,7 @@ qt5_wrap_cpp(gui_sources
   ${PROJECT_SOURCE_DIR}/include/ignition/gazebo/gui/GuiSystem.hh
   # TODO (anyone) Remove when GuiRunner.hh is moved to `src`
   ${PROJECT_SOURCE_DIR}/include/ignition/gazebo/gui/GuiRunner.hh
-  # TODO (anyone) Remove when TmpIface.hh is moved to `src`
+  # TODO (anyone) Remove in v6
   ${PROJECT_SOURCE_DIR}/include/ignition/gazebo/gui/TmpIface.hh
 )
 

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -25,7 +25,6 @@
 
 #include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/gui/GuiRunner.hh"
-#include "ignition/gazebo/gui/TmpIface.hh"
 
 #include "ignition/gazebo/gui/Gui.hh"
 #include "GuiFileHandler.hh"
@@ -65,10 +64,6 @@ std::unique_ptr<ignition::gui::Application> createGui(
   auto app = std::make_unique<ignition::gui::Application>(_argc, _argv);
   app->AddPluginPath(IGN_GAZEBO_GUI_PLUGIN_INSTALL_DIR);
 
-  // Temporary transport interface
-  auto tmp = new ignition::gazebo::TmpIface();
-  tmp->setParent(app->Engine());
-
   auto guiFileHandler = new ignition::gazebo::gui::GuiFileHandler();
   guiFileHandler->setParent(app->Engine());
 
@@ -105,9 +100,8 @@ std::unique_ptr<ignition::gui::Application> createGui(
   auto win = mainWin->QuickWindow();
   win->setProperty("title", "Gazebo");
 
-  // Let QML files use TmpIface' functions and properties
+  // Let QML files use C++ functions and properties
   auto context = new QQmlContext(app->Engine()->rootContext());
-  context->setContextProperty("TmpIface", tmp);
   context->setContextProperty("GuiFileHandler", guiFileHandler);
 
   // Instantiate GazeboDrawer.qml file into a component

--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -45,9 +45,6 @@ Rectangle {
   function onAction(_action) {
     switch(_action) {
       // Handle custom actions
-      case "newWorld":
-        TmpIface.OnNewWorld();
-        break
       case "saveWorld":
         if (lastSaveSuccess)
           GuiFileHandler.SaveWorldAs(saveWorldFileText.text, sdfGenConfig)
@@ -56,9 +53,6 @@ Rectangle {
         break
       case "saveWorldAs":
         sdfGenConfigDialog.open();
-        break
-      case "loadWorld":
-        loadWorldDialog.open();
         break
       // Forward others to default drawer
       default:
@@ -71,16 +65,6 @@ Rectangle {
     id: drawerModel
 
     // Custom action which calls custom C++ code
-    /*ListElement {
-      title: "New world"
-      actionElement: "newWorld"
-      type: "world"
-    }
-    ListElement {
-      title: "Load world"
-      actionElement: "loadWorld"
-      type: "world"
-    }*/
     ListElement {
       title: "Save world"
       actionElement: "saveWorld"
@@ -133,21 +117,6 @@ Rectangle {
     model: drawerModel
 
     ScrollIndicator.vertical: ScrollIndicator { }
-  }
-
-  /**
-   * Load world dialog
-   */
-  FileDialog {
-    id: loadWorldDialog
-    title: "Load world"
-    folder: shortcuts.home
-    nameFilters: [ "World files (*.world, *.sdf)" ]
-    selectMultiple: false
-    selectExisting: true
-    onAccepted: {
-      TmpIface.OnLoadWorld(fileUrl)
-    }
   }
 
   /**


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This file was never meant to be installed. In fact, it should have been deleted back before we released Acropolis:

https://github.com/ignitionrobotics/ign-gazebo/blob/bd261d5c140fa4c31a6df8702a305d400e3e1654/include/ignition/gazebo/gui/TmpIface.hh#L38

Better late than never :innocent: 

I felt the urge to just remove it, but we never know if some code is instantiating it by mistake... So this kicks off the tick-tock cycle (deprecate on v5, remove on v6). It's been there for 4 versions, one more won't hurt.

I also removed all the disabled code for loading a new world or a world from a file. We can revive it when addressing #94.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**