### PR TITLE
Replace deprecated function FreeGroup::CanonicalLink with FreeGroup::RootLink

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1419,23 +1419,20 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
           return true;
         }
 
-        // The canonical link as specified by sdformat is different from the
-        // canonical link of the FreeGroup object
-
         // TODO(addisu) Store the free group instead of searching for it at
         // every iteration
         auto freeGroup = modelPtrPhys->FindFreeGroup();
         if (!freeGroup)
           return true;
 
-        // Get canonical link offset
+        // Get root link offset
         const auto linkEntity =
-            this->entityLinkMap.Get(freeGroup->CanonicalLink());
+            this->entityLinkMap.Get(freeGroup->RootLink());
         if (linkEntity == kNullEntity)
           return true;
 
-        // set world pose of canonical link in freegroup
-        // canonical link might be in a nested model so use RelativePose to get
+        // set world pose of root link in freegroup
+        // root link might be in a nested model so use RelativePose to get
         // its pose relative to this model
         math::Pose3d linkPose =
             this->RelativePose(_entity, linkEntity, _ecm);


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-physics/issues/233

## Summary
`ignition::physics::FreeGroup::CanonicalLink` was deprecated in https://github.com/ignitionrobotics/ign-physics/pull/234. This PR uses the replacement `ignition::physics::FreeGroup::RootLink`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] ~Updated documentation (as needed)~
- [ ] ~Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

