### PR TITLE
Remove bounding box when model is deleted

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -600,6 +600,14 @@ void RenderUtil::Update()
         this->dataPtr->removeSensorCb(entity.first);
         this->dataPtr->sensorEntities.erase(sensorEntityIt);
       }
+
+      // delete associated bounding box, if existing
+      auto wireBoxIt = this->dataPtr->wireBoxes.find(entity.first);
+      if (wireBoxIt != this->dataPtr->wireBoxes.end())
+      {
+        this->dataPtr->scene->DestroyVisual(wireBoxIt->second->Parent());
+        this->dataPtr->wireBoxes.erase(wireBoxIt);
+      }
     }
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Currently, when a selected model is deleted, its bounding box is not deleted and moves to the origin:

![aabb](https://user-images.githubusercontent.com/5751272/110413804-60323780-8043-11eb-8ae2-a4f1cbd1844c.gif)


With this PR, the box is correctly deleted.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests: nothing in `rendering` has unit tests right now. We should add some.
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
