### PR TITLE
Use unordered maps for component look-ups in views

### DIFF
--- a/include/ignition/gazebo/detail/ComponentStorageBase.hh
+++ b/include/ignition/gazebo/detail/ComponentStorageBase.hh
@@ -17,7 +17,7 @@
 #ifndef IGNITION_GAZEBO_DETAIL_COMPONENTSTORAGEBASE_HH_
 #define IGNITION_GAZEBO_DETAIL_COMPONENTSTORAGEBASE_HH_
 
-#include <map>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include "ignition/gazebo/components/Component.hh"
@@ -212,7 +212,7 @@ namespace ignition
       private: ComponentId idCounter = 0;
 
       /// \brief Map of ComponentId to Components (see the components vector).
-      private: std::map<ComponentId, int> idMap;
+      private: std::unordered_map<ComponentId, int> idMap;
 
       /// \brief Sequential storage of components.
       public: std::vector<ComponentTypeT> components;

--- a/include/ignition/gazebo/detail/View.hh
+++ b/include/ignition/gazebo/detail/View.hh
@@ -17,9 +17,9 @@
 #ifndef IGNITION_GAZEBO_DETAIL_VIEW_HH_
 #define IGNITION_GAZEBO_DETAIL_VIEW_HH_
 
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include "ignition/gazebo/components/Component.hh"
 #include "ignition/gazebo/Entity.hh"
@@ -126,9 +126,32 @@ class IGNITION_GAZEBO_VISIBLE View
   /// \brief List of entities about to be removed
   public: std::set<Entity> toRemoveEntities;
 
+  /// \brief Hash functor for std::pair<Entity, ComponentTypeId>
+  public: struct Hasher
+          {
+            std::size_t operator()(
+                std::pair<Entity, ComponentTypeId> _pair) const
+            {
+              _pair.first ^= _pair.second + 0x9e3779b9 + (_pair.second << 6)
+                 + (_pair.second >> 2);
+              return _pair.first;
+            }
+          };
+
+  /// \brief Equality functor for std::pair<Entity, ComponentTypeId>
+  public: struct EqualTo
+          {
+            bool operator()(const std::pair<Entity, ComponentTypeId> &_lhs,
+                const std::pair<Entity, ComponentTypeId> &_rhs) const
+            {
+              return _lhs.first == _rhs.first &&
+                _lhs.second == _rhs.second;
+            }
+          };
+
   /// \brief All of the components for each entity.
-  public: std::map<std::pair<Entity, ComponentTypeId>,
-          ComponentId> components;
+  public: std::unordered_map<std::pair<Entity, ComponentTypeId>, ComponentId,
+            Hasher, EqualTo> components;
 };
 /// \endcond
 }


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

## Summary
Related to #711 

Currently, when calling `EntityComponentManager::Each`, the following methods get called:
1. [EntityComponentManager::Each](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/EntityComponentManager.hh#L362-L380)
2. [View::Component](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/View.hh#L63-L75)
3. [View::ComponentImplementation](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/src/View.cc#L61-L69)
4. [EntityComponentManager::ComponentImplementation](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/src/EntityComponentManager.cc#L598-L608)
5. [ComponentStorageBase::Component](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/ComponentStorageBase.hh#L187-L199)

There are a few `std::map` lookups in this process:
* https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/src/View.cc#L68
* https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/ComponentStorageBase.hh#L191

Since lookup time in a `std::map` is `O(log(n))`, it's better to use `std::unordered_map` which has a lookup time of `O(1)` (assuming no collisions). This PR makes these changes, with the hope of improving the performance of `ecm.Each`.

### Testing

I tested these changes applied to `ign-gazebo` at commit https://github.com/ignitionrobotics/ign-gazebo/commit/a41cf80049c07977079d0b215398dc4225b63038. I used the testing methodology that was followed in #678 (take a look at that PR for more details about how to run the tests). The results are as follows (the model `ecm.Each` call I am referring to in the test results is a part of the `UpdateSim` in the physics system that can be found [here](https://github.com/ignitionrobotics/ign-gazebo/blob/a41cf80049c07977079d0b215398dc4225b63038/src/systems/physics/Physics.cc#L1810-L1812)):

#### 3000 non-static simple shapes
Using `std::map`: 15.75% RTF, .803ms for the model `ecm.Each` call

![map_views_non_static](https://user-images.githubusercontent.com/42042756/114480498-a8a7bc80-9bd0-11eb-9ba0-a2a77624b93d.png)

Using `std::unordered_map`: 16.5% RTF, .306ms for the model `ecm.Each` call

![unordered_map_views_non_static](https://user-images.githubusercontent.com/42042756/114480527-b2c9bb00-9bd0-11eb-8978-6ff501cb6a87.png)

#### 3000 static simple shapes
Using `std::map`: 50% RTF, .754ms for the model `ecm.Each` call

![map_views_static](https://user-images.githubusercontent.com/42042756/114480554-c07f4080-9bd0-11eb-92ae-bc9fbee26611.png)

Using `std::unordered_map`: 70% RTF, .289ms for the model `ecm.Each` call

![unordered_map_views_static](https://user-images.githubusercontent.com/42042756/114480570-c70db800-9bd0-11eb-8ac2-718dc18429a5.png)

### Takeaways
After running some tests, it appears that the performance gains from this change are minimal, and in some cases, not noticeable at all. This change seems to help the use case where `ecm.Each` is being used on a large(r) set of components that match a lot of entities.

We could also change [EntityComponentManagerPrivate::views](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/src/EntityComponentManager.cc#L110-L111) to an unordered map, but this would require some more work/thought because [the key of this map is actually a `std::set`](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/View.hh#L37-L38). I don't think we should be using a `std::set` as the key of a map, but this seems to be necessary due to some limitations in our current implementation of views (this leads me to my next point that we need to fix the current design of views - see the next paragraph). 

The real reason why this change does not help the performance of `ecm.Each` much is because of how views are currently being used. See https://github.com/ignitionrobotics/ign-gazebo/issues/711#issuecomment-816890851 for more information - I plan to address what is mentioned in this comment next.

_Also, on a related note: I believe that changing https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/View.hh#L37-L38 to a `std::unordered_set` may help a bit with performance, but I don't believe this can be done in an existing release because there are methods in the ECM (like [FindView](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/EntityComponentManager.hh#L681-L689)) that use this `std::set`._

**Edit:**
I'd like to give one other perspective as to why the changes here don't result in much of an improvement. If we look at the [callback loop](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.8.0/include/ignition/gazebo/detail/EntityComponentManager.hh#L371-L379) in `ecm.Each` again, the time complexity can be calculated as:
```
O(E * (C * L))
```
The variables are defined as follows:
* `E`: the number of entities (or number of `for` loops)
* `C`: the number of components
* `L`: the lookup time for a component in a view
* `C * L`: the time complexity for `view.Component<ComponentTypeTs>(entity, this)...`

Before this PR, `L` was `O(log(n))` since `std::map`s were used. After this PR, `L` is now `O(1)`. It's worth analyzing the time complexity for two cases:
* We have a lot of entities and few components in an `ecm.Each` call. The complexity is now:
```
O(E * (C * L)) = O(E * (C * 1)) = O(C * E)
```
Before this PR, the time complexity for this case would be `O(C * E * log(E))`.

* The number of components is large (i.e., approaching the number of entities), the time complexity is now:
```
O(E * (E * 1)) = O(E^2)
```
Before this PR, the time complexity for this case would be `O(E^2 * log(E))`. 

As we can see in this analysis, the real issue is that we still have to spend time finding each component in the view (as mentioned in https://github.com/ignitionrobotics/ign-gazebo/issues/711#issuecomment-816890851) - the time complexity for the `ecm.Each` callback loop should really be `O(E)` (all components should be cached at the time of view creation, which would mean that `C * L` is no longer part of the equation for time complexity). If anyone believes that my analysis here may be incorrect, feel free to mention what I am missing, and I will update this accordingly.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers