### PR TITLE
Fixed material colors for Ackermann SDF files

### DIFF
--- a/examples/worlds/ackermann_steering.sdf
+++ b/examples/worlds/ackermann_steering.sdf
@@ -315,12 +315,12 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
-      
+
       <link name="front_right_wheel_steering_link">
         <pose>0.554283 -0.5 0.02 0 0 0</pose>
         <inertial>
@@ -340,8 +340,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -360,7 +360,7 @@
           <use_parent_model_frame>1</use_parent_model_frame>
         </axis>
       </joint>
-      
+
       <joint name="front_right_wheel_steering_joint" type="revolute">
         <parent>chassis</parent>
         <child>front_right_wheel_steering_link</child>

--- a/test/worlds/ackermann_steering.sdf
+++ b/test/worlds/ackermann_steering.sdf
@@ -259,12 +259,12 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
-      
+
       <link name="front_right_wheel_steering_link">
         <pose>0.554283 -0.5 0.02 0 0 0</pose>
         <inertial>
@@ -284,8 +284,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -304,7 +304,7 @@
           <use_parent_model_frame>1</use_parent_model_frame>
         </axis>
       </joint>
-      
+
       <joint name="front_right_wheel_steering_joint" type="revolute">
         <parent>chassis</parent>
         <child>front_right_wheel_steering_link</child>

--- a/test/worlds/ackermann_steering_custom_frame_id.sdf
+++ b/test/worlds/ackermann_steering_custom_frame_id.sdf
@@ -303,12 +303,12 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
-      
+
       <link name="front_right_wheel_steering_link">
         <pose>0.554283 -0.5 0.02 0 0 0</pose>
         <inertial>
@@ -328,8 +328,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -348,7 +348,7 @@
           <use_parent_model_frame>1</use_parent_model_frame>
         </axis>
       </joint>
-      
+
       <joint name="front_right_wheel_steering_joint" type="revolute">
         <parent>chassis</parent>
         <child>front_right_wheel_steering_link</child>

--- a/test/worlds/ackermann_steering_custom_topics.sdf
+++ b/test/worlds/ackermann_steering_custom_topics.sdf
@@ -303,12 +303,12 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
-      
+
       <link name="front_right_wheel_steering_link">
         <pose>0.554283 -0.5 0.02 0 0 0</pose>
         <inertial>
@@ -328,8 +328,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -348,7 +348,7 @@
           <use_parent_model_frame>1</use_parent_model_frame>
         </axis>
       </joint>
-      
+
       <joint name="front_right_wheel_steering_joint" type="revolute">
         <parent>chassis</parent>
         <child>front_right_wheel_steering_link</child>

--- a/test/worlds/ackermann_steering_limited_joints_pub.sdf
+++ b/test/worlds/ackermann_steering_limited_joints_pub.sdf
@@ -303,12 +303,12 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
-      
+
       <link name="front_right_wheel_steering_link">
         <pose>0.554283 -0.5 0.02 0 0 0</pose>
         <inertial>
@@ -328,8 +328,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -348,7 +348,7 @@
           <use_parent_model_frame>1</use_parent_model_frame>
         </axis>
       </joint>
-      
+
       <joint name="front_right_wheel_steering_joint" type="revolute">
         <parent>chassis</parent>
         <child>front_right_wheel_steering_link</child>

--- a/test/worlds/ackermann_steering_slow_odom.sdf
+++ b/test/worlds/ackermann_steering_slow_odom.sdf
@@ -259,12 +259,12 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
-      
+
       <link name="front_right_wheel_steering_link">
         <pose>0.554283 -0.5 0.02 0 0 0</pose>
         <inertial>
@@ -284,8 +284,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -304,7 +304,7 @@
           <use_parent_model_frame>1</use_parent_model_frame>
         </axis>
       </joint>
-      
+
       <joint name="front_right_wheel_steering_joint" type="revolute">
         <parent>chassis</parent>
         <child>front_right_wheel_steering_link</child>


### PR DESCRIPTION
Signed-off-by: Jenn Nguyen <jenn@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
There were several Ackermann SDF files that had invalid material color components (e.g., `<diffuse>11 11 11</diffuse>`). With the new changes from https://github.com/osrf/sdformat/pull/519, this will fail. These invalid color components have been replaced with `1 1 1`. 

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**