### PR TITLE
Fix ColladaExporter submesh index bug

### DIFF
--- a/src/systems/collada_world_exporter/ColladaWorldExporter.cc
+++ b/src/systems/collada_world_exporter/ColladaWorldExporter.cc
@@ -112,9 +112,9 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
       ignition::common::MeshManager *meshManager =
           ignition::common::MeshManager::Instance();
 
-      auto addSubmeshFunc = [&](int i) {
+      auto addSubmeshFunc = [&](int i, int k) {
           subm = worldMesh.AddSubMesh(
-              *mesh->SubMeshByIndex(0).lock().get());
+              *mesh->SubMeshByIndex(k).lock().get());
           subm.lock()->SetMaterialIndex(i);
           subm.lock()->Scale(scale);
           subMeshMatrix.push_back(matrix);
@@ -128,7 +128,7 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
           scale = _geom->Data().BoxShape()->Size();
           int i = worldMesh.AddMaterial(mat);
 
-          addSubmeshFunc(i);
+          addSubmeshFunc(i, 0);
         }
       }
       else if (_geom->Data().Type() == sdf::GeometryType::CYLINDER)
@@ -142,7 +142,7 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
 
           int i = worldMesh.AddMaterial(mat);
 
-          addSubmeshFunc(i);
+          addSubmeshFunc(i, 0);
         }
       }
       else if (_geom->Data().Type() == sdf::GeometryType::PLANE)
@@ -166,7 +166,7 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
           matrix = math::Matrix4d(worldPose);
 
           int i = worldMesh.AddMaterial(mat);
-          addSubmeshFunc(i);
+          addSubmeshFunc(i, 0);
         }
       }
       else if (_geom->Data().Type() == sdf::GeometryType::SPHERE)
@@ -180,8 +180,7 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
           scale.Z() = scale.X();
 
           int i = worldMesh.AddMaterial(mat);
-
-          addSubmeshFunc(i);
+          addSubmeshFunc(i, 0);
         }
       }
       else if (_geom->Data().Type() == sdf::GeometryType::MESH)
@@ -221,8 +220,7 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
           }
 
           scale = _geom->Data().MeshShape()->Scale();
-
-          addSubmeshFunc(i);
+          addSubmeshFunc(i, k);
         }
       }
       else


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #761

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
The fix IMO is straightforward, use the iteration index to include properly the missing submeshes to the exported SubMeshes array.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers