### PR TITLE
Fix diffuse and ambient values for ackermann example

### DIFF
--- a/examples/worlds/ackermann_steering.sdf
+++ b/examples/worlds/ackermann_steering.sdf
@@ -315,8 +315,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>0.2 0.2 0.2 1</ambient>
-            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>
@@ -340,8 +340,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>0.2 0.2 0.2 1</ambient>
-            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
           </material>
         </visual>
       </link>

--- a/examples/worlds/ackermann_steering.sdf
+++ b/examples/worlds/ackermann_steering.sdf
@@ -315,8 +315,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
           </material>
         </visual>
       </link>
@@ -340,8 +340,8 @@
             </cylinder>
           </geometry>
           <material>
-            <ambient>11 11 11</ambient>
-            <diffuse>11 11 11</diffuse>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
           </material>
         </visual>
       </link>


### PR DESCRIPTION
Signed-off-by: Ammaar Solkar <asketch8@gmail.com>

## Summary
File `ackermann_steering.sdf` contained 
```
<material>
  <ambient>11 11 11</ambient>
  <diffuse>11 11 11</diffuse>
</material>
```
in two places which prevented world file from launching due to invalid values. Changed values to
```
<material>
  <ambient>0.2 0.2 0.2 1</ambient>
  <diffuse>0.2 0.2 0.2 1</diffuse>
</material>
```