### PR TITLE
Validate step size and RTF parameters

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -355,20 +355,32 @@ void SimulationRunner::UpdatePhysicsParams()
   if (newStepSize != this->stepSize ||
       std::abs(newRTF - this->desiredRtf) > eps)
   {
-    this->SetStepSize(
-      std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-        newStepSize));
-    this->desiredRtf = newRTF;
-    this->updatePeriod = std::chrono::nanoseconds(
-        static_cast<int>(this->stepSize.count() / this->desiredRtf));
-
-    this->simTimes.clear();
-    this->realTimes.clear();
-    // Update physics components
-    physicsComp->Data().SetMaxStepSize(physicsParams.max_step_size());
-    physicsComp->Data().SetRealTimeFactor(newRTF);
-    this->entityCompMgr.SetChanged(worldEntity, components::Physics::typeId,
-        ComponentState::OneTimeChange);
+    bool updated = false;
+    // Make sure the values are valid before setting them
+    if (newStepSize.count() > 0.0)
+    {
+      this->SetStepSize(
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+          newStepSize));
+      physicsComp->Data().SetMaxStepSize(physicsParams.max_step_size());
+      updated = true;
+    }
+    if (newRTF > 0.0)
+    {
+      this->desiredRtf = newRTF;
+      this->updatePeriod = std::chrono::nanoseconds(
+          static_cast<int>(this->stepSize.count() / this->desiredRtf));
+      physicsComp->Data().SetRealTimeFactor(newRTF);
+      updated = true;
+    }
+    if (updated)
+    {
+      this->simTimes.clear();
+      this->realTimes.clear();
+      // Set as OneTimeChange to make sure the update is not missed
+      this->entityCompMgr.SetChanged(worldEntity, components::Physics::typeId,
+          ComponentState::OneTimeChange);
+    }
   }
   this->entityCompMgr.RemoveComponent<components::PhysicsCmd>(worldEntity);
 }

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -981,4 +981,21 @@ TEST_F(UserCommandsTest, Physics)
   physicsComp = ecm->Component<components::Physics>(worldEntity);
   EXPECT_DOUBLE_EQ(0.123, physicsComp->Data().MaxStepSize());
   EXPECT_DOUBLE_EQ(4.567, physicsComp->Data().RealTimeFactor());
+
+  // Send invalid values (not > 0) and make sure they are not updated
+  req.set_max_step_size(0.0);
+  req.set_real_time_factor(0.0);
+
+  EXPECT_TRUE(node.Request(service, req, timeout, res, result));
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(res.data());
+
+  // Run two iterations, in the first one the PhysicsCmd component is created
+  // in the second one it is processed
+  server.Run(true, 2, false);
+
+  // Check updated physics properties
+  physicsComp = ecm->Component<components::Physics>(worldEntity);
+  EXPECT_DOUBLE_EQ(0.123, physicsComp->Data().MaxStepSize());
+  EXPECT_DOUBLE_EQ(4.567, physicsComp->Data().RealTimeFactor());
 }


### PR DESCRIPTION
# 🦟 Bug fix

Addresses #536 ([comment](https://github.com/ignitionrobotics/ign-gazebo/pull/536#issuecomment-781270162))

## Summary

Calling the `set_physics` service with only one parameter, i.e.:

```
ign service -s /world/sim_world/set_physics --reqtype ignition.msgs.Physics --reptype ignition.msgs.Boolean --timeout 2000 --req "real_time_factor: 1"
```

caused the other parameter to be set to the default value of 0. The function updating the physics parameters was not checking the values received and setting rtf / step size to 0 which would cause undefined behavior and sometimes crash the simulation.
This PR adds a check to the values and only updates them if they are strictly positive.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
