### PR TITLE
Setting the intiial velocity for a model or joint

### DIFF
--- a/examples/worlds/joint_controller.sdf
+++ b/examples/worlds/joint_controller.sdf
@@ -158,6 +158,7 @@
         filename="ignition-gazebo-joint-controller-system"
         name="ignition::gazebo::systems::JointController">
         <joint_name>j1</joint_name>
+        <initial_velocity>5.0</initial_velocity>
       </plugin>
     </model>
 

--- a/examples/worlds/velocity_control.sdf
+++ b/examples/worlds/velocity_control.sdf
@@ -485,6 +485,8 @@
       <plugin
         filename="ignition-gazebo-velocity-control-system"
         name="ignition::gazebo::systems::VelocityControl">
+        <initial_linear>0.3 0 0</initial_linear>
+        <initial_angular>0 0 -0.1</initial_angular>
       </plugin>
 
     </model>

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -98,6 +98,13 @@ void JointController::Configure(const Entity &_entity,
     return;
   }
 
+  if (_sdf->HasElement("initial_velocity"))
+  {
+    this->dataPtr->jointVelCmd = _sdf->Get<double>("initial_velocity");
+    ignmsg << "Joint velocity initialized to ["
+           << this->dataPtr->jointVelCmd << "]" << std::endl;
+  }
+
   if (_sdf->HasElement("use_force_commands") &&
       _sdf->Get<bool>("use_force_commands"))
   {

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -42,6 +42,11 @@ namespace systems
   /// using force commands. If this parameter is not set or is false, the
   /// controller will use velocity commands internally.
   ///
+  /// `<topic>` Topic to receive commands in. Defaults to
+  ///     `/model/<model_name>/joint/<joint_name>/cmd_vel`.
+  ///
+  /// `<initial_velocity>` Velocity to start with.
+  ///
   /// ### Velocity mode: No additional parameters are required.
   ///
   /// ### Force mode: The controller accepts the next optional parameters:

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -88,6 +88,24 @@ void VelocityControl::Configure(const Entity &_entity,
     return;
   }
 
+  if (_sdf->HasElement("linear"))
+  {
+    this->dataPtr->linearVelocity = _sdf->Get<math::Vector3d>("linear");
+    msgs::Set(this->dataPtr->targetVel.mutable_linear(),
+        this->dataPtr->linearVelocity);
+    ignmsg << "Linear velocity initialized to ["
+           << this->dataPtr->linearVelocity << "]" << std::endl;
+  }
+
+  if (_sdf->HasElement("angular"))
+  {
+    this->dataPtr->angularVelocity = _sdf->Get<math::Vector3d>("angular");
+    msgs::Set(this->dataPtr->targetVel.mutable_angular(),
+        this->dataPtr->angularVelocity);
+    ignmsg << "Angular velocity initialized to ["
+           << this->dataPtr->angularVelocity << "]" << std::endl;
+  }
+
   // Subscribe to commands
   std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -88,18 +88,19 @@ void VelocityControl::Configure(const Entity &_entity,
     return;
   }
 
-  if (_sdf->HasElement("linear"))
+  if (_sdf->HasElement("initial_linear"))
   {
-    this->dataPtr->linearVelocity = _sdf->Get<math::Vector3d>("linear");
+    this->dataPtr->linearVelocity = _sdf->Get<math::Vector3d>("initial_linear");
     msgs::Set(this->dataPtr->targetVel.mutable_linear(),
         this->dataPtr->linearVelocity);
     ignmsg << "Linear velocity initialized to ["
            << this->dataPtr->linearVelocity << "]" << std::endl;
   }
 
-  if (_sdf->HasElement("angular"))
+  if (_sdf->HasElement("initial_angular"))
   {
-    this->dataPtr->angularVelocity = _sdf->Get<math::Vector3d>("angular");
+    this->dataPtr->angularVelocity =
+        _sdf->Get<math::Vector3d>("initial_angular");
     msgs::Set(this->dataPtr->targetVel.mutable_angular(),
         this->dataPtr->angularVelocity);
     ignmsg << "Angular velocity initialized to ["

--- a/src/systems/velocity_control/VelocityControl.hh
+++ b/src/systems/velocity_control/VelocityControl.hh
@@ -35,6 +35,15 @@ namespace systems
 
   /// \brief Linear and angular velocity controller
   /// which is directly set on a model.
+  ///
+  /// ## System Parameters
+  ///
+  /// `<topic>` Topic to receive commands in. Defaults to
+  ///     `/model/<model_name>/cmd_vel`.
+  ///
+  /// `<initial_linear>` Linear velocity to start with.
+  ///
+  /// `<initial_angular>` Linear velocity to start with.
   class VelocityControl
       : public System,
         public ISystemConfigure,

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -103,12 +103,21 @@ TEST_F(JointControllerTestFixture, JointVelocityCommand)
 
   server.AddSystem(testSystem.systemPtr);
 
-  const std::size_t initIters = 10;
+  const std::size_t initIters = 1000;
   server.Run(true, initIters, false);
   EXPECT_EQ(initIters, angularVelocities.size());
-  for (const auto &angVel : angularVelocities)
+  for (auto i = 0u; i < angularVelocities.size(); ++i)
   {
-    EXPECT_NEAR(0, angVel.Length(), TOL);
+    if (i == 0)
+    {
+      EXPECT_NEAR(0.0, angularVelocities[i].Length(), TOL)
+          << "Iteration [" << i << "]";
+    }
+    else
+    {
+      EXPECT_NEAR(5.0, angularVelocities[i].Length(), TOL)
+          << "Iteration [" << i << "]";
+    }
   }
 
   angularVelocities.clear();

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -167,7 +167,7 @@ TEST_F(VelocityControlTest, InitialVelocity)
     });
   server.AddSystem(testSystem.systemPtr);
 
-  // Run server and check that vehicle didn't move
+  // Run server and check that vehicle moved
   server.Run(true, 1000, false);
   EXPECT_EQ(1000u, poses.size());
 

--- a/test/worlds/joint_controller.sdf
+++ b/test/worlds/joint_controller.sdf
@@ -151,6 +151,7 @@
         filename="ignition-gazebo-joint-controller-system"
         name="ignition::gazebo::systems::JointController">
         <joint_name>j1</joint_name>
+        <initial_velocity>5.0</initial_velocity>
       </plugin>
     </model>
 

--- a/test/worlds/velocity_control.sdf
+++ b/test/worlds/velocity_control.sdf
@@ -485,6 +485,8 @@
       <plugin
         filename="ignition-gazebo-velocity-control-system"
         name="ignition::gazebo::systems::VelocityControl">
+        <initial_linear>0.3 0 0</initial_linear>
+        <initial_angular>0 0 -0.1</initial_angular>
       </plugin>
 
     </model>


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Let the user set an initial velocity through the `VelocityControl` plugin or `JointController` plugin.

I'm using this for a demo.

I'll come back to add tests and docs, just opening in time for feature freeze :cold_face: 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

I'll add it to the example world.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests: ~~**TODO**~~ Done
- [x] Added example and/or tutorial ~~**TODO**~~ Done
- [x] Updated documentation (as needed) ~~**TODO**~~ Done
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
