### PR TITLE
Fix component inspector shutdown crash

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -106,6 +106,9 @@ using namespace gazebo;
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const math::Pose3d &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Pose3d"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QList({
@@ -122,6 +125,9 @@ void ignition::gazebo::setData(QStandardItem *_item, const math::Pose3d &_data)
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const msgs::Light &_data)
 {
+  if (nullptr == _item)
+    return;
+
   int lightType = -1;
   if (_data.type() == msgs::Light::POINT)
   {
@@ -168,6 +174,9 @@ template<>
 void ignition::gazebo::setData(QStandardItem *_item,
     const math::Vector3d &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Vector3d"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QList({
@@ -181,6 +190,9 @@ void ignition::gazebo::setData(QStandardItem *_item,
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const std::string &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("String"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QString::fromStdString(_data),
@@ -192,6 +204,9 @@ template<>
 void ignition::gazebo::setData(QStandardItem *_item,
     const std::ostringstream &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Raw"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QString::fromStdString(_data.str()),
@@ -202,6 +217,9 @@ void ignition::gazebo::setData(QStandardItem *_item,
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const bool &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Boolean"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(_data, ComponentsModel::RoleNames().key("data"));
@@ -211,6 +229,9 @@ void ignition::gazebo::setData(QStandardItem *_item, const bool &_data)
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const int &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Integer"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(_data, ComponentsModel::RoleNames().key("data"));
@@ -220,6 +241,9 @@ void ignition::gazebo::setData(QStandardItem *_item, const int &_data)
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const double &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Float"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(_data, ComponentsModel::RoleNames().key("data"));
@@ -229,6 +253,9 @@ void ignition::gazebo::setData(QStandardItem *_item, const double &_data)
 template<>
 void ignition::gazebo::setData(QStandardItem *_item, const sdf::Physics &_data)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString("Physics"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QList({
@@ -240,6 +267,9 @@ void ignition::gazebo::setData(QStandardItem *_item, const sdf::Physics &_data)
 //////////////////////////////////////////////////
 void ignition::gazebo::setUnit(QStandardItem *_item, const std::string &_unit)
 {
+  if (nullptr == _item)
+    return;
+
   _item->setData(QString::fromStdString(_unit),
       ComponentsModel::RoleNames().key("unit"));
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The component inspector occasionally crashes on shutdown trying to access a null item. I think we should eventually track down the destruction order to make sure the `setData` callbacks are shut down before the items are destroyed. But for now, I'm just adding a safety check to all the calls.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
