### PR TITLE
Scene add sensors

### DIFF
--- a/src/SdfEntityCreator_TEST.cc
+++ b/src/SdfEntityCreator_TEST.cc
@@ -106,7 +106,7 @@ TEST_F(SdfEntityCreatorTest, CreateEntities)
 
   // Check entities
   // 1 x world + 3 x model + 3 x link + 3 x collision + 3 x visual + 1 x light
-  EXPECT_EQ(14u, this->ecm.EntityCount());
+  EXPECT_EQ(15u, this->ecm.EntityCount());
 
   // Check worlds
   unsigned int worldCount{0};
@@ -953,7 +953,7 @@ TEST_F(SdfEntityCreatorTest, RemoveEntities)
 
   // Check entities
   // 1 x world + 3 x model + 3 x link + 3 x collision + 3 x visual + 1 x light
-  EXPECT_EQ(14u, this->ecm.EntityCount());
+  EXPECT_EQ(15u, this->ecm.EntityCount());
 
   auto world = this->ecm.EntityByComponents(components::World());
   EXPECT_NE(kNullEntity, world);
@@ -979,7 +979,7 @@ TEST_F(SdfEntityCreatorTest, RemoveEntities)
   creator.RequestRemoveEntity(models.front());
   this->ecm.ProcessEntityRemovals();
 
-  EXPECT_EQ(10u, this->ecm.EntityCount());
+  EXPECT_EQ(11u, this->ecm.EntityCount());
 
   models = this->ecm.ChildrenByComponents(world, components::Model());
   ASSERT_EQ(2u, models.size());
@@ -1002,7 +1002,7 @@ TEST_F(SdfEntityCreatorTest, RemoveEntities)
   creator.RequestRemoveEntity(models.front(), false);
   this->ecm.ProcessEntityRemovals();
 
-  EXPECT_EQ(9u, this->ecm.EntityCount());
+  EXPECT_EQ(10u, this->ecm.EntityCount());
 
   // There's only 1 model left
   models = this->ecm.ChildrenByComponents(world, components::Model());

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -287,7 +287,7 @@ TEST_P(ServerFixture, SdfServerConfig)
   EXPECT_FALSE(*server.Running(0));
   EXPECT_TRUE(*server.Paused());
   EXPECT_EQ(0u, *server.IterationCount());
-  EXPECT_EQ(16u, *server.EntityCount());
+  EXPECT_EQ(17u, *server.EntityCount());
   EXPECT_EQ(3u, *server.SystemCount());
 
   EXPECT_TRUE(server.HasEntity("box"));

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -152,7 +152,7 @@ TEST_P(SimulationRunnerTest, CreateEntities)
   // Check entities
   // 1 x world + 1 x (default) level + 1 x wind + 3 x model + 3 x link + 3 x
   // collision + 3 x visual + 1 x light
-  EXPECT_EQ(16u, runner.EntityCompMgr().EntityCount());
+  EXPECT_EQ(17u, runner.EntityCompMgr().EntityCount());
 
   // Check worlds
   unsigned int worldCount{0};

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -38,6 +38,7 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/components/Static.hh"
 #include "ignition/gazebo/components/Visual.hh"
 #include "ignition/gazebo/components/World.hh"
@@ -122,6 +123,14 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
   /// \param[in] _entity Parent entity in the graph
   /// \param[in] _graph Scene graph
   public: static void AddVisuals(msgs::Link *_msg, const Entity _entity,
+                                 const SceneGraphType &_graph);
+
+  /// \brief Adds sensors to a msgs::Link object based on the contents of
+  /// the scene graph
+  /// \param[in] _msg Pointer to msg object to which the sensors will be added
+  /// \param[in] _entity Parent entity in the graph
+  /// \param[in] _graph Scene graph
+  public: static void AddSensors(msgs::Link *_msg, const Entity _entity,
                                  const SceneGraphType &_graph);
 
   /// \brief Recursively remove entities from the graph
@@ -734,6 +743,26 @@ void SceneBroadcasterPrivate::SceneGraphAddEntities(
         return true;
       });
 
+  // Sensors
+  _manager.EachNew<components::Sensor, components::Name,
+                   components::ParentEntity, components::Pose>(
+      [&](const Entity &_entity, const components::Sensor *,
+          const components::Name *_nameComp,
+          const components::ParentEntity *_parentComp,
+          const components::Pose *_poseComp) -> bool
+      {
+        auto sensorMsg = std::make_shared<msgs::Sensor>();
+        sensorMsg->set_id(_entity);
+        sensorMsg->set_parent_id(_parentComp->Data());
+        sensorMsg->set_name(_nameComp->Data());
+        sensorMsg->mutable_pose()->CopyFrom(msgs::Convert(_poseComp->Data()));
+
+        // Add to graph
+        newGraph.AddVertex(_nameComp->Data(), sensorMsg, _entity);
+        newGraph.AddEdge({_parentComp->Data(), _entity}, true);
+        newEntity = true;
+        return true;
+      });
 
   // Update the whole scene graph from the new graph
   {
@@ -879,6 +908,24 @@ void SceneBroadcasterPrivate::AddVisuals(msgs::Link *_msg, const Entity _entity,
 }
 
 //////////////////////////////////////////////////
+void SceneBroadcasterPrivate::AddSensors(msgs::Link *_msg, const Entity _entity,
+    const SceneGraphType &_graph)
+{
+  if (!_msg)
+    return;
+
+  for (const auto &vertex : _graph.AdjacentsFrom(_entity))
+  {
+    auto sensorMsg = std::dynamic_pointer_cast<msgs::Sensor>(
+        vertex.second.get().Data());
+    if (!sensorMsg)
+      continue;
+
+    _msg->add_sensor()->CopyFrom(*sensorMsg);
+  }
+}
+
+//////////////////////////////////////////////////
 void SceneBroadcasterPrivate::AddLinks(msgs::Model *_msg, const Entity _entity,
                                        const SceneGraphType &_graph)
 {
@@ -900,6 +947,9 @@ void SceneBroadcasterPrivate::AddLinks(msgs::Model *_msg, const Entity _entity,
 
     // Lights
     AddLights(msgOut, vertex.second.get().Id(), _graph);
+
+    // Sensors
+    AddSensors(msgOut, vertex.second.get().Id(), _graph);
   }
 }
 

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -162,7 +162,6 @@ TEST_P(SceneBroadcasterTest, SceneGraph)
 
   EXPECT_TRUE(node.Request("/world/default/scene/graph", timeout, res, result));
   EXPECT_TRUE(result);
-  std::cout << res.data() << "\n";
   EXPECT_FALSE(res.data().empty());
   EXPECT_NE(res.data().find("default (1)"), std::string::npos);
   EXPECT_NE(res.data().find("box (4)"), std::string::npos);

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -52,7 +52,7 @@ TEST_P(SceneBroadcasterTest, PoseInfo)
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(16u, *server.EntityCount());
+  EXPECT_EQ(17u, *server.EntityCount());
 
   // Create pose subscriber
   transport::Node node;
@@ -102,7 +102,7 @@ TEST_P(SceneBroadcasterTest, SceneInfo)
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(16u, *server.EntityCount());
+  EXPECT_EQ(17u, *server.EntityCount());
 
   // Run server
   server.Run(true, 1, false);
@@ -148,7 +148,7 @@ TEST_P(SceneBroadcasterTest, SceneGraph)
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(16u, *server.EntityCount());
+  EXPECT_EQ(17u, *server.EntityCount());
 
   // Run server
   server.Run(true, 1, false);
@@ -162,7 +162,7 @@ TEST_P(SceneBroadcasterTest, SceneGraph)
 
   EXPECT_TRUE(node.Request("/world/default/scene/graph", timeout, res, result));
   EXPECT_TRUE(result);
-
+  std::cout << res.data() << "\n";
   EXPECT_FALSE(res.data().empty());
   EXPECT_NE(res.data().find("default (1)"), std::string::npos);
   EXPECT_NE(res.data().find("box (4)"), std::string::npos);
@@ -174,6 +174,7 @@ TEST_P(SceneBroadcasterTest, SceneGraph)
   EXPECT_NE(res.data().find("sphere (12)"), std::string::npos);
   EXPECT_NE(res.data().find("sphere_link (13)"), std::string::npos);
   EXPECT_NE(res.data().find("sphere_visual (14)"), std::string::npos);
+  EXPECT_NE(res.data().find("altimeter (16)"), std::string::npos);
 }
 
 /////////////////////////////////////////////////
@@ -188,7 +189,7 @@ TEST_P(SceneBroadcasterTest, SceneTopic)
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(16u, *server.EntityCount());
+  EXPECT_EQ(17u, *server.EntityCount());
 
   // Create requester
   transport::Node node;
@@ -218,6 +219,12 @@ TEST_P(SceneBroadcasterTest, SceneTopic)
   EXPECT_TRUE(node.Request("/world/default/scene/info", timeout, msg, result));
   EXPECT_TRUE(result);
   EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(msg, scene));
+
+  EXPECT_EQ(1, msg.model(2).link(0).sensor_size());
+  EXPECT_EQ("altimeter", msg.model(2).link(0).sensor(0).name());
+  EXPECT_DOUBLE_EQ(0.1, msg.model(2).link(0).sensor(0).pose().position().x());
+  EXPECT_DOUBLE_EQ(0.2, msg.model(2).link(0).sensor(0).pose().position().y());
+  EXPECT_DOUBLE_EQ(0.3, msg.model(2).link(0).sensor(0).pose().position().z());
 }
 
 /////////////////////////////////////////////////
@@ -233,7 +240,7 @@ TEST_P(SceneBroadcasterTest, DeletedTopic)
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
 
-  const std::size_t initEntityCount = 16;
+  const std::size_t initEntityCount = 17;
   EXPECT_EQ(initEntityCount, *server.EntityCount());
 
   // Subscribe to deletions
@@ -293,7 +300,7 @@ TEST_P(SceneBroadcasterTest, SpawnedModel)
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
 
-  const std::size_t initEntityCount = 16;
+  const std::size_t initEntityCount = 17;
   EXPECT_EQ(initEntityCount, *server.EntityCount());
 
   server.Run(true, 1, false);
@@ -362,7 +369,7 @@ TEST_P(SceneBroadcasterTest, State)
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(16u, *server.EntityCount());
+  EXPECT_EQ(17u, *server.EntityCount());
   transport::Node node;
 
   // Run server
@@ -392,7 +399,7 @@ TEST_P(SceneBroadcasterTest, State)
       [&](const msgs::SerializedStepMap &_res, const bool _success)
   {
     EXPECT_TRUE(_success);
-    checkMsg(_res, 16);
+    checkMsg(_res, 17);
   };
   std::function<void(const msgs::SerializedStepMap &)> cb2 =
       [&](const msgs::SerializedStepMap &_res)
@@ -404,7 +411,7 @@ TEST_P(SceneBroadcasterTest, State)
   std::function<void(const msgs::SerializedStepMap &)> cbAsync =
       [&](const msgs::SerializedStepMap &_res)
   {
-    checkMsg(_res, 16);
+    checkMsg(_res, 17);
   };
 
   // The request is blocking even though it's meant to be async, so we spin a

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -348,7 +348,7 @@ TEST_F(UserCommandsTest, Remove)
   // Check entities
   // 1 x world + 1 x (default) level + 1 x wind + 3 x model + 3 x link + 3 x
   // collision + 3 x visual + 1 x light
-  EXPECT_EQ(16u, ecm->EntityCount());
+  EXPECT_EQ(17u, ecm->EntityCount());
 
   // Entity remove by name
   msgs::Entity req;
@@ -371,7 +371,7 @@ TEST_F(UserCommandsTest, Remove)
 
   // Run an iteration and check it was removed
   server.Run(true, 1, false);
-  EXPECT_EQ(12u, ecm->EntityCount());
+  EXPECT_EQ(13u, ecm->EntityCount());
 
   EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
       components::Name("box")));

--- a/test/worlds/shapes.sdf
+++ b/test/worlds/shapes.sdf
@@ -163,6 +163,28 @@
             <specular>0 0 1 1</specular>
           </material>
         </visual>
+
+        <sensor name="altimeter" type="altimeter">
+          <pose>0.1 0.2 0.3 0 0 0</pose>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+          <topic>altimeter</topic>
+          <altimeter>
+            <vertical_position>
+              <noise type="gaussian">
+                <mean>0.1</mean>
+                <stddev>0.2</stddev>
+              </noise>
+            </vertical_position>
+            <vertical_velocity>
+              <noise type="gaussian">
+                <mean>0.2</mean>
+                <stddev>0.1</stddev>
+              </noise>
+            </vertical_velocity>
+          </altimeter>
+        </sensor>
       </link>
     </model>
   </world>


### PR DESCRIPTION
# 🎉 New feature

## Summary

This adds some sensor information to the scene broadcaster. Web sensor data visualization needs this information.

## Test it

You should see sensors appear in the `scene/graph` and `scene/info` service results.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**