### PR TITLE
Depend on cli component of ignition-utils1

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -13,6 +13,7 @@ libignition-rendering5-dev
 libignition-sensors5-dev
 libignition-tools-dev
 libignition-transport10-dev
+libignition-utils1-cli-dev
 libogre-1.9-dev
 libogre-2.1-dev
 libprotobuf-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ ign_find_package(ignition-tools
 
 #--------------------------------------
 # Find ignition-utils
-ign_find_package(ignition-utils1 REQUIRED)
+ign_find_package(ignition-utils1 REQUIRED COMPONENTS cli)
 set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
 
 #--------------------------------------

--- a/Migration.md
+++ b/Migration.md
@@ -7,6 +7,8 @@ release will remove the deprecated code.
 
 ## Ignition Gazebo 4.x to 5.x
 
+* Use `cli` component of `ignition-utils1`.
+
 * `ignition::gazebo::RenderUtil::SelectedEntities()` now returns a
   `const std::vector<Entity> &` instead of forcing a copy. The calling code
   should create a copy if it needs to modify the vector in some way.


### PR DESCRIPTION
# 🎉 New feature

## Summary

Depend on the `cli` component of `ignition-utils1` so that we can implement the backend of the `ign` commands as executables instead of `dlopen` calls from ruby (similar to https://github.com/ignitionrobotics/ign-transport/pull/216). This just adds the dependency for now, so we can implement the functionality in a minor release if desired.

## Test it

It just needs to not break CI.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**