### PR TITLE
explain why detail::View symbols are visible

### DIFF
--- a/include/ignition/gazebo/detail/View.hh
+++ b/include/ignition/gazebo/detail/View.hh
@@ -45,6 +45,11 @@ using ComponentTypeKey = std::set<ComponentTypeId>;
 /// use a cache to improve performance. The assumption is that entities
 /// and the types of components assigned to entities change infrequently
 /// compared to the frequency of queries performed by systems.
+///
+/// Note that symbols for this class are visible because methods from this class
+/// are used in templated Ignition::Gazebo::EntityComponentManager methods.
+/// However, users should not use this class (or anything else in namespace
+/// ignition::gazebo::detail) directly.
 class IGNITION_GAZEBO_VISIBLE View
 {
   /// Get a pointer to a component for an entity based on a component type.


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

Fixes #759

## Summary
~~This hides the symbols of the `detail::View` class so that we can make changes to it as needed without breaking ABI. Since this is an ABI-breaking change, this has to be done in fortress.~~

**Edit:** the symbol visibility for `detail::View` cannot be hidden. See the comments below for an explanation.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**