### PR TITLE
Support fuel local cache in resource spawner

### DIFF
--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -304,7 +304,24 @@ std::vector<Resource> ResourceSpawner::LocalResources(const std::string &_path)
       {
         std::string modelConfigPath =
           common::joinPaths(currentPath, "model.config");
-        resource = this->LocalResource(modelConfigPath);
+        if (common::isFile(modelConfigPath ))
+        {
+          resource = this->LocalResource(modelConfigPath);
+        }
+        else
+        {
+          // This will try to add models from a path containing Fuel models.
+          // The latest version of a model will be shown in the GUI based
+          // purely on iterating numerically through the list of verisons.
+          for (common::DirIter fuelFile(currentPath);
+               fuelFile != common::DirIter(); ++fuelFile)
+          {
+            std::string currentPathFuel(*fuelFile);
+            modelConfigPath = common::joinPaths(currentPathFuel,
+                "model.config");
+            resource = this->LocalResource(modelConfigPath);
+          }
+        }
       }
       else
       {


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

The resource spawner can now use a local Fuel cache, such as `.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models`.

## Test it

```
IGN_GAZEBO_RESOURCE_PATH=~/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models ign gazebo -v 4
```

Add the resource spawner.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**