### PR TITLE
Check empty world name in Scene3d

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2721,21 +2721,20 @@ void Scene3D::Update(const UpdateInfo &_info,
   if (this->dataPtr->worldName.empty())
   {
     // TODO(anyone) Only one scene is supported for now
+    Entity worldEntity;
     _ecm.Each<components::World, components::Name>(
-        [&](const Entity &/*_entity*/,
+        [&](const Entity &_entity,
           const components::World * /* _world */ ,
           const components::Name *_name)->bool
         {
           this->dataPtr->worldName = _name->Data();
+          worldEntity = _entity;
           return true;
         });
 
     if (!this->dataPtr->worldName.empty())
     {
       renderWindow->SetWorldName(this->dataPtr->worldName);
-      auto worldEntity =
-        _ecm.EntityByComponents(components::Name(this->dataPtr->worldName),
-          components::World());
       auto renderEngineGuiComp =
         _ecm.Component<components::RenderEngineGuiPlugin>(worldEntity);
       if (renderEngineGuiComp && !renderEngineGuiComp->Data().empty())

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2730,20 +2730,23 @@ void Scene3D::Update(const UpdateInfo &_info,
           return true;
         });
 
-    renderWindow->SetWorldName(this->dataPtr->worldName);
-    auto worldEntity =
-      _ecm.EntityByComponents(components::Name(this->dataPtr->worldName),
-        components::World());
-    auto renderEngineGuiComp =
-      _ecm.Component<components::RenderEngineGuiPlugin>(worldEntity);
-    if (renderEngineGuiComp && !renderEngineGuiComp->Data().empty())
+    if (!this->dataPtr->worldName.empty())
     {
-      this->dataPtr->renderUtil->SetEngineName(renderEngineGuiComp->Data());
-    }
-    else
-    {
-      igndbg << "RenderEngineGuiPlugin component not found, "
-        "render engine won't be set from the ECM" << std::endl;
+      renderWindow->SetWorldName(this->dataPtr->worldName);
+      auto worldEntity =
+        _ecm.EntityByComponents(components::Name(this->dataPtr->worldName),
+          components::World());
+      auto renderEngineGuiComp =
+        _ecm.Component<components::RenderEngineGuiPlugin>(worldEntity);
+      if (renderEngineGuiComp && !renderEngineGuiComp->Data().empty())
+      {
+        this->dataPtr->renderUtil->SetEngineName(renderEngineGuiComp->Data());
+      }
+      else
+      {
+        igndbg << "RenderEngineGuiPlugin component not found, "
+          "render engine won't be set from the ECM " << std::endl;
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

When loading a world with large complex meshes, I get a spam of the following msg:

```
[GUI] [Dbg] [Scene3D.cc:2745] RenderEngineGuiPlugin component not found, render engine won't be set from the ECM
```

This happens because the server takes a while to load while the gui is already up and running and it keeps checking for the RenderEngineGuiPlugin component on every update (and stops checking only when the it gets the world entity form the sever). In simple worlds, this does not happen because the server is usually loaded quite fast and have the world entity ready for gui on initalization.

This PR adds a check on the Scene3d plugin side so that it does not attempt to find the world's `RenderEngineGuiPlugin` component if the world entity is not ready yet.

# To test

run ign gazebo with a complex world, e.g.

```
ign gazebo -v tunnel.sdf
```

You should see a few `RenderEngineGuiPlugin component not found` msgs printed in the console.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

