### PR TITLE
Fix 'invalid animation update data' message for actors

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1653,8 +1653,13 @@ void RenderUtilPrivate::UpdateRenderingEntities(
         // Trajectory info from SDF so ign-rendering can calculate bone poses
         else
         {
-          this->actorAnimationData[_entity] =
-              this->sceneManager.ActorAnimationAt(_entity, this->simTime);
+          auto animData =
+            this->sceneManager.ActorAnimationAt(_entity, this->simTime);
+
+          if (animData.valid)
+          {
+            this->actorAnimationData[_entity] = animData;
+          }
         }
 
         // Trajectory pose set by other systems


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

Related to #647

## Summary
https://github.com/ignitionrobotics/ign-common/pull/188 fixed actors crashing on launch, but the following console error message would still appear when actors were initialized:
```
[GUI] [Err] [RenderUtil.cc:919] invalid animation update data
```

The issue appears to be that on startup, [RenderUtilPrivate::UpdateRenderingEntities](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo5_5.0.0/src/rendering/RenderUtil.cc#L1585) (which is called by [RenderUtil::UpdateFromECM](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo5_5.0.0/src/rendering/RenderUtil.cc#L456)) is called before [RenderUtil::Update](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo5_5.0.0/src/rendering/RenderUtil.cc#L521). `RenderUtil::Update` needs to be called in order to actually [create the actor(s)](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo5_5.0.0/src/rendering/RenderUtil.cc#L661-L665), which will then [set the actor trajectory](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo5_5.0.0/src/rendering/SceneManager.cc#L962) so that it's valid when calling [SceneManager::ActorAnimationAt](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo5_5.0.0/src/rendering/SceneManager.cc#L1408-L1420) in `RenderUtilPrivate::UpdateRenderingEntities`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
