### PR TITLE
add conversion for particle scatter ratio field

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1334,7 +1334,7 @@ msgs::ParticleEmitter ignition::gazebo::convert(const sdf::ParticleEmitter &_in)
 {
   msgs::ParticleEmitter out;
   out.set_name(_in.Name());
-  switch(_in.Type())
+  switch (_in.Type())
   {
     default:
     case sdf::ParticleEmitterType::POINT:
@@ -1390,6 +1390,12 @@ msgs::ParticleEmitter ignition::gazebo::convert(const sdf::ParticleEmitter &_in)
     header->add_value(_in.Topic());
   }
 
+  // todo(anyone) add particle_scatter_ratio field in particle_emitter.proto
+  auto header = out.mutable_header()->add_data();
+  header->set_key("particle_scatter_ratio");
+  std::string *value = header->add_value();
+  *value = std::to_string(_in.ScatterRatio());
+
   return out;
 }
 
@@ -1400,7 +1406,7 @@ sdf::ParticleEmitter ignition::gazebo::convert(const msgs::ParticleEmitter &_in)
 {
   sdf::ParticleEmitter out;
   out.SetName(_in.name());
-  switch(_in.type())
+  switch (_in.type())
   {
     default:
     case msgs::ParticleEmitter::POINT:
@@ -1448,6 +1454,10 @@ sdf::ParticleEmitter ignition::gazebo::convert(const msgs::ParticleEmitter &_in)
     if (data.key() == "topic" && data.value_size() > 0)
     {
       out.SetTopic(data.value(0));
+    }
+    else if (data.key() == "particle_scatter_ratio" && data.value_size() > 0)
+    {
+      out.SetScatterRatio(std::stof(data.value(0)));
     }
   }
 

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -794,6 +794,7 @@ TEST(Conversions, ParticleEmitter)
   emitter.SetColorRangeImage("range_image");
   emitter.SetTopic("my_topic");
   emitter.SetRawPose(math::Pose3d(1, 2, 3, 0, 0, 0));
+  emitter.SetScatterRatio(0.9f);
 
   sdf::Material material;
   sdf::Pbr pbr;
@@ -828,6 +829,10 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ("topic", header.key());
   EXPECT_EQ("my_topic", header.value(0));
 
+  auto headerScatterRatio = emitterMsg.header().data(1);
+  EXPECT_EQ("particle_scatter_ratio", headerScatterRatio.key());
+  EXPECT_FLOAT_EQ(0.9f, std::stof(headerScatterRatio.value(0)));
+
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 0), msgs::Convert(emitterMsg.pose()));
 
   auto pbrMsg = emitterMsg.material().pbr();
@@ -852,4 +857,5 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ(emitter2.ColorRangeImage(), emitter.ColorRangeImage());
   EXPECT_EQ(emitter2.Topic(), emitter.Topic());
   EXPECT_EQ(emitter2.RawPose(), emitter.RawPose());
+  EXPECT_FLOAT_EQ(emitter2.ScatterRatio(), emitter.ScatterRatio());
 }

--- a/src/systems/particle_emitter2/ParticleEmitter2.cc
+++ b/src/systems/particle_emitter2/ParticleEmitter2.cc
@@ -242,7 +242,6 @@ void ParticleEmitter2::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
           components::ParticleEmitterCmd::typeId,
           ComponentState::OneTimeChange);
     }
-
   }
   this->dataPtr->userCmd.clear();
 }

--- a/test/integration/particle_emitter2.cc
+++ b/test/integration/particle_emitter2.cc
@@ -83,7 +83,6 @@ TEST_F(ParticleEmitter2Test, SDFLoad)
                 const components::Name *_name,
                 const components::Pose *_pose) -> bool
             {
-
               if (_name->Data() == "smoke_emitter")
               {
                 updateCustomChecked = true;

--- a/test/integration/particle_emitter2.cc
+++ b/test/integration/particle_emitter2.cc
@@ -117,6 +117,24 @@ TEST_F(ParticleEmitter2Test, SDFLoad)
                 // will not be able to find a file that does not exist
                 EXPECT_EQ("/path/to/dummy_image.png",
                     _emitter->Data().color_range_image().data());
+
+                // particle scatter ratio is temporarily stored in header
+                bool hasParticleScatterRatio = false;
+                for (int i = 0; i < _emitter->Data().header().data_size(); ++i)
+                {
+                  for (int j = 0;
+                      j < _emitter->Data().header().data(i).value_size(); ++j)
+                  {
+                    if (_emitter->Data().header().data(i).key() ==
+                        "particle_scatter_ratio")
+                    {
+                      EXPECT_DOUBLE_EQ(0.01, math::parseFloat(
+                          _emitter->Data().header().data(i).value(0)));
+                      hasParticleScatterRatio = true;
+                    }
+                  }
+                }
+                EXPECT_TRUE(hasParticleScatterRatio);
               }
               else
               {

--- a/test/integration/thermal_sensor_system.cc
+++ b/test/integration/thermal_sensor_system.cc
@@ -151,7 +151,7 @@ TEST_F(ThermalSensorTest,
   // Run server
   server.Run(true, 1, false);
 
- // verify camera properties from sdf
+  // verify camera properties from sdf
   unsigned int width = 320u;
   unsigned int height = 240u;
   EXPECT_EQ("thermal_camera_invalid", name);

--- a/test/integration/thermal_system.cc
+++ b/test/integration/thermal_system.cc
@@ -224,7 +224,6 @@ TEST_F(ThermalTest, IGN_UTILS_TEST_DISABLED_ON_MAC(ThermalSensorSystem))
             maxTemp = info.max.Kelvin();
             return true;
           });
-
     });
   server.AddSystem(testSystem.systemPtr);
 

--- a/test/worlds/particle_emitter2.sdf
+++ b/test/worlds/particle_emitter2.sdf
@@ -121,6 +121,7 @@
           <color_end>0 1 0</color_end>
           <scale_rate>10</scale_rate>
           <color_range_image>/path/to/dummy_image.png</color_range_image>
+          <particle_scatter_ratio>0.01</particle_scatter_ratio>
         </particle_emitter>
       </link>
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Depends on https://github.com/osrf/sdformat/pull/547

This feature was originally added for the `particle_emitter` system in https://github.com/ignitionrobotics/ign-gazebo/pull/674. This PR ports the functionality to the `particle_emitter2` system.

## Test it

You can test this PR in the same way as the steps listed in https://github.com/ignitionrobotics/ign-gazebo/pull/674 but using this [sensor_particles_scattering2.sdf](https://gist.github.com/iche033/0527a92bcae36f0fd85feca36551383a) world file. The first time you run it, it'll download the [Fog Generator](https://app.ignitionrobotics.org/OpenRobotics/fuel/models/Fog%20Generator) model.

```
ign gazebo -r sensor_particles_scattering2.sdf
```

Pay attention to the particle effects in depth, rgbd cameras and lidars. Now change particle scatter ratio by modifying `~/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/fog generator/<version_number>/model.sdf` and adding `<particle_scatter_ratio>0.01</particle_scatter_ratio>` under `<emitter>`.

Run ign-gazebo with `sensor_particles_scattering2.sdf` again to see that the new scatter ratio in effect. The fog particles should appear to be less dense (noisy) in the depth / rgbd cameras and lidar visualizations.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
