### PR TITLE
Fix joint controller GUI test

### DIFF
--- a/src/gui/plugins/joint_position_controller/JointPositionController.cc
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.cc
@@ -49,7 +49,7 @@ namespace ignition::gazebo::gui
     public: Entity modelEntity{kNullEntity};
 
     /// \brief Name of the model
-    public: QString modelName;
+    public: QString modelName{"No model selected"};
 
     /// \brief Whether currently locked on a given entity
     public: bool locked{false};
@@ -58,7 +58,7 @@ namespace ignition::gazebo::gui
     public: transport::Node node;
 
     /// \brief Whether the initial model set from XML has been setup.
-    public: bool xmlModelInitialized{false};
+    public: bool xmlModelInitialized{true};
   };
 }
 
@@ -157,11 +157,10 @@ void JointPositionController::LoadConfig(
     if (auto elem = _pluginElem->FirstChildElement("model_name"))
     {
       this->dataPtr->modelName = QString::fromStdString(elem->GetText());
+      // If model name isn't set, initialization is not complete yet.
+      this->dataPtr->xmlModelInitialized = false;
     }
   }
-
-  // If model name isn't set, initialization is complete.
-  this->dataPtr->xmlModelInitialized = this->dataPtr->modelName.isEmpty();
 
   ignition::gui::App()->findChild<
       ignition::gui::MainWindow *>()->installEventFilter(this);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `JoingPositionController_TEST` was broken when https://github.com/ignitionrobotics/ign-gazebo/pull/534 was forward-ported in https://github.com/ignitionrobotics/ign-gazebo/pull/689.

I think this fix is also reasonable for `ign-gazebo3`, but for some timing issue, the test doesn't seem to be failing there. So I'm fixing it here and we can backport if needed.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
