### PR TITLE
Respect spotlight direction

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -939,6 +939,7 @@ rendering::LightPtr SceneManager::CreateLight(Entity _id,
       spotLight->SetInnerAngle(_light.SpotInnerAngle());
       spotLight->SetOuterAngle(_light.SpotOuterAngle());
       spotLight->SetFalloff(_light.SpotFalloff());
+      spotLight->SetDirection(_light.Direction());
       break;
     }
     case sdf::LightType::DIRECTIONAL:


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
According to SDF and ign-rendering, spot lights have a direction parameter. However, this parameter was ignored when setting the light in the scene. This PR fixes it.

Of course, this might break some scenes which were set up with the direction ignored. However, I still feel that the change is worth it (but I'd suggest the SubT team to thoroughly check if some worlds aren't affected :) ). If merging in Dome is not possible, merge to Edifice, please.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**