### PR TITLE
iterate through changed links only in UpdateSim

### DIFF
--- a/src/systems/physics/EntityFeatureMap.hh
+++ b/src/systems/physics/EntityFeatureMap.hh
@@ -137,6 +137,7 @@ namespace systems::physics_system
         return castEntity;
       }
     }
+
     /// \brief Helper function to cast from an entity type with minimum features
     /// to an entity with a different set of features. This overload takes a
     /// physics entity as input
@@ -187,6 +188,21 @@ namespace systems::physics_system
       return kNullEntity;
     }
 
+    /// \brief Get the physics entity with required features that has a
+    /// particular ID
+    /// \param[in] _id The ID of the desired physics entity
+    /// \return If found, returns the corresponding physics entity. Otherwise,
+    /// nullptr
+    public: RequiredEntityPtr GetPhysicsEntityPtr(std::size_t _id) const
+    {
+      auto it = this->physEntityById.find(_id);
+      if (it != this->physEntityById.end())
+      {
+        return it->second;
+      }
+      return nullptr;
+    }
+
     /// \brief Check whether there is a physics entity associated with the given
     /// Gazebo entity
     /// \param[in] _entity Gazebo entity.
@@ -215,6 +231,7 @@ namespace systems::physics_system
     {
       this->entityMap[_entity] = _physicsEntity;
       this->reverseMap[_physicsEntity] = _entity;
+      this->physEntityById[_physicsEntity->EntityID()] = _physicsEntity;
     }
 
     /// \brief Remove entity from all associated maps
@@ -226,8 +243,9 @@ namespace systems::physics_system
       if (it != this->entityMap.end())
       {
         this->reverseMap.erase(it->second);
-        this->entityMap.erase(it);
+        this->physEntityById.erase(it->second->EntityID());
         this->castCache.erase(_entity);
+        this->entityMap.erase(it);
         return true;
       }
       return false;
@@ -242,8 +260,9 @@ namespace systems::physics_system
       if (it != this->reverseMap.end())
       {
         this->entityMap.erase(it->second);
-        this->reverseMap.erase(it);
+        this->physEntityById.erase(it->first->EntityID());
         this->castCache.erase(it->second);
+        this->reverseMap.erase(it);
         return true;
       }
       return false;
@@ -257,13 +276,13 @@ namespace systems::physics_system
       return this->entityMap;
     }
 
-    /// \brief Get the total number of entries in the three maps. Only used for
+    /// \brief Get the total number of entries in the maps. Only used for
     /// testing.
     /// \return Number of entries in all the maps.
     public: std::size_t TotalMapEntryCount() const
     {
       return this->entityMap.size() + this->reverseMap.size() +
-             this->castCache.size();
+             this->castCache.size() + this->physEntityById.size();
     }
 
     /// \brief Map from Gazebo entity to physics entities with required features
@@ -271,6 +290,10 @@ namespace systems::physics_system
 
     /// \brief Reverse map of entityMap
     private: std::unordered_map<RequiredEntityPtr, Entity> reverseMap;
+
+    /// \brief Map of physics entity IDs to the corresponding physics entity
+    /// with required features
+    private: std::unordered_map<std::size_t, RequiredEntityPtr> physEntityById;
 
     /// \brief Cache map from Gazebo entity to physics entities with optional
     /// features

--- a/src/systems/physics/EntityFeatureMap_TEST.cc
+++ b/src/systems/physics/EntityFeatureMap_TEST.cc
@@ -118,8 +118,8 @@ TEST_F(EntityFeatureMapFixture, AddCastRemoveEntity)
 
   testMap.AddEntity(gazeboWorld1Entity, testWorld1);
 
-  // After adding the entity, there should be one entry each in two maps
-  EXPECT_EQ(2u, testMap.TotalMapEntryCount());
+  // After adding the entity, there should be one entry each in three maps
+  EXPECT_EQ(3u, testMap.TotalMapEntryCount());
   EXPECT_EQ(testWorld1, testMap.Get(gazeboWorld1Entity));
   EXPECT_EQ(gazeboWorld1Entity, testMap.Get(testWorld1));
 
@@ -128,7 +128,7 @@ TEST_F(EntityFeatureMapFixture, AddCastRemoveEntity)
       testMap.EntityCast<TestOptionalFeatures1>(gazeboWorld1Entity);
   ASSERT_NE(nullptr, testWorld1Feature1);
   // After the cast, there should be one more entry in the cache map.
-  EXPECT_EQ(3u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
 
   // Cast to optional feature2
   auto testWorld1Feature2 =
@@ -136,12 +136,12 @@ TEST_F(EntityFeatureMapFixture, AddCastRemoveEntity)
   ASSERT_NE(nullptr, testWorld1Feature2);
   // After the cast, the number of entries should remain the same because we
   // have not added an entity.
-  EXPECT_EQ(3u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
 
   // Add another entity
   WorldPtrType testWorld2 = this->engine->ConstructEmptyWorld("world2");
   testMap.AddEntity(gazeboWorld2Entity, testWorld2);
-  EXPECT_EQ(5u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(7u, testMap.TotalMapEntryCount());
   EXPECT_EQ(testWorld2, testMap.Get(gazeboWorld2Entity));
   EXPECT_EQ(gazeboWorld2Entity, testMap.Get(testWorld2));
 
@@ -149,21 +149,21 @@ TEST_F(EntityFeatureMapFixture, AddCastRemoveEntity)
       testMap.EntityCast<TestOptionalFeatures1>(testWorld2);
   ASSERT_NE(nullptr, testWorld2Feature1);
   // After the cast, there should be one more entry in the cache map.
-  EXPECT_EQ(6u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(8u, testMap.TotalMapEntryCount());
 
   auto testWorld2Feature2 =
       testMap.EntityCast<TestOptionalFeatures2>(testWorld2);
   ASSERT_NE(nullptr, testWorld2Feature2);
   // After the cast, the number of entries should remain the same because we
   // have not added an entity.
-  EXPECT_EQ(6u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(8u, testMap.TotalMapEntryCount());
 
   // Remove entitites
   testMap.Remove(gazeboWorld1Entity);
   EXPECT_FALSE(testMap.HasEntity(gazeboWorld1Entity));
   EXPECT_EQ(nullptr, testMap.Get(gazeboWorld1Entity));
   EXPECT_EQ(gazebo::kNullEntity, testMap.Get(testWorld1));
-  EXPECT_EQ(3u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
 
   testMap.Remove(testWorld2);
   EXPECT_FALSE(testMap.HasEntity(gazeboWorld2Entity));

--- a/test/integration/wind_effects.cc
+++ b/test/integration/wind_effects.cc
@@ -270,7 +270,7 @@ TEST_F(WindEffectsTest , TopicsAndServices)
   this->server->Run(true, 10, false);
 
   // As specified in SDF
-  math::Vector3d windVelSeed{1.0, 0.0, 1.0};
+  math::Vector3d windVelSeed{10.0, 0.0, 10.0};
 
   transport::Node node;
   std::size_t timeout{5000};

--- a/test/worlds/wind_effects.sdf
+++ b/test/worlds/wind_effects.sdf
@@ -31,7 +31,7 @@
     </plugin>
 
     <wind>
-      <linear_velocity>1 0 1</linear_velocity>
+      <linear_velocity>10 0 10</linear_velocity>
     </wind>
 
     <model name="wind_test1">


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🎉 New feature

requires:
* https://github.com/ignitionrobotics/ign-physics/pull/223
* https://github.com/ignitionrobotics/ign-physics/pull/238
* https://github.com/ignitionrobotics/ign-math/pull/196

related to https://github.com/ignitionrobotics/ign-physics/issues/219

## Summary

As mentioned in https://github.com/ignitionrobotics/ign-physics/issues/219, `UpdateSim` in the `ign-gazebo` physics system iterates over all links, because it has no way of knowing which links have moved. https://github.com/ignitionrobotics/ign-physics/pull/223 and https://github.com/ignitionrobotics/ign-physics/pull/238 should resolve this issue, so this PR uses each of these `ign-physics` PRs (and https://github.com/ignitionrobotics/ign-math/pull/196) to have `UpdateSim` iterate over just the links that have moved.

As a result of this change, the link pose caching that was done in https://github.com/ignitionrobotics/ign-gazebo/pull/669 is no longer needed if a physics engine is being used that writes output pose data (we still need the caching done in https://github.com/ignitionrobotics/ign-gazebo/pull/656 regardless of whether the physics engine being used writes output pose data or not). I also had to add some functionality to the `EntityFeatureMap` class (introduced in https://github.com/ignitionrobotics/ign-gazebo/pull/586) that maps physics link entity IDs (`std::size_t`) to the corresponding entity in `ign-gazebo` (the [link data](https://github.com/ignitionrobotics/ign-physics/blob/ignition-physics3_3.1.0/include/ignition/physics/ForwardStep.hh#L39-L44) that `ign-gazebo` gets from `ign-physics` contains a link's pose and link ID).

This new behavior is **optional**. In other words, if a physics engine is being used that writes output pose data, then the output pose data will be used to update the simulation state. If a physics engine is being used that does not write output pose data, then the approach for updating the simulation state remains unchanged (getting all link poses from the latest step via `ECM`).

## Test it

Testing this PR can follow the testing approach taken in #656 and #669, which involves profiling a world as follows:
* [3000 non-static (or static) simple shapes](https://gist.github.com/adlarkin/c0a97f50bfaa04131ec7275eaa3f7c0f) sitting on a static ground plane
* running with unbounded RTF (-z 1000000000)
* running headless (with -s and only the Physics system)

Profiling the world above can be done with both DART and TPE physics engines. In the comparisons below, the metrics being compared to (i.e., before this PR) are being done on commit https://github.com/ignitionrobotics/ign-gazebo/commit/2bf29c214bc81d5b75a087f995582d7a82908445 of `ign-gazebo`, and commit https://github.com/ignitionrobotics/ign-physics/commit/54d2a4433cf231deb3c8ace085c35cea5c9c06c6 of `ign-physics`.

### TPE

#### Static

Before this PR:
* RTF: 21%
* `UpdateSim` time: 3ms

![static_tpe_pre_PR](https://user-images.githubusercontent.com/42042756/112644557-f32ce900-8e1b-11eb-9990-b8ed87accc87.png)

After this PR:
* RTF: 40%
* `UpdateSim` time: 0.67ms

![static_tpe_post_PR](https://user-images.githubusercontent.com/42042756/112644838-3be4a200-8e1c-11eb-8220-1eb1d4844e0f.png)

#### Non-Static

Before this PR:
* RTF: 4.8%
* `UpdateSim` time: 13.6ms

![non_static_tpe_pre_PR](https://user-images.githubusercontent.com/42042756/112645034-72222180-8e1c-11eb-87c1-e8ad77513c38.png)

After this PR:
* RTF: 13.8%
* `UpdateSim` time: 0.8ms

![non_static_tpe_post_PR](https://user-images.githubusercontent.com/42042756/112645172-9847c180-8e1c-11eb-82ae-f6918acdd6bc.png)

### DART

#### Static

Before this PR:
* RTF: 8.5%
* `UpdateSim` time: 4.1ms

![static_dart_pre_PR](https://user-images.githubusercontent.com/42042756/112645884-52d7c400-8e1d-11eb-9a87-4154b375cb4e.png)

After this PR:
* RTF: 12.5%
* `UpdateSim` time: 1.1ms

![static_dart_post_PR](https://user-images.githubusercontent.com/42042756/112645923-608d4980-8e1d-11eb-9833-3cd6bec658f4.png)

#### Non-Static

Before this PR:
* RTF: 0.95%
* `UpdateSim` time: 15.6ms

![non_static_dart_pre_PR](https://user-images.githubusercontent.com/42042756/112646137-96323280-8e1d-11eb-9353-2b84831280ca.png)

After this PR:
* RTF: 1.1%
* `UpdateSim` time: 2.8ms

![non_static_dart_post_PR](https://user-images.githubusercontent.com/42042756/112646287-b4982e00-8e1d-11eb-8f28-07252cb5d91f.png)

## Takeaways

The TPE performance improvement is noticeable (2x RTF increase for static shapes, and 3x RTF increase for non-static shapes). The performance improvement for DART is not as noticeable (1.5x RTF increase for static shapes, and no real change in RTF for non-static shapes), probably because `UpdateSim` is a small part of the `Update` in the physics system - for DART, most of the work in the physics system `Update` comes from the physics step itself, which we probably don't have a ton of control over when it comes to optimization.

### Future Work

Although there are noticeable performance improvements here, there are a few things that I'd like to do next to create even more performance improvements:
1. address https://github.com/ignitionrobotics/ign-gazebo/issues/706 - if you take a look at the profiler images above, you'll notice that most of the time in `UpdateSim` is taken up by `Models`, which is a loop that updates model poses if necessary. Since we now only have the links that have changed after each physics step, it would be nice to make a bi-directional mapping between models and their canonical links (currently, we only have a mapping from a model to its canonical link - see #685). That way, we can loop through all of the changed links and update the models that have this link as its canonical link instead of looping through all of the models and seeing if a model's canonical link has changed pose. I believe that this would decrease the `Model` block time significantly.
1. optimize the `EntityComponentManager::Each` call. As I mentioned in https://github.com/ignitionrobotics/ign-gazebo/pull/678#issuecomment-806317054, reducing the number of components used in the `ecm.Each` call sped up the time for the `ecm.Each` call to complete by approximately 3x (wow!). Considering how often we use `ecm.Each` in `ign-gazebo`, I imagine that optimizing this function call would result in a massive performance benefit. I have created an issue for this so that it can be tracked: https://github.com/ignitionrobotics/ign-gazebo/issues/711

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
