### PR TITLE
Add light intensity field to ComponentInspector

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -158,6 +158,7 @@ void ignition::gazebo::setData(QStandardItem *_item, const msgs::Light &_data)
     QVariant(_data.spot_inner_angle()),
     QVariant(_data.spot_outer_angle()),
     QVariant(_data.spot_falloff()),
+    QVariant(_data.intensity()),
     QVariant(lightType)
   }), ComponentsModel::RoleNames().key("data"));
 }
@@ -814,7 +815,7 @@ void ComponentInspector::OnLight(
   double _attRange, double _attLinear, double _attConstant,
   double _attQuadratic, bool _castShadows, double _directionX,
   double _directionY, double _directionZ, double _innerAngle,
-  double _outerAngle, double _falloff, int _type)
+  double _outerAngle, double _falloff, double _intensity, int _type)
 {
   std::function<void(const ignition::msgs::Boolean &, const bool)> cb =
       [](const ignition::msgs::Boolean &/*_rep*/, const bool _result)
@@ -835,6 +836,7 @@ void ComponentInspector::OnLight(
   req.set_attenuation_constant(_attConstant);
   req.set_attenuation_quadratic(_attQuadratic);
   req.set_cast_shadows(_castShadows);
+  req.set_intensity(_intensity);
   if (_type == 0)
     req.set_type(ignition::msgs::Light::POINT);
   else if (_type == 1)

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -243,6 +243,7 @@ namespace gazebo
     /// \param[in] _innerAngle Inner angle of the spotlight
     /// \param[in] _outerAngle Outer angle of the spotlight
     /// \param[in] _falloff Falloff of the spotlight
+    /// \param[in] _intensity Intensity of the light
     /// \param[in] _type light type
     public: Q_INVOKABLE void OnLight(
       double _rSpecular, double _gSpecular, double _bSpecular,
@@ -251,7 +252,7 @@ namespace gazebo
       double _attLinear, double _attConstant, double _attQuadratic,
       bool _castShadows, double _directionX, double _directionY,
       double _directionZ, double _innerAngle, double _outerAngle,
-      double _falloff, int _type);
+      double _falloff, double _intensity, int _type);
 
     /// \brief Callback in Qt thread when physics' properties change.
     /// \param[in] _stepSize step size

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -92,12 +92,12 @@ Rectangle {
                    _rDiffuse, _gDiffuse, _bDiffuse, _aDiffuse,
                    _attRange, _attLinear, _attConstant, _attQuadratic,
                    _castShadows, _directionX, _directionY, _directionZ,
-                   _innerAngle, _outerAngle, _falloff, _type) {
+                   _innerAngle, _outerAngle, _falloff, _intensity, _type) {
     ComponentInspector.OnLight(_rSpecular, _gSpecular, _bSpecular, _aSpecular,
                                _rDiffuse, _gDiffuse, _bDiffuse, _aDiffuse,
                                _attRange, _attLinear, _attConstant, _attQuadratic,
                                _castShadows, _directionX, _directionY, _directionZ,
-                               _innerAngle, _outerAngle, _falloff, _type)
+                               _innerAngle, _outerAngle, _falloff, _intensity, _type)
   }
 
   /*

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -96,6 +96,9 @@ Rectangle {
   // Loaded item for falloff (spotlight)
   property var falloffItem: {}
 
+  // Loaded item for intensity
+  property var intensityItem: {}
+
   // Send new light data to C++
   function sendLight() {
     // TODO(anyone) There's a loss of precision when these values get to C++
@@ -119,7 +122,8 @@ Rectangle {
       innerAngleItem.value,
       outerAngleItem.value,
       falloffItem.value,
-      model.data[19]
+      intensityItem.value,
+      model.data[20]
     );
   }
 
@@ -281,6 +285,27 @@ Rectangle {
         id: grid
         width: parent.width
 
+        RowLayout {
+          Text {
+            Layout.columnSpan: 6
+            text: "      Intensity"
+            color: "dimgrey"
+            width: margin + indentation
+          }
+          Item {
+            Layout.fillWidth: true
+            height: 40
+            Loader {
+              id: intensityLoader
+              anchors.fill: parent
+              property double numberValue: model.data[19]
+              sourceComponent: spinZeroMax
+              onLoaded: {
+                intensityItem = intensityLoader.item
+              }
+            }
+          }
+        }
         RowLayout {
           Layout.alignment : Qt.AlignLeft
           Text {

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -286,15 +286,32 @@ Rectangle {
         width: parent.width
 
         RowLayout {
-          Text {
-            Layout.columnSpan: 6
-            text: "      Intensity"
-            color: "dimgrey"
-            width: margin + indentation
+          Rectangle {
+            color: "transparent"
+            height: 40
+            Layout.preferredWidth: intensityText.width + indentation*3
+            Loader {
+              id: loaderIntensity
+              width: iconWidth
+              height: iconHeight
+              y:10
+              sourceComponent: plotIcon
+            }
+            Component.onCompleted: loaderIntensity.item.componentInfo = "intensity"
+
+            Text {
+              id : intensityText
+              text: ' Intensity:'
+              leftPadding: 5
+              color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
+              font.pointSize: 12
+              anchors.centerIn: parent
+            }
           }
           Item {
             Layout.fillWidth: true
             height: 40
+            Layout.columnSpan: 4
             Loader {
               id: intensityLoader
               anchors.fill: parent

--- a/src/gui/plugins/plotting/Plotting.cc
+++ b/src/gui/plugins/plotting/Plotting.cc
@@ -118,6 +118,7 @@ PlotComponent::PlotComponent(const std::string &_type,
     this->dataPtr->data["innerAngle"] = std::make_shared<PlotData>();
     this->dataPtr->data["outerAngle"] = std::make_shared<PlotData>();
     this->dataPtr->data["falloff"] = std::make_shared<PlotData>();
+    this->dataPtr->data["intensity"] = std::make_shared<PlotData>();
   }
   else if (_type == "double")
     this->dataPtr->data["value"] = std::make_shared<PlotData>();
@@ -267,6 +268,8 @@ void Plotting::SetData(std::string _Id, const ignition::msgs::Light &_light)
     _light.attenuation_quadratic());
   this->dataPtr->components[_Id]->SetAttributeValue("castshadows",
     _light.cast_shadows());
+  this->dataPtr->components[_Id]->SetAttributeValue("intensity",
+    _light.intensity());
   if (_light.has_direction())
   {
     this->dataPtr->components[_Id]->SetAttributeValue("directionX",

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -770,6 +770,12 @@ void RenderUtil::Update()
         }
         if (l->CastShadows() != light.second.cast_shadows())
           l->SetCastShadows(light.second.cast_shadows());
+        if (!ignition::math::equal(
+            l->Intensity(),
+            static_cast<double>(light.second.intensity())))
+        {
+          l->SetIntensity(light.second.intensity());
+        }
         auto lDirectional =
           std::dynamic_pointer_cast<rendering::DirectionalLight>(node);
         if (lDirectional)

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -182,6 +182,10 @@ class LightCommand : public UserCommandBase
                  1e-6f) &&
                _a.cast_shadows() == _b.cast_shadows() &&
                math::equal(
+                 _a.intensity(),
+                 _b.intensity(),
+                 1e-6f) &&
+               math::equal(
                  _a.direction().x(), _b.direction().x(), 1e-6) &&
                math::equal(
                  _a.direction().y(), _b.direction().y(), 1e-6) &&


### PR DESCRIPTION
Signed-off-by: Atharva Pusalkar <atharvapusalkar18@gmail.com>

# 🎉 New feature

Closes #637 

## Summary
I have added light intensity field to the ComponentInspector. Changes were also made to `RenderUtil.cc` and `UserCommands.cc` to set the light intensity value.
Here's a demo:
![light_intensity](https://user-images.githubusercontent.com/39728574/110214075-e70ed500-7ec8-11eb-9b2e-d384ba1a3559.gif)


## Test it
You can test the feature by running `ign gazebo examples/worlds/lights.sdf`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**