### PR TITLE
Do not pass -Wno-unused-parameter to MSVC compiler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,10 +10,12 @@ set_source_files_properties(
 )
 
 # Suppress compiler warnings in generated protobuf C++ code.
-set_source_files_properties(
-  ${PROTO_PRIVATE_SRC}
-  COMPILE_FLAGS -Wno-unused-parameter
-)
+if(NOT MSVC)
+  set_source_files_properties(
+    ${PROTO_PRIVATE_SRC}
+    COMPILE_FLAGS -Wno-unused-parameter
+  )
+endif()
 
 set(network_sources
   network/NetworkConfig.cc


### PR DESCRIPTION
# 🦟 Bug fix

Fix compilation on MSVC compiler by avoiding to pass -Wno-unused-parameter to it. 


## Summary

The ` -Wno-unused-parameter` option is not supported by MSVC, that fails with:
~~~
2021-03-28T13:16:44.8417876Z FAILED: src/CMakeFiles/ignition-gazebo4.dir/msgs/simulation_step.pb.cc.obj 
2021-03-28T13:16:44.8420880Z C:\PROGRA~2\MICROS~1\2017\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\cl.exe   /TP -DIGN_PROFILER_ENABLE=0 -DNOMINMAX -DPROTOBUF_USE_DLLS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_QML_LIB -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_WIDGETS_LIB -DWIN32_LEAN_AND_MEAN -Dignition_gazebo4_EXPORTS -I..\include -Iinclude -Icore\include -Isrc -I..\test -I%PREFIX%\Library\include\ignition\math6 -I%PREFIX%\Library\include\ignition\plugin1 -I%PREFIX%\Library\include\ignition\cmake2 -I%PREFIX%\Library\include\ignition\common3 -I%PREFIX%\Library\include\ignition\fuel_tools5 -I%PREFIX%\Library\include\ignition\msgs6 -I%PREFIX%\Library\include -I%PREFIX%\Library\include\ignition\gui4 -I%PREFIX%\Library\include\eigen3 -I%PREFIX%\Library\include\ignition\transport9 -I%PREFIX%\Library\include\qt -I%PREFIX%\Library\include\qt\QtCore -I%PREFIX%\Library\.\mkspecs\win32-msvc -I%PREFIX%\Library\include\qt\QtQml -I%PREFIX%\Library\include\qt\QtNetwork -I%PREFIX%\Library\include\qt\QtQuick -I%PREFIX%\Library\include\qt\QtGui -I%PREFIX%\Library\include\qt\QtANGLE -I%PREFIX%\Library\include\qt\QtQuickControls2 -I%PREFIX%\Library\include\qt\QtWidgets -I%PREFIX%\Library\include\sdformat-10.3\sdf\.. /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MD /O2 /Ob2 /DNDEBUG /Gy /W2 /Zi /GL /EHsc -ID:/bld/libignition-gazebo4_1616936352265/_h_env/Library/include -std:c++17 -Wno-unused-parameter /showIncludes /Fosrc\CMakeFiles\ignition-gazebo4.dir\msgs\simulation_step.pb.cc.obj /Fdsrc\CMakeFiles\ignition-gazebo4.dir\ /FS -c src\msgs\simulation_step.pb.cc
2021-03-28T13:16:44.8423926Z Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27045 for x64
2021-03-28T13:16:44.8424459Z Copyright (C) Microsoft Corporation.  All rights reserved.
2021-03-28T13:16:44.8424680Z 
2021-03-28T13:16:44.8430239Z cl : Command line warning D9025 : overriding '/W3' with '/W2'
2021-03-28T13:16:44.8430868Z cl : Command line error D8021 : invalid numeric argument '/Wno-unused-parameter'
~~~

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
