### PR TITLE
Fix entity tree for large worlds

### DIFF
--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -328,7 +328,9 @@ void EntityTree::Update(const UpdateInfo &, EntityComponentManager &_ecm)
           Q_ARG(QString, entityType(_entity, _ecm)));
       return true;
     });
-    this->dataPtr->initialized = true;
+
+    if (this->dataPtr->worldEntity != kNullEntity)
+      this->dataPtr->initialized = true;
   }
   else
   {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Since #497 it's possible that plugins receive updates before any entity has been created. This happens for example for large worlds like `tunnel.sdf`, which take a while to load. This PR makes sure the tree keeps trying to get all entities until some are available.

To test it, run `ign gazebo tunnel.sdf` with and without this PR. Without this PR, the entity tree will be empty.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests: no, tough to test large worlds that take time to load
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
