### PR TITLE
Respect spotlight direction

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -31,6 +31,11 @@ release will remove the deprecated code.
   * **Deprecated** `ignition::gazebo::gui::SnapPreviewPath`
   * **Replacement** `ignition::gui::SnapFromPath`
 
+* The `<direction>` tag of spot lights was previously not parsed by the
+  scene, so all spot lights shone in the direction corresponding to the
+  default `0 0 -1`. Since 5.x, the `<direction>` tag is correctly
+  processed.
+
 ## Ignition Gazebo 4.0.0 to 4.X.X
 
 * Ignition Gazebo 4.0.0 enabled double sided material by default but this

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -1105,6 +1105,7 @@ rendering::LightPtr SceneManager::CreateLight(Entity _id,
       spotLight->SetInnerAngle(_light.SpotInnerAngle());
       spotLight->SetOuterAngle(_light.SpotOuterAngle());
       spotLight->SetFalloff(_light.SpotFalloff());
+      spotLight->SetDirection(_light.Direction());
       break;
     }
     case sdf::LightType::DIRECTIONAL:


### PR DESCRIPTION
# Summary

According to SDF and ign-rendering, spot lights have a direction parameter. However, this parameter was ignored when setting the light in the scene. This PR fixes it.

This PR replaces #717.