### PR TITLE
Util: Use public API from libsdformat for detecting non-file source

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -34,6 +34,7 @@
 #include <ignition/common/StringUtils.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/TopicUtils.hh>
+#include <sdf/Types.hh>
 
 #include "ignition/gazebo/components/Actor.hh"
 #include "ignition/gazebo/components/Collision.hh"
@@ -295,7 +296,7 @@ std::string asFullPath(const std::string &_uri, const std::string &_filePath)
 #endif
 
   // When SDF is loaded from a string instead of a file
-  if ("data-string" == _filePath)
+  if (std::string(sdf::kSdfStringSource) == _filePath)
   {
     ignwarn << "Can't resolve full path for relative path ["
             << _uri << "]. Loaded from a data-string." << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/osrf/sdformat/issues/536, follow-up to https://github.com/osrf/sdformat/pull/537
Companion to https://github.com/osrf/sdformat/pull/551

## Summary
Ensures internal usage of `libsdformat` admits a form of encapsulation. (We can change the constant w/o worrying too much.)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests - N/A
- [x] Updated documentation (as needed) - N/A
- [x] Updated migration guide (as needed) - N/A
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**