### PR TITLE
Use Protobuf_IMPORT_DIRS instead of PROTOBUF_IMPORT_DIRS for compatibility with Protobuf CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project
@@ -136,7 +136,7 @@ ign_find_package(IgnProtobuf
                  REQUIRED
                  COMPONENTS all
                  PRETTY Protobuf)
-set(PROTOBUF_IMPORT_DIRS ${ignition-msgs5_INCLUDE_DIRS})
+set(Protobuf_IMPORT_DIRS ${ignition-msgs5_INCLUDE_DIRS})
 
 # Plugin install dirs
 set(IGNITION_GAZEBO_PLUGIN_INSTALL_DIR


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the compilation of Ignition Gazebo on Windows or in any case on a platform in which Protobuf installs its CMake Config files. 

## Summary
Ignition Gazebo uses the [`PROTOBUF_GENERATE_CPP`](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/src/msgs/CMakeLists.txt#L1) CMake function to generate C++ code from the `.proto` files. 
Depending on the system and the protobuf version installed, this function can be defined in two possible places:
* If a CMake config file for Protobuf is installed, the `FindIgnProtobuf` prefers it over the CMake's `FindProtobuf` (see https://github.com/ignitionrobotics/ign-cmake/blob/ignition-cmake2_2.6.2/cmake/FindIgnProtobuf.cmake#L29), and so the function defined in the `protobuf-module.cmake` is used https://github.com/protocolbuffers/protobuf/blob/v3.15.6/cmake/protobuf-module.cmake.in#L4 . This function **considers in input the `Protobuf_IMPORT_DIRS` variable**.
* If a CMake config file for Protobuf is not installed (as it happens for Ubuntu 20.04 debian packages), the the CMake's FindProtobuf is used, and the `PROTOBUF_GENERATE_CPP` function used is the one defined there: https://github.com/Kitware/CMake/blob/v3.16.9/Modules/FindProtobuf.cmake#L245 . This function **considers in input the `Protobuf_IMPORT_DIRS` and `PROTOBUF_IMPORT_DIRS` variables**.

As currently ignition-gazebo only sets the `PROTOBUF_IMPORT_DIRS` variable, if a Protobuf CMake config is used, the generation of messages fails with error:
~~~
2021-03-27T23:20:08.8623834Z -- Build files have been written to: D:/bld/libignition-gazebo4_1616885912413/work/build
2021-03-27T23:20:09.2594171Z [1/408] cmd.exe /C "cd /D %SRC_DIR%\build\src\msgs && %PREFIX%\Library\bin\protoc.exe --cpp_out D:/bld/libignition-gazebo4_1616885912413/work/build/src/msgs -I D:/bld/libignition-gazebo4_1616885912413/work/src/msgs D:/bld/libignition-gazebo4_1616885912413/work/src/msgs/peer_info.proto"
2021-03-27T23:20:09.2597900Z FAILED: src/msgs/peer_info.pb.h src/msgs/peer_info.pb.cc 
2021-03-27T23:20:09.2605328Z cmd.exe /C "cd /D %SRC_DIR%\build\src\msgs && %PREFIX%\Library\bin\protoc.exe --cpp_out D:/bld/libignition-gazebo4_1616885912413/work/build/src/msgs -I D:/bld/libignition-gazebo4_1616885912413/work/src/msgs D:/bld/libignition-gazebo4_1616885912413/work/src/msgs/peer_info.proto"
2021-03-27T23:20:09.2606754Z ignition/msgs/header.proto: File not found.
2021-03-27T23:20:09.2613215Z peer_info.proto:22:1: Import "ignition/msgs/header.proto" was not found or had errors.
2021-03-27T23:20:09.2614568Z peer_info.proto:28:3: "ignition.msgs.Header" is not defined.
2021-03-27T23:20:09.2616338Z [2/408] cmd.exe /C "cd /D %SRC_DIR%\build\src\msgs && %PREFIX%\Library\bin\protoc.exe --cpp_out D:/bld/libignition-gazebo4_1616885912413/work/build/src/msgs -I D:/bld/libignition-gazebo4_1616885912413/work/src/msgs D:/bld/libignition-gazebo4_1616885912413/work/src/msgs/peer_control.proto"
2021-03-27T23:20:09.2618072Z FAILED: src/msgs/peer_control.pb.h src/msgs/peer_control.pb.cc 
2021-03-27T23:20:09.2619552Z cmd.exe /C "cd /D %SRC_DIR%\build\src\msgs && %PREFIX%\Library\bin\protoc.exe --cpp_out D:/bld/libignition-gazebo4_1616885912413/work/build/src/msgs -I D:/bld/libignition-gazebo4_1616885912413/work/src/msgs D:/bld/libignition-gazebo4_1616885912413/work/src/msgs/peer_control.proto"
2021-03-27T23:20:09.2621084Z ignition/msgs/header.proto: File not found.
2021-03-27T23:20:09.2625509Z peer_control.proto:22:1: Import "ignition/msgs/header.proto" was not found or had errors.
2021-03-27T23:20:09.2627093Z peer_control.proto:30:3: "ignition.msgs.Header" is not defined.
2021-03-27T23:20:09.2628926Z [3/408] cmd.exe /C "cd /D %SRC_DIR%\build\src\msgs && %PREFIX%\Library\bin\protoc.exe --cpp_out D:/bld/libignition-gazebo4_1616885912413/work/build/src/msgs -I D:/bld/libignition-gazebo4_1616885912413/work/src/msgs D:/bld/libignition-gazebo4_1616885912413/work/src/msgs/simulation_step.proto"
2021-03-27T23:20:09.2630539Z FAILED: src/msgs/simulation_step.pb.h src/msgs/simulation_step.pb.cc 
2021-03-27T23:20:09.2638659Z cmd.exe /C "cd /D %SRC_DIR%\build\src\msgs && %PREFIX%\Library\bin\protoc.exe --cpp_out D:/bld/libignition-gazebo4_1616885912413/work/build/src/msgs -I D:/bld/libignition-gazebo4_1616885912413/work/src/msgs D:/bld/libignition-gazebo4_1616885912413/work/src/msgs/simulation_step.proto"
2021-03-27T23:20:09.2639864Z ignition/msgs/world_stats.proto: File not found.
2021-03-27T23:20:09.2640359Z ignition/msgs/entity.proto: File not found.
~~~

(error taken from https://github.com/conda-forge/libignition-gazebo-feedstock/pull/3).

To avoid this errors, I switched the Ignition Gazebo to set the `Protobuf_IMPORT_DIRS` variable that will work fine regardless of whether a CMake config file for ProtoBuf is used or not.

However, as the use of Protobuf_IMPORT_DIRS (instead of `PROTOBUF_IMPORT_DIRS`) was only introduced in CMake 3.6 (see https://github.com/Kitware/CMake/blob/v3.20.0/Modules/FindProtobuf.cmake#L13), I also bumped the minimum required version to 3.10.2 (for consistency with ignition-cmake2). CMake 3.10.2 is available in apt in Ubuntu 18.04 (see https://repology.org/project/cmake/versions).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
