### PR TITLE
Fixed collision visual bounding boxes

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2164,11 +2164,9 @@ void RenderUtil::ViewCollisions(const Entity &_entity)
 
     if (showCol)
     {
-      // turn off wireboxes for collision entity except for most recent
-      // selected entity (it is still highlighted in entity tree)
+      // turn off wireboxes for collision entity
       if (this->dataPtr->wireBoxes.find(colEntity)
-            != this->dataPtr->wireBoxes.end()
-          && colEntity != this->dataPtr->selectedEntities.back())
+            != this->dataPtr->wireBoxes.end())
       {
         ignition::rendering::WireBoxPtr wireBox =
           this->dataPtr->wireBoxes[colEntity];

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2161,5 +2161,21 @@ void RenderUtil::ViewCollisions(const Entity &_entity)
 
     this->dataPtr->viewingCollisions[colEntity] = showCol;
     colVisual->SetVisible(showCol);
+
+    if (showCol)
+    {
+      // turn off wireboxes for collision entity except for most recent
+      // selected entity (it is still highlighted in entity tree)
+      if (this->dataPtr->wireBoxes.find(colEntity)
+            != this->dataPtr->wireBoxes.end()
+          && colEntity != this->dataPtr->selectedEntities.back())
+      {
+        ignition::rendering::WireBoxPtr wireBox =
+          this->dataPtr->wireBoxes[colEntity];
+        auto visParent = wireBox->Parent();
+        if (visParent)
+          visParent->SetVisible(false);
+      }
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Jenn Nguyen <jenn@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Encountered a new bug with collision visualizations. When collisions are turned on for a model, then any collision entity that was selected from the entity tree (which "highlights" the collision entity by putting a bounding box around it), will have bounding boxes around them once you turn off, then turn back on collisions. The only way to make the bounding boxes disappear is to select the collision entity again then deselect but once you turn collisions off then back on again for the model the bounding boxes reappear. 

**Steps to reproduce bug before PR**:
1. `ign gazebo -v 4 "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Edifice demo"`
2. Turn on collisions for Mecanum lift
3. In entity tree, open Mecanum lift > chassis
4. Click on collision entities for bar_1 and bar_2
5. Right-click Mecanum lift and toggle off collisions
6. Right-click Mecanum lift and toggle back on collisions

bar_1 and bar_2 should have bounding boxes around them.

If you run the above steps above with this PR, then the bounding boxes will not be shown around the collisions unless it is the most recent highlighted one from the entity tree. For example, if collisions are turned off and you select bar_2 from the entity tree then when you turn collisions back on (with bar_2 highlighted), bar_2 will have a bounding box around it.

This bug fix will need to be backported to `ign-gazebo4` for Dome.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**