### PR TITLE
🎈 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ignition-cmake2 2.3 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX pre1)
+ign_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ### Ignition Gazebo 5.X.X (20XX-XX-XX)
 
-### Ignition Gazebo 5.0.0 (20XX-XX-XX)
+### Ignition Gazebo 5.0.0 (2021-03-30)
 
 1. Added Ellipsoid and Capsule geometries
     * [Pull request #581](https://github.com/ignitionrobotics/ign-gazebo/pull/581)
@@ -83,6 +83,19 @@
     * [Pull request #565](https://github.com/ignitionrobotics/ign-gazebo/pull/565)
     * [Pull request #616](https://github.com/ignitionrobotics/ign-gazebo/pull/616)
     * [Pull request #622](https://github.com/ignitionrobotics/ign-gazebo/pull/622)
+
+1. Documentation fixes
+    * [Pull request #727](https://github.com/ignitionrobotics/ign-gazebo/pull/727)
+    * [Pull request #710](https://github.com/ignitionrobotics/ign-gazebo/pull/710)
+
+1. Replace deprecated function FreeGroup::CanonicalLink with FreeGroup::RootLink
+    * [Pull request #723](https://github.com/ignitionrobotics/ign-gazebo/pull/723)
+
+1. Respect spotlight direction
+    * [Pull request #718](https://github.com/ignitionrobotics/ign-gazebo/pull/718)
+
+1. Add UserCommands plugin to fuel.sdf
+    * [Pull request #719](https://github.com/ignitionrobotics/ign-gazebo/pull/719)
 
 1. Change SelectedEntities to return a const ref
     * [Pull request #571](https://github.com/ignitionrobotics/ign-gazebo/pull/571)


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.0.0 release.

Comparison to version 4: https://github.com/ignitionrobotics/ign-gazebo/compare/ign-gazebo4...ign-gazebo5

Targets new branch: `ign-gazebo5`

Should come after:

* https://github.com/ignitionrobotics/ign-common/pull/191
* https://github.com/ignitionrobotics/ign-math/pull/202
* https://github.com/ignitionrobotics/ign-plugin/pull/49
* https://github.com/ignitionrobotics/ign-utils/pull/18
* https://github.com/osrf/sdformat/pull/529
* https://github.com/ignitionrobotics/ign-sensors/pull/118
* https://github.com/ignitionrobotics/ign-common/pull/191
* https://github.com/ignitionrobotics/ign-rendering/pull/292
* https://github.com/ignitionrobotics/ign-msgs/pull/150
* https://github.com/ignitionrobotics/ign-transport/pull/234
* https://github.com/ignitionrobotics/ign-physics/pull/244

https://github.com/ignition-tooling/release-tools/issues/421

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed):

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
