### PR TITLE
Fix compute_rtfs arguments

### DIFF
--- a/test/performance/ign_perf.py
+++ b/test/performance/ign_perf.py
@@ -19,7 +19,7 @@ def read_data(filename):
                 entries.append([float(r) for r in row])
     return (header, np.array(entries))
 
-def compute_rtfs(data):
+def compute_rtfs(real_time, sim_time):
     # Compute time deltas
     real_dt = np.diff(real_time)
     sim_dt = np.diff(sim_time)
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     real_time = data[:,0] + 1e-9 * data[:,1]
     sim_time = data[:,2] + 1e-9 * data[:,3]
 
-    rtfs = compute_rtfs(data)
+    rtfs = compute_rtfs(real_time, sim_time)
 
     if args.summarize:
         iters = len(data)


### PR DESCRIPTION
Signed-off-by: Caio Amaral <caioaamaral@gmail.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
`compute_rtfs` was using `real_time` and `sim_time` while they are not defined at the function scope, but at `local()` when calling the `__main__` function. This fixes the function argument to use `real_time` and `sim_time` instead of `data`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
