### PR TITLE
Bump main to 6.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo5 VERSION 5.0.0)
+project(ignition-gazebo6 VERSION 6.0.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Ignition Gazebo 6.x
+
+### Ignition Gazebo 6.X.X (20XX-XX-XX)
+
+### Ignition Gazebo 6.0.0 (20XX-XX-XX)
+
 ## Ignition Gazebo 5.x
 
 ### Ignition Gazebo 5.X.X (20XX-XX-XX)

--- a/examples/plugin/command_actor/CMakeLists.txt
+++ b/examples/plugin/command_actor/CMakeLists.txt
@@ -7,9 +7,9 @@ project(CommandActor)
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)
 set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 
-find_package(ignition-gazebo5 REQUIRED)
+find_package(ignition-gazebo6 REQUIRED)
 add_library(CommandActor SHARED CommandActor.cc)
 set_property(TARGET CommandActor PROPERTY CXX_STANDARD 17)
 target_link_libraries(CommandActor
   PRIVATE ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
-  PRIVATE ignition-gazebo5::ignition-gazebo5)
+  PRIVATE ignition-gazebo6::ignition-gazebo6)

--- a/examples/plugin/custom_component/CMakeLists.txt
+++ b/examples/plugin/custom_component/CMakeLists.txt
@@ -7,11 +7,11 @@ project(CustomComponentPlugin)
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)
 set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 
-find_package(ignition-gazebo5 REQUIRED)
+find_package(ignition-gazebo6 REQUIRED)
 add_library(CustomComponentPlugin SHARED
   CustomComponentPlugin.cc
 )
 set_property(TARGET CustomComponentPlugin PROPERTY CXX_STANDARD 17)
 target_link_libraries(CustomComponentPlugin
   PRIVATE ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
-  PRIVATE ignition-gazebo5::ignition-gazebo5)
+  PRIVATE ignition-gazebo6::ignition-gazebo6)

--- a/examples/plugin/gui_system_plugin/CMakeLists.txt
+++ b/examples/plugin/gui_system_plugin/CMakeLists.txt
@@ -8,7 +8,7 @@ project(GuiSystemPlugin)
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(ignition-gazebo5 REQUIRED COMPONENTS gui)
+find_package(ignition-gazebo6 REQUIRED COMPONENTS gui)
 
 QT5_ADD_RESOURCES(resources_RCC ${PROJECT_NAME}.qrc)
 
@@ -17,5 +17,5 @@ add_library(${PROJECT_NAME} SHARED
   ${resources_RCC}
 )
 target_link_libraries(${PROJECT_NAME}
-  PRIVATE ignition-gazebo5::gui
+  PRIVATE ignition-gazebo6::gui
 )

--- a/examples/plugin/rendering_plugins/CMakeLists.txt
+++ b/examples/plugin/rendering_plugins/CMakeLists.txt
@@ -32,13 +32,13 @@ target_link_libraries(${GUI_PLUGIN}
 set(SERVER_PLUGIN RenderingServerPlugin)
 
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)
-find_package(ignition-gazebo5 REQUIRED)
+find_package(ignition-gazebo6 REQUIRED)
 
 add_library(${SERVER_PLUGIN} SHARED ${SERVER_PLUGIN}.cc)
 set_property(TARGET ${SERVER_PLUGIN} PROPERTY CXX_STANDARD 17)
 target_link_libraries(${SERVER_PLUGIN}
   PRIVATE
     ignition-plugin1::ignition-plugin1
-    ignition-gazebo5::ignition-gazebo5
+    ignition-gazebo6::ignition-gazebo6
     ignition-rendering5::ignition-rendering5
 )

--- a/examples/plugin/system_plugin/CMakeLists.txt
+++ b/examples/plugin/system_plugin/CMakeLists.txt
@@ -7,9 +7,9 @@ project(SampleSystem)
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)
 set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 
-find_package(ignition-gazebo5 REQUIRED)
+find_package(ignition-gazebo6 REQUIRED)
 add_library(SampleSystem SHARED SampleSystem.cc SampleSystem2.cc)
 set_property(TARGET SampleSystem PROPERTY CXX_STANDARD 17)
 target_link_libraries(SampleSystem
   PRIVATE ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
-  PRIVATE ignition-gazebo5::ignition-gazebo5)
+  PRIVATE ignition-gazebo6::ignition-gazebo6)

--- a/examples/standalone/custom_server/CMakeLists.txt
+++ b/examples/standalone/custom_server/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  find_package(ignition-gazebo5 REQUIRED)
-  set(IGN_COMMON_VER ${ignition-gazebo5_VERSION_MAJOR})
+  find_package(ignition-gazebo6 REQUIRED)
+  set(IGN_COMMON_VER ${ignition-gazebo6_VERSION_MAJOR})
 
   add_executable(custom_server custom_server.cc)
   target_link_libraries(custom_server

--- a/examples/standalone/each_performance/CMakeLists.txt
+++ b/examples/standalone/each_performance/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
-find_package(ignition-gazebo5 QUIET REQUIRED)
+find_package(ignition-gazebo6 QUIET REQUIRED)
 
 add_executable(each each.cc)
 target_link_libraries(each
-  ignition-gazebo5::core)
+  ignition-gazebo6::core)
 

--- a/examples/standalone/light_control/CMakeLists.txt
+++ b/examples/standalone/light_control/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 find_package(ignition-transport10 QUIET REQUIRED OPTIONAL_COMPONENTS log)
 set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
 
-find_package(ignition-gazebo5 REQUIRED)
-set(IGN_GAZEBO_VER ${ignition-gazebo5_VERSION_MAJOR})
+find_package(ignition-gazebo6 REQUIRED)
+set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
 
 add_executable(light_control light_control.cc)
 target_link_libraries(light_control

--- a/tutorials/migrating_ardupilot_plugin.md
+++ b/tutorials/migrating_ardupilot_plugin.md
@@ -753,7 +753,7 @@ In the new code we explicitly reference each Ignition package that we use:
 # NEW
 find_package(sdformat11 REQUIRED)
 find_package(ignition-common4-all REQUIRED)
-find_package(ignition-gazebo5-all REQUIRED)
+find_package(ignition-gazebo6-all REQUIRED)
 find_package(ignition-math6-all REQUIRED)
 find_package(ignition-msgs7-all REQUIRED)
 find_package(ignition-physics4-all REQUIRED)


### PR DESCRIPTION
Branch `ign-gazebo5` has been created for the Edifice release and 5.0.0 released from that.

The `main` branch now corresponds to version 6.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421