### PR TITLE
Fix included nested model expansion in SDF generation

### DIFF
--- a/src/SdfGenerator.hh
+++ b/src/SdfGenerator.hh
@@ -76,6 +76,12 @@ namespace sdf_generator
                           const EntityComponentManager &_ecm,
                           const Entity &_entity);
 
+  /// \brief Update a sdf::Element model to use //include instead of expanded
+  /// model (to be used when expand_include_tags is disabled)
+  /// \input[in, out] _elem sdf::Element to update
+  IGNITION_GAZEBO_VISIBLE
+  void updateModelElementWithNestedInclude(sdf::ElementPtr &_elem);
+
   /// \brief Update a sdf::Element of an included resource.
   /// Intended for internal use.
   /// \input[in, out] _elem sdf::Element to update

--- a/test/worlds/model_nested_include.sdf
+++ b/test/worlds/model_nested_include.sdf
@@ -1,0 +1,88 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <world name="model_nested_include_world">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="libignition-gazebo-physics-system.so"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-scene-broadcaster-system.so"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="L0">
+        <collision name="C0">
+          <geometry>
+            <box>
+              <size>20 20 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="V0">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+
+    <model name="M1">
+      <include>
+        <uri>include_nested</uri>
+        <name>include_nested_new_name</name>
+        <pose>1 2 3 0 0 0</pose>
+      </include>
+
+      <include>
+        <uri>sphere</uri>
+        <pose>0 2 2 0 0 0</pose>
+      </include>
+
+      <pose>0 -2 0 0 0 0</pose>
+      <link name="L1">
+        <pose>0 0 2 0 0 0</pose>
+        <collision name="C1">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="V1">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/479

## Summary
This PR resolves the issue of included nested models (e.g., `//model/include`) being expanded even though the option "Expand include tags" is disabled. 

**Before PR**
1. Load [model_nested_include.sdf](https://github.com/ignitionrobotics/ign-gazebo/blob/e3d78d68c3b6a6157b3801a84bfa053bf8c968db/test/worlds/model_nested_include.sdf) in Ignition
2. Click on the top left menu > Save world as...
3. Save the world (with "Expand include tags" disabled)
4. Open the saved sdf file and see the included models are expanded

**After PR**
Run the above steps again except the saved sdf file will have `//include` tags instead

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
