### PR TITLE
Backport #561: Use common::setenv

### DIFF
--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -49,8 +49,8 @@ class ServerFixture : public ::testing::TestWithParam<int>
   protected: void SetUp() override
   {
     // Augment the system plugin path.  In SetUp to avoid test order issues.
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
     ignition::common::Console::SetVerbosity(4);
   }
@@ -788,9 +788,9 @@ TEST_P(ServerFixture, Seed)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, ResourcePath)
 {
-  setenv("IGN_GAZEBO_RESOURCE_PATH",
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
          (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +
-          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str(), 1);
+          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str());
 
   ServerConfig serverConfig;
   serverConfig.SetSdfFile("resource_paths.sdf");
@@ -876,8 +876,8 @@ TEST_P(ServerFixture, ResourcePath)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, GetResourcePaths)
 {
-  setenv("IGN_GAZEBO_RESOURCE_PATH",
-      "/tmp/some/path:/home/user/another_path", 1);
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+      "/tmp/some/path:/home/user/another_path");
 
   ServerConfig serverConfig;
   gazebo::Server server(serverConfig);
@@ -908,7 +908,7 @@ TEST_P(ServerFixture, CachedFuelWorld)
 {
   auto cachedWorldPath =
     common::joinPaths(std::string(PROJECT_SOURCE_PATH), "test", "worlds");
-  setenv("IGN_FUEL_CACHE_PATH", cachedWorldPath.c_str(), 1);
+  ignition::common::setenv("IGN_FUEL_CACHE_PATH", cachedWorldPath.c_str());
 
   ServerConfig serverConfig;
   auto fuelWorldURL =
@@ -932,10 +932,10 @@ TEST_P(ServerFixture, CachedFuelWorld)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, AddResourcePaths)
 {
-  setenv("IGN_GAZEBO_RESOURCE_PATH",
-      "/tmp/some/path:/home/user/another_path", 1);
-  setenv("SDF_PATH", "", 1);
-  setenv("IGN_FILE_PATH", "", 1);
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+      "/tmp/some/path:/home/user/another_path");
+  ignition::common::setenv("SDF_PATH", "");
+  ignition::common::setenv("IGN_FILE_PATH", "");
 
   ServerConfig serverConfig;
   gazebo::Server server(serverConfig);
@@ -979,7 +979,7 @@ TEST_P(ServerFixture, AddResourcePaths)
   // Check environment variables
   for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
   {
-    char *pathCStr = getenv(env);
+    char *pathCStr = std::getenv(env);
 
     auto paths = common::Split(pathCStr, ':');
     paths.erase(std::remove_if(paths.begin(), paths.end(),

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -19,6 +19,7 @@
 #include <tinyxml2.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>

--- a/src/gui/Gui_TEST.cc
+++ b/src/gui/Gui_TEST.cc
@@ -21,6 +21,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/StringUtils.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
@@ -40,10 +41,10 @@ TEST(GuiTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PathManager))
   common::Console::SetVerbosity(4);
   igndbg << "Start test" << std::endl;
 
-  setenv("IGN_GAZEBO_RESOURCE_PATH",
-         "/from_env:/tmp/more_env", 1);
-  setenv("SDF_PATH", "", 1);
-  setenv("IGN_FILE_PATH", "", 1);
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+         "/from_env:/tmp/more_env");
+  ignition::common::setenv("SDF_PATH", "");
+  ignition::common::setenv("IGN_FILE_PATH", "");
   igndbg << "Environment set" << std::endl;
 
   transport::Node node;
@@ -95,7 +96,7 @@ TEST(GuiTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PathManager))
   for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
   {
     igndbg << "Checking variable [" << env << "]" << std::endl;
-    char *pathCStr = getenv(env);
+    char *pathCStr = std::getenv(env);
 
     auto paths = common::Split(pathCStr, ':');
     paths.erase(std::remove_if(paths.begin(), paths.end(),
@@ -141,7 +142,7 @@ TEST(GuiTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PathManager))
   for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
   {
     igndbg << "Checking variable [" << env << "]" << std::endl;
-    char *pathCStr = getenv(env);
+    char *pathCStr = std::getenv(env);
 
     auto paths = common::Split(pathCStr, ':');
     paths.erase(std::remove_if(paths.begin(), paths.end(),

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -20,6 +20,7 @@
 #include <cstdlib>
 
 #include <string>
+#include <ignition/common/Util.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
@@ -94,7 +95,7 @@ TEST(CmdLine, Server)
 TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_MAC(CachedFuelWorld))
 {
   std::string projectPath = std::string(PROJECT_SOURCE_PATH) + "/test/worlds";
-  setenv("IGN_FUEL_CACHE_PATH", projectPath.c_str(), true);
+  ignition::common::setenv("IGN_FUEL_CACHE_PATH", projectPath.c_str());
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5" +
     " https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Test%20world";
   std::cout << "Running command [" << cmd << "]" << std::endl;
@@ -172,7 +173,7 @@ int main(int _argc, char **_argv)
 {
   // Set IGN_CONFIG_PATH to the directory where the .yaml configuration files
   // is located.
-  setenv("IGN_CONFIG_PATH", IGN_CONFIG_PATH, 1);
+  ignition::common::setenv("IGN_CONFIG_PATH", IGN_CONFIG_PATH);
 
   ::testing::InitGoogleTest(&_argc, _argv);
   return RUN_ALL_TESTS();

--- a/src/network/PeerTracker_TEST.cc
+++ b/src/network/PeerTracker_TEST.cc
@@ -19,6 +19,7 @@
 
 #include <cstdlib>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 
 #include "PeerTracker.hh"
 #include "ignition/gazebo/EventManager.hh"
@@ -281,11 +282,11 @@ TEST(PeerTracker, PartitionedEnv)
   ignition::common::Console::SetVerbosity(4);
   EventManager eventMgr;
 
-  setenv("IGN_PARTITION", "p1", 1);
+  ignition::common::setenv("IGN_PARTITION", "p1");
   auto tracker1 = PeerTracker(
       PeerInfo(NetworkRole::SimulationPrimary), &eventMgr);
 
-  setenv("IGN_PARTITION", "p2", 1);
+  ignition::common::setenv("IGN_PARTITION", "p2");
   auto tracker2 = PeerTracker(
       PeerInfo(NetworkRole::SimulationPrimary), &eventMgr);
 
@@ -296,11 +297,11 @@ TEST(PeerTracker, PartitionedEnv)
   EXPECT_EQ(0u, tracker1.NumPeers());
   EXPECT_EQ(0u, tracker2.NumPeers());
 
-  setenv("IGN_PARTITION", "p1", 1);
+  ignition::common::setenv("IGN_PARTITION", "p1");
   auto tracker3 = PeerTracker(
       PeerInfo(NetworkRole::SimulationSecondary), &eventMgr);
 
-  setenv("IGN_PARTITION", "p2", 1);
+  ignition::common::setenv("IGN_PARTITION", "p2");
   auto tracker4 = PeerTracker(
       PeerInfo(NetworkRole::SimulationSecondary), &eventMgr);
 
@@ -314,6 +315,6 @@ TEST(PeerTracker, PartitionedEnv)
   EXPECT_EQ(1u, tracker3.NumPeers());
   EXPECT_EQ(1u, tracker4.NumPeers());
 
-  unsetenv("IGN_PARTITION");
+  ignition::common::unsetenv("IGN_PARTITION");
 }
 #endif

--- a/test/integration/air_pressure_system.cc
+++ b/test/integration/air_pressure_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/fluid_pressure.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/AirPressureSensor.hh"
@@ -40,8 +41,8 @@ class AirPressureTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -21,6 +21,7 @@
 #include <mutex>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -46,8 +47,8 @@ class AltimeterTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/apply_joint_force_system.cc
+++ b/test/integration/apply_joint_force_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/double.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/Joint.hh"
@@ -44,8 +45,8 @@ class ApplyJointForceTestFixture : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -21,6 +21,7 @@
 
 #include <ignition/common/Battery.hh>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/common/Filesystem.hh>
 
 #include <sdf/Root.hh>
@@ -48,8 +49,8 @@ class BatteryPluginTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
     auto plugin = sm.LoadPlugin("libMockSystem.so",
                                 "ignition::gazebo::MockSystem",

--- a/test/integration/breadcrumbs.cc
+++ b/test/integration/breadcrumbs.cc
@@ -20,12 +20,14 @@
 #include <ignition/msgs/empty.pb.h>
 #include <ignition/msgs/twist.pb.h>
 
+#include <optional>
 #include <regex>
 
 #include <sdf/Root.hh>
 #include <sdf/World.hh>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Entity.hh"
@@ -48,8 +50,8 @@ class BreadcrumbsTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
   public: void LoadWorld(const std::string &_path, bool _useLevels = false)
   {

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
@@ -41,8 +42,8 @@ class BuoyancyTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/camera_video_record_system.cc
+++ b/test/integration/camera_video_record_system.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
@@ -36,8 +37,8 @@ class CameraVideoRecorderTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -22,6 +22,7 @@
 #include <thread>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Server.hh"
@@ -39,8 +40,8 @@ class ContactSystemTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/image.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
@@ -41,8 +42,8 @@ class DepthCameraTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/detachable_joint.cc
+++ b/test/integration/detachable_joint.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/msgs/Utility.hh>
 #include <ignition/transport/Node.hh>
 
@@ -45,8 +46,8 @@ class DetachableJointTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   public: void StartServer(const std::string &_sdfFile)

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -42,8 +43,8 @@ class DiffDriveTest : public ::testing::TestWithParam<int>
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   /// \param[in] _sdfFile SDF file to load.

--- a/test/integration/each_new_removed.cc
+++ b/test/integration/each_new_removed.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <sdf/World.hh>
 
 #include "ignition/gazebo/components/Factory.hh"
@@ -42,8 +43,8 @@ class EachNewRemovedFixture : public ::testing::Test
   protected: void SetUp() override
   {
     // Augment the system plugin path.  In SetUp to avoid test order issues.
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/entity_erase.cc
+++ b/test/integration/entity_erase.cc
@@ -29,8 +29,8 @@ class PhysicsSystemFixture : public ::testing::Test
   protected: void SetUp() override
   {
     // Augment the system plugin path.  In SetUp to avoid test order issues.
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/events.cc
+++ b/test/integration/events.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
@@ -32,8 +33,8 @@ TEST(EventTrigger, TriggerPause)
 {
   common::Console::SetVerbosity(4);
 
-  setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-    (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+  ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+    (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
   // Create server
   ServerConfig config;

--- a/test/integration/examples_build.cc
+++ b/test/integration/examples_build.cc
@@ -19,6 +19,7 @@
 #include <string>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/common/Filesystem.hh>
 
 #include "ignition/gazebo/test_config.hh"

--- a/test/integration/gpu_lidar.cc
+++ b/test/integration/gpu_lidar.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/laserscan.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
@@ -40,8 +41,8 @@ class GpuLidarTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/imu_system.cc
+++ b/test/integration/imu_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/imu.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -49,8 +50,8 @@ class ImuTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/double.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
@@ -44,8 +45,8 @@ class JointControllerTestFixture : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/joint_position_controller_system.cc
+++ b/test/integration/joint_position_controller_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/double.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/Joint.hh"
@@ -44,8 +45,8 @@ class JointPositionControllerTestFixture : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/joint_state_publisher_system.cc
+++ b/test/integration/joint_state_publisher_system.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Server.hh"
@@ -33,8 +34,8 @@ class JointStatePublisherTest : public ::testing::TestWithParam<int>
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -18,9 +18,11 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <vector>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Joint.hh>
@@ -102,8 +104,8 @@ class LevelManagerFixture : public ::testing::Test
   {
     common::Console::SetVerbosity(4);
 
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
     ignition::gazebo::ServerConfig serverConfig;
 

--- a/test/integration/level_manager_runtime_performers.cc
+++ b/test/integration/level_manager_runtime_performers.cc
@@ -20,9 +20,11 @@
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
+#include <optional>
 #include <vector>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Server.hh"
@@ -99,8 +101,8 @@ class LevelManagerFixture : public ::testing::Test
   {
     common::Console::SetVerbosity(4);
 
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
     ignition::gazebo::ServerConfig serverConfig;
 

--- a/test/integration/lift_drag_system.cc
+++ b/test/integration/lift_drag_system.cc
@@ -21,6 +21,7 @@
 #include <ignition/msgs/Utility.hh>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
@@ -51,8 +52,8 @@ class LiftDragTestFixture : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/link.cc
+++ b/test/integration/link.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 
 #include <ignition/gazebo/components/AngularVelocity.hh>
 #include <ignition/gazebo/components/CanonicalLink.hh>

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -27,6 +27,7 @@
 #include <string>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/fuel_tools/Zip.hh>
 #include <ignition/transport/Node.hh>
@@ -155,8 +156,8 @@ class LogSystemTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   // Create a temporary directory in build path for recorded data
@@ -337,7 +338,7 @@ TEST_F(LogSystemTest, LogDefaults)
   std::string homeOrig;
   common::env(IGN_HOMEDIR, homeOrig);
   std::string homeFake = common::joinPaths(this->logsDir, "default");
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeFake.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
 
   // Test case 1:
   // No path specified, on both command line and SDF. This does not go through
@@ -418,7 +419,7 @@ TEST_F(LogSystemTest, LogDefaults)
 #endif
 
   // Revert environment variable after test is done
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeOrig.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeOrig.c_str()));
 }
 
 /////////////////////////////////////////////////
@@ -474,7 +475,7 @@ TEST_F(LogSystemTest, LogPaths)
   std::string homeOrig;
   common::env(IGN_HOMEDIR, homeOrig);
   std::string homeFake = common::joinPaths(this->logsDir, "default");
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeFake.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
 
   // Store number of files before running
   auto logPath = common::joinPaths(homeFake.c_str(), ".ignition", "gazebo",
@@ -696,7 +697,7 @@ TEST_F(LogSystemTest, LogPaths)
 #endif
 
   // Revert environment variable after test is done
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeOrig.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeOrig.c_str()));
 
   this->RemoveLogsDir();
 }
@@ -1162,7 +1163,7 @@ TEST_F(LogSystemTest, LogOverwrite)
   std::string homeOrig;
   common::env(IGN_HOMEDIR, homeOrig);
   std::string homeFake = common::joinPaths(this->logsDir, "default");
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeFake.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
 
   // Store number of files before running
   auto logPath = common::joinPaths(homeFake.c_str(), ".ignition", "gazebo",
@@ -1225,7 +1226,7 @@ TEST_F(LogSystemTest, LogOverwrite)
   common::removeAll(timestampPath);
 
   // Revert environment variable after test is done
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeOrig.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeOrig.c_str()));
 
   // Test case 4:
   // Path exists, command line --log-overwrite, should overwrite by
@@ -1716,7 +1717,7 @@ TEST_F(LogSystemTest, LogResources)
   std::string homeOrig;
   common::env(IGN_HOMEDIR, homeOrig);
   std::string homeFake = common::joinPaths(this->logsDir, "default");
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeFake.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
 
   const std::string recordPath = this->logDir;
   std::string statePath = common::joinPaths(recordPath, "state.tlog");
@@ -1781,7 +1782,7 @@ TEST_F(LogSystemTest, LogResources)
       "models", "x2 config 1")));
 
   // Revert environment variable after test is done
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeOrig.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeOrig.c_str()));
 
   // Remove artifacts
   this->RemoveLogsDir();
@@ -1803,7 +1804,7 @@ TEST_F(LogSystemTest, LogTopics)
   std::string homeOrig;
   common::env(IGN_HOMEDIR, homeOrig);
   std::string homeFake = common::joinPaths(this->logsDir, "default");
-  EXPECT_EQ(setenv(IGN_HOMEDIR, homeFake.c_str(), 1), 0);
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
 
   const std::string recordPath = this->logDir;
   std::string statePath = common::joinPaths(recordPath, "state.tlog");

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
@@ -49,8 +50,8 @@ class LogicalAudioTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/logical_camera_system.cc
+++ b/test/integration/logical_camera_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/logical_camera_image.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -43,8 +44,8 @@ class LogicalCameraTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/magnetometer_system.cc
+++ b/test/integration/magnetometer_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/magnetometer.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -47,8 +48,8 @@ class MagnetometerTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/model.cc
+++ b/test/integration/model.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 
 #include <ignition/gazebo/EntityComponentManager.hh>

--- a/test/integration/multicopter.cc
+++ b/test/integration/multicopter.cc
@@ -18,9 +18,12 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
+
 #include <ignition/msgs.hh>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
@@ -48,8 +51,8 @@ class MulticopterTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   protected: std::unique_ptr<Server> StartServer(const std::string &_filePath)

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -40,8 +40,8 @@ class PerformerDetectorTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   protected: std::unique_ptr<Server> StartServer(const std::string &_filePath,

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <sdf/Collision.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Geometry.hh>
@@ -67,8 +68,8 @@ class PhysicsSystemFixture : public ::testing::Test
   {
     common::Console::SetVerbosity(4);
     // Augment the system plugin path.  In SetUp to avoid test order issues.
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -19,6 +19,7 @@
 #include <mutex>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -45,8 +46,8 @@ class PosePublisherTest : public ::testing::TestWithParam<int>
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/image.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
@@ -41,8 +42,8 @@ class RgbdCameraTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -28,6 +28,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -21,6 +21,7 @@
 #include <thread>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Server.hh"
@@ -35,8 +36,8 @@ class SceneBroadcasterTest : public ::testing::TestWithParam<int>
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/sdf_frame_semantics.cc
+++ b/test/integration/sdf_frame_semantics.cc
@@ -51,8 +51,8 @@ class SdfFrameSemanticsTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   public: void StartServer()

--- a/test/integration/sensors_system.cc
+++ b/test/integration/sensors_system.cc
@@ -52,8 +52,8 @@ class SensorsFixture : public ::testing::Test
   {
     common::Console::SetVerbosity(4);
     // Augment the system plugin path.  In SetUp to avoid test order issues.
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+      (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
     auto plugin = sm.LoadPlugin("libMockSystem.so",
                                 "ignition::gazebo::MockSystem",

--- a/test/integration/thermal_system.cc
+++ b/test/integration/thermal_system.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -41,8 +42,8 @@ class ThermalTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Server.hh"
@@ -32,8 +33,8 @@ class TouchPluginTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   public: void StartServer(const std::string &_sdfFile)

--- a/test/integration/triggered_publisher.cc
+++ b/test/integration/triggered_publisher.cc
@@ -25,6 +25,7 @@
 #include <sdf/World.hh>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/Server.hh"
@@ -46,8 +47,8 @@ class TriggeredPublisherTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
     // Start server
     ServerConfig serverConfig;
     const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/entity_factory.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -44,8 +45,8 @@ class UserCommandsTest : public ::testing::Test
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 };
 

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -40,8 +41,8 @@ class VelocityControlTest : public ::testing::TestWithParam<int>
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   /// \param[in] _sdfFile SDF file to load.

--- a/test/integration/wheel_slip.cc
+++ b/test/integration/wheel_slip.cc
@@ -20,6 +20,7 @@
 #include <ignition/msgs/entity_factory.pb.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
 
@@ -59,8 +60,8 @@ class WheelSlipTest : public ::testing::Test
   protected: void SetUp() override
              {
                common::Console::SetVerbosity(4);
-               setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-                   (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+               ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+                   (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
              }
   /// \brief Class to hold parameters for tire tests.
   public: class WheelSlipState

--- a/test/integration/wind_effects.cc
+++ b/test/integration/wind_effects.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/msgs/Utility.hh>
 #include <ignition/transport/Node.hh>
 
@@ -44,8 +45,8 @@ class WindEffectsTest : public ::testing::Test
   protected: void SetUp() override
   {
     common::Console::SetVerbosity(4);
-    setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
   }
 
   public: void StartServer(const std::string &_sdfFile)

--- a/test/integration/world.cc
+++ b/test/integration/world.cc
@@ -20,6 +20,7 @@
 #include <sdf/Atmosphere.hh>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 
 #include <ignition/gazebo/EntityComponentManager.hh>

--- a/test/performance/level_manager.cc
+++ b/test/performance/level_manager.cc
@@ -21,6 +21,7 @@
 
 #include <ignition/math/Stopwatch.hh>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
@@ -35,8 +36,8 @@ TEST(LevelManagerPerfrormance, LevelVsNoLevel)
 
   common::Console::SetVerbosity(4);
 
-  setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-         (std::string(PROJECT_BINARY_PATH) + "/lib").c_str(), 1);
+  ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+         (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
 
   ignition::gazebo::ServerConfig serverConfig;
   serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +

--- a/test/test_config.hh.in
+++ b/test/test_config.hh.in
@@ -25,35 +25,9 @@
 
 #define IGN_CONFIG_PATH "@CMAKE_BINARY_DIR@/test/conf"
 
-#if (_MSC_VER >= 1400) // Visual Studio 2005
-  #include <sstream>
-
-  /// \brief setenv/unstenv are not present in Windows. Define them to make
-  /// the code portable.
-  /// \param[in] _name Variable name.
-  /// \param[in] _value Value.
-  /// \param[in] _rewrite If 'name' does exist in the environment, then its
-  /// value is changed to 'value' if 'rewrite' is nonzero. If overwrite is
-  /// zero, then the value of 'name' is not changed.
-  /// /return 0 on success or -1 on error.
-  int setenv(const char *_name, const char *_value, int /*_rewrite*/)
-  {
-    std::stringstream sstr;
-    std::string name = _name;
-    std::string value = _value;
-    sstr << name << '=' << value;
-    return _putenv(sstr.str().c_str());
-  }
-
-  /// \brief Deletes an environment variable.
-  /// \param[in] _name Variable name.
-  void unsetenv(const char *_name)
-  {
-    std::stringstream sstr;
-    std::string name = _name;
-    sstr << name << '=';
-    _putenv(sstr.str().c_str());
-  }
+#ifdef _MSC_VER
+#    define popen _popen
+#    define pclose _pclose
 #endif
 
 namespace ignition


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Backporting https://github.com/ignitionrobotics/ign-gazebo/pull/561/.

Similar to #665, the motivation is to make forward-porting changes easier. On https://github.com/ignitionrobotics/ign-gazebo/pull/622 we had to make lots of changes for the code ported from Dome to Edifice to work on Windows. If we encourage proper usage of `common::setenv` from Citadel, new plugins should use correct boilerplate from the beginning.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
