### PR TITLE
[Backport #536 3 ⬅️ 4] Add service and GUI to configure physics parameters

### DIFF
--- a/include/ignition/gazebo/Conversions.hh
+++ b/include/ignition/gazebo/Conversions.hh
@@ -26,6 +26,7 @@
 #include <ignition/msgs/inertial.pb.h>
 #include <ignition/msgs/light.pb.h>
 #include <ignition/msgs/material.pb.h>
+#include <ignition/msgs/physics.pb.h>
 #include <ignition/msgs/scene.pb.h>
 #include <ignition/msgs/sensor.pb.h>
 #include <ignition/msgs/sensor_noise.pb.h>
@@ -46,6 +47,7 @@
 #include <sdf/Light.hh>
 #include <sdf/Material.hh>
 #include <sdf/Noise.hh>
+#include <sdf/Physics.hh>
 #include <sdf/Scene.hh>
 #include <sdf/Sensor.hh>
 
@@ -417,6 +419,41 @@ namespace ignition
     sdf::Atmosphere convert(const msgs::Atmosphere &_in);
 
 
+    /// \brief Generic conversion from an SDF Physics to another type.
+    /// \param[in] _in SDF Physics.
+    /// \return Conversion result.
+    /// \tparam Out Output type.
+    template<class Out>
+    Out convert(const sdf::Physics &/*_in*/)
+    {
+      Out::ConversionNotImplemented;
+    }
+
+    /// \brief Specialized conversion from an SDF physics to a physics
+    /// message.
+    /// \param[in] _in SDF physics.
+    /// \return Physics message.
+    template<>
+    msgs::Physics convert(const sdf::Physics &_in);
+
+    /// \brief Generic conversion from a physics message to another type.
+    /// \param[in] _in Physics message.
+    /// \return Conversion result.
+    /// \tparam Out Output type.
+    template<class Out>
+    Out convert(const msgs::Physics &/*_in*/)
+    {
+      Out::ConversionNotImplemented;
+    }
+
+    /// \brief Specialized conversion from a physics message to a physics
+    /// SDF object.
+    /// \param[in] _in Physics message.
+    /// \return SDF physics.
+    template<>
+    sdf::Physics convert(const msgs::Physics &_in);
+
+
     /// \brief Generic conversion from an SDF Sensor to another type.
     /// \param[in] _in SDF Sensor.
     /// \return Conversion result.
@@ -429,7 +466,7 @@ namespace ignition
 
     /// \brief Specialized conversion from an SDF sensor to a sensor
     /// message.
-    /// \param[in] _in SDF geometry.
+    /// \param[in] _in SDF sensor.
     /// \return Sensor message.
     template<>
     msgs::Sensor convert(const sdf::Sensor &_in);

--- a/include/ignition/gazebo/components/Physics.hh
+++ b/include/ignition/gazebo/components/Physics.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_COMPONENTS_PHYSICS_HH_
+#define IGNITION_GAZEBO_COMPONENTS_PHYSICS_HH_
+
+#include <ignition/msgs/physics.pb.h>
+
+#include <sdf/Physics.hh>
+
+#include <ignition/gazebo/config.hh>
+#include <ignition/gazebo/Export.hh>
+
+#include <ignition/gazebo/components/Factory.hh>
+#include "ignition/gazebo/components/Component.hh"
+#include <ignition/gazebo/components/Serialization.hh>
+#include <ignition/gazebo/Conversions.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+// Inline bracket to help doxygen filtering.
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace serializers
+{
+  using PhysicsSerializer =
+      serializers::ComponentToMsgSerializer<sdf::Physics, msgs::Physics>;
+}
+namespace components
+{
+  /// \brief A component type that contains the physics properties of
+  /// the World entity.
+  using Physics = Component<sdf::Physics, class PhysicsTag,
+      serializers::PhysicsSerializer>;
+  IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.Physics",
+      Physics)
+}
+}
+}
+}
+
+#endif

--- a/include/ignition/gazebo/components/PhysicsCmd.hh
+++ b/include/ignition/gazebo/components/PhysicsCmd.hh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_COMPONENTS_PHYSICSCMD_HH_
+#define IGNITION_GAZEBO_COMPONENTS_PHYSICSCMD_HH_
+
+#include <ignition/msgs/physics.pb.h>
+
+#include <ignition/gazebo/config.hh>
+#include <ignition/gazebo/Export.hh>
+
+#include <ignition/gazebo/components/Factory.hh>
+#include "ignition/gazebo/components/Component.hh"
+
+namespace ignition
+{
+namespace gazebo
+{
+// Inline bracket to help doxygen filtering.
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace components
+{
+  /// \brief A component type that contains the physics properties of
+  /// the World entity.
+  using PhysicsCmd = Component<msgs::Physics, class PhysicsCmdTag>;
+  IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.PhysicsCmd",
+      PhysicsCmd)
+}
+}
+}
+}
+
+#endif

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -744,6 +744,26 @@ void ignition::gazebo::set(msgs::WorldStatistics *_msg,
 }
 
 //////////////////////////////////////////////////
+template<>
+msgs::Physics ignition::gazebo::convert(const sdf::Physics &_in)
+{
+  msgs::Physics out;
+  out.set_max_step_size(_in.MaxStepSize());
+  out.set_real_time_factor(_in.RealTimeFactor());
+  return out;
+}
+
+//////////////////////////////////////////////////
+template<>
+sdf::Physics ignition::gazebo::convert(const msgs::Physics &_in)
+{
+  sdf::Physics out;
+  out.SetRealTimeFactor(_in.real_time_factor());
+  out.SetMaxStepSize(_in.max_step_size());
+  return out;
+}
+
+//////////////////////////////////////////////////
 void ignition::gazebo::set(msgs::SensorNoise *_msg, const sdf::Noise &_sdf)
 {
   switch (_sdf.Type())

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -28,6 +28,7 @@
 #include <sdf/Magnetometer.hh>
 #include <sdf/Mesh.hh>
 #include <sdf/Pbr.hh>
+#include <sdf/Physics.hh>
 #include <sdf/Plane.hh>
 #include <sdf/Root.hh>
 #include <sdf/Scene.hh>
@@ -155,6 +156,28 @@ TEST(Conversions, Entity)
   std::string empty = "";
   auto entityType2 = convert<msgs::Entity_Type>(empty);
   EXPECT_EQ(msgs::Entity_Type_NONE, entityType2);
+}
+
+/////////////////////////////////////////////////
+TEST(Conversions, Physics)
+{
+  // Test conversion from msg to sdf
+  msgs::Physics msg;
+  msg.set_real_time_factor(1.23);
+  msg.set_max_step_size(0.12);
+
+  auto physics = convert<sdf::Physics>(msg);
+  EXPECT_DOUBLE_EQ(1.23, physics.RealTimeFactor());
+  EXPECT_DOUBLE_EQ(0.12, physics.MaxStepSize());
+
+  // Test conversion from sdf to msg
+  sdf::Physics physSdf;
+  physSdf.SetMaxStepSize(0.34);
+  physSdf.SetRealTimeFactor(2.34);
+
+  auto physMsg = convert<msgs::Physics>(physSdf);
+  EXPECT_DOUBLE_EQ(2.34, physMsg.real_time_factor());
+  EXPECT_DOUBLE_EQ(0.34, physMsg.max_step_size());
 }
 
 /////////////////////////////////////////////////

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -46,6 +46,7 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Performer.hh"
 #include "ignition/gazebo/components/PerformerLevels.hh"
+#include "ignition/gazebo/components/Physics.hh"
 #include "ignition/gazebo/components/PhysicsEnginePlugin.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/RenderEngineGuiPlugin.hh"
@@ -95,6 +96,14 @@ void LevelManager::ReadLevelPerformerInfo()
 
   this->runner->entityCompMgr.CreateComponent(this->worldEntity,
       components::Gravity(this->runner->sdfWorld->Gravity()));
+
+  auto physics = this->runner->sdfWorld->PhysicsByIndex(0);
+  if (!physics)
+  {
+    physics = this->runner->sdfWorld->PhysicsDefault();
+  }
+  this->runner->entityCompMgr.CreateComponent(this->worldEntity,
+      components::Physics(*physics));
 
   this->runner->entityCompMgr.CreateComponent(this->worldEntity,
       components::MagneticField(this->runner->sdfWorld->MagneticField()));

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -55,6 +55,7 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentLinkName.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/Physics.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/RgbdCamera.hh"
 #include "ignition/gazebo/components/Scene.hh"
@@ -201,6 +202,16 @@ Entity SdfEntityCreator::CreateEntities(const sdf::World *_world)
   // Gravity
   this->dataPtr->ecm->CreateComponent(worldEntity,
       components::Gravity(_world->Gravity()));
+
+  // Physics
+  // \todo(anyone) Support picking a specific physics profile
+  auto physics = _world->PhysicsByIndex(0);
+  if (!physics)
+  {
+    physics = _world->PhysicsDefault();
+  }
+  this->dataPtr->ecm->CreateComponent(worldEntity,
+      components::Physics(*physics));
 
   // MagneticField
   this->dataPtr->ecm->CreateComponent(worldEntity,

--- a/src/SdfEntityCreator_TEST.cc
+++ b/src/SdfEntityCreator_TEST.cc
@@ -43,6 +43,7 @@
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/ParentLinkName.hh"
+#include "ignition/gazebo/components/Physics.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/Transparency.hh"
 #include "ignition/gazebo/components/Visual.hh"
@@ -112,15 +113,20 @@ TEST_F(SdfEntityCreatorTest, CreateEntities)
   unsigned int worldCount{0};
   Entity worldEntity = kNullEntity;
   this->ecm.Each<components::World,
-           components::Name>(
+           components::Name,
+           components::Physics>(
     [&](const Entity &_entity,
         const components::World *_world,
-        const components::Name *_name)->bool
+        const components::Name *_name,
+        const components::Physics *_physics)->bool
     {
       EXPECT_NE(nullptr, _world);
       EXPECT_NE(nullptr, _name);
+      EXPECT_NE(nullptr, _physics);
 
       EXPECT_EQ("default", _name->Data());
+      EXPECT_DOUBLE_EQ(0.001, _physics->Data().MaxStepSize());
+      EXPECT_DOUBLE_EQ(1.0, _physics->Data().RealTimeFactor());
 
       worldCount++;
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -27,6 +27,8 @@
 #include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/components/Visual.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/components/Physics.hh"
+#include "ignition/gazebo/components/PhysicsCmd.hh"
 #include "ignition/gazebo/Events.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
 #include "ignition/gazebo/Util.hh"
@@ -60,8 +62,8 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   // Keep system loader so plugins can be loaded at runtime
   this->systemLoader = _systemLoader;
 
-  // Get the first physics profile
-  // \todo(louise) Support picking a specific profile
+  // Get the physics profile
+  // TODO(luca): remove duplicated logic in SdfEntityCreator and LevelManager
   auto physics = _world->PhysicsByIndex(0);
   if (!physics)
   {
@@ -76,7 +78,7 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
       dur);
 
   // Desired real time factor
-  double desiredRtf = _world->PhysicsDefault()->RealTimeFactor();
+  this->desiredRtf = physics->RealTimeFactor();
 
   // The instantaneous real time factor is given as:
   //
@@ -102,7 +104,7 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   //
   // period = step_size / RTF
   this->updatePeriod = std::chrono::nanoseconds(
-      static_cast<int>(this->stepSize.count() / desiredRtf));
+      static_cast<int>(this->stepSize.count() / this->desiredRtf));
 
   this->pauseConn = this->eventMgr.Connect<events::Pause>(
       std::bind(&SimulationRunner::SetPaused, this, std::placeholders::_1));
@@ -323,6 +325,47 @@ void SimulationRunner::UpdateCurrentInfo()
     ++this->currentInfo.iterations;
     this->currentInfo.dt = this->stepSize;
   }
+}
+
+/////////////////////////////////////////////////
+void SimulationRunner::UpdatePhysicsParams()
+{
+  auto worldEntity =
+    this->entityCompMgr.EntityByComponents(components::World());
+  const auto physicsCmdComp =
+    this->entityCompMgr.Component<components::PhysicsCmd>(worldEntity);
+  if (!physicsCmdComp)
+  {
+    return;
+  }
+  auto physicsComp =
+    this->entityCompMgr.Component<components::Physics>(worldEntity);
+
+  const auto& physicsParams = physicsCmdComp->Data();
+  const auto newStepSize =
+    std::chrono::duration<double>(physicsParams.max_step_size());
+  const double newRTF = physicsParams.real_time_factor();
+
+  const double eps = 0.00001;
+  if (newStepSize != this->stepSize ||
+      std::abs(newRTF - this->desiredRtf) > eps)
+  {
+    this->SetStepSize(
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+        newStepSize));
+    this->desiredRtf = newRTF;
+    this->updatePeriod = std::chrono::nanoseconds(
+        static_cast<int>(this->stepSize.count() / this->desiredRtf));
+
+    this->simTimes.clear();
+    this->realTimes.clear();
+    // Update physics components
+    physicsComp->Data().SetMaxStepSize(physicsParams.max_step_size());
+    physicsComp->Data().SetRealTimeFactor(newRTF);
+    this->entityCompMgr.SetChanged(worldEntity, components::Physics::typeId,
+        ComponentState::OneTimeChange);
+  }
+  this->entityCompMgr.RemoveComponent<components::PhysicsCmd>(worldEntity);
 }
 
 /////////////////////////////////////////////////
@@ -642,6 +685,10 @@ bool SimulationRunner::Run(const uint64_t _iterations)
        processedIterations < _iterations))
   {
     IGN_PROFILE("SimulationRunner::Run - Iteration");
+
+    // Update the step size and desired rtf
+    this->UpdatePhysicsParams();
+
     // Compute the time to sleep in order to match, as closely as possible,
     // the update period.
     sleepTime = 0ns;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -372,6 +372,10 @@ namespace ignition
       /// \brief Set the next step to be blocking and paused.
       public: void SetNextStepAsBlockingPaused(const bool value);
 
+      /// \brief Updates the physics parameters of the simulation based on the
+      /// Physics component of the world, if any.
+      public: void UpdatePhysicsParams();
+
       /// \brief This is used to indicate that a stop event has been received.
       private: std::atomic<bool> stopReceived{false};
 
@@ -461,6 +465,9 @@ namespace ignition
 
       /// \brief Step size
       private: ignition::math::clock::duration stepSize{10ms};
+
+      /// \brief Desired real time factor
+      private: double desiredRtf{1.0};
 
       /// \brief Connection to the pause event.
       private: ignition::common::ConnectionPtr pauseConn;

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -177,6 +177,10 @@ TEST_P(SimulationRunnerTest, CreateEntities)
   EXPECT_EQ(1u, worldCount);
   EXPECT_NE(kNullEntity, worldEntity);
 
+  // Test step size, real time factor is not testable since it has no public API
+  auto stepSize = std::chrono::duration<double>(runner.StepSize()).count();
+  EXPECT_DOUBLE_EQ(0.001, stepSize);
+
   // Check models
   unsigned int modelCount{0};
   Entity boxModelEntity = kNullEntity;

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -46,6 +46,7 @@
 #include "ignition/gazebo/components/ParentLinkName.hh"
 #include "ignition/gazebo/components/Performer.hh"
 #include "ignition/gazebo/components/PerformerAffinity.hh"
+#include "ignition/gazebo/components/Physics.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/PoseCmd.hh"
 #include "ignition/gazebo/components/SelfCollide.hh"
@@ -172,6 +173,18 @@ void ignition::gazebo::setData(QStandardItem *_item, const double &_data)
   _item->setData(QString("Float"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(_data, ComponentsModel::RoleNames().key("data"));
+}
+
+//////////////////////////////////////////////////
+template<>
+void ignition::gazebo::setData(QStandardItem *_item, const sdf::Physics &_data)
+{
+  _item->setData(QString("Physics"),
+      ComponentsModel::RoleNames().key("dataType"));
+  _item->setData(QList({
+    QVariant(_data.MaxStepSize()),
+    QVariant(_data.RealTimeFactor())
+  }), ComponentsModel::RoleNames().key("data"));
 }
 
 //////////////////////////////////////////////////
@@ -510,6 +523,12 @@ void ComponentInspector::Update(const UpdateInfo &,
       if (comp)
         setData(item, comp->Data());
     }
+    else if (typeId == components::Physics::typeId)
+    {
+      auto comp = _ecm.Component<components::Physics>(this->dataPtr->entity);
+      if (comp)
+        setData(item, comp->Data());
+    }
     else if (typeId == components::Pose::typeId)
     {
       auto comp = _ecm.Component<components::Pose>(this->dataPtr->entity);
@@ -715,6 +734,30 @@ void ComponentInspector::OnPose(double _x, double _y, double _z, double _roll,
   auto poseCmdService = "/world/" + this->dataPtr->worldName
       + "/set_pose";
   this->dataPtr->node.Request(poseCmdService, req, cb);
+}
+
+/////////////////////////////////////////////////
+void ComponentInspector::OnPhysics(double _stepSize, double _realTimeFactor)
+{
+  std::function<void(const ignition::msgs::Boolean &, const bool)> cb =
+      [](const ignition::msgs::Boolean &/*_rep*/, const bool _result)
+  {
+    if (!_result)
+        ignerr << "Error setting physics parameters" << std::endl;
+  };
+
+  ignition::msgs::Physics req;
+  req.set_max_step_size(_stepSize);
+  req.set_real_time_factor(_realTimeFactor);
+  auto physicsCmdService = "/world/" + this->dataPtr->worldName
+      + "/set_physics";
+  physicsCmdService = transport::TopicUtils::AsValidTopic(physicsCmdService);
+  if (physicsCmdService.empty())
+  {
+    ignerr << "Invalid physics command service topic provided" << std::endl;
+    return;
+  }
+  this->dataPtr->node.Request(physicsCmdService, req, cb);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -28,6 +28,8 @@
 #include <ignition/gazebo/gui/GuiSystem.hh>
 #include <ignition/gazebo/Types.hh>
 
+#include "ignition/gazebo/components/Physics.hh"
+
 Q_DECLARE_METATYPE(ignition::gazebo::ComponentTypeId)
 
 namespace ignition
@@ -74,6 +76,12 @@ namespace gazebo
   /// \param[in] _data Data to set.
   template<>
   void setData(QStandardItem *_item, const math::Vector3d &_data);
+
+  /// \brief Specialized to set Physics data.
+  /// \param[in] _item Item whose data will be set.
+  /// \param[in] _data Data to set.
+  template<>
+  void setData(QStandardItem *_item, const sdf::Physics &_data);
 
   /// \brief Specialized to set boolean data.
   /// \param[in] _item Item whose data will be set.
@@ -206,6 +214,12 @@ namespace gazebo
     /// \param[in] _yaw Yaw
     public: Q_INVOKABLE void OnPose(double _x, double _y, double _z,
         double _roll, double _pitch, double _yaw);
+
+    /// \brief Callback in Qt thread when physics' properties change.
+    /// \param[in] _stepSize step size
+    /// \param[in] _realTimeFactor real time factor
+    public: Q_INVOKABLE void OnPhysics(double _stepSize,
+        double _realTimeFactor);
 
     /// \brief Get whether the entity is a nested model or not
     /// \return True if the entity is a nested model, false otherwise

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -85,6 +85,13 @@ Rectangle {
     ComponentInspector.OnPose(_x, _y, _z, _roll, _pitch, _yaw)
   }
 
+  /**
+   * Forward physics changes to C++
+   */
+  function onPhysics(_stepSize, _realTimeFactor) {
+    ComponentInspector.OnPhysics(_stepSize, _realTimeFactor)
+  }
+
   Rectangle {
     id: header
     height: lockButton.height

--- a/src/gui/plugins/component_inspector/ComponentInspector.qrc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qrc
@@ -3,6 +3,7 @@
   <file>Boolean.qml</file>
   <file>ComponentInspector.qml</file>
   <file>NoData.qml</file>
+  <file>Physics.qml</file>
   <file>Pose3d.qml</file>
   <file>String.qml</file>
   <file>TypeHeader.qml</file>

--- a/src/gui/plugins/component_inspector/Physics.qml
+++ b/src/gui/plugins/component_inspector/Physics.qml
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Controls 1.4
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.3
+import QtQuick.Controls.Styles 1.4
+import "qrc:/ComponentInspector"
+import "qrc:/qml"
+
+// Item displaying physics information.
+Rectangle {
+  height: header.height + content.height
+  width: componentInspector.width
+  color: index % 2 == 0 ? lightGrey : darkGrey
+
+  // Left indentation
+  property int indentation: 10
+
+  // Minimum parameter value, step size and RTF must be strictly positive
+  property double minPhysParam: 0.000001
+
+  // Maximum parameter value
+  property double maxPhysParam: 100000
+
+  // Horizontal margins
+  property int margin: 5
+
+  property int iconWidth: 20
+  property int iconHeight: 20
+
+  // Loaded item for physics step size
+  property var stepSizeItem: {}
+
+  // Loaded item for real time factor
+  property var realTimeFactorItem: {}
+
+  // Send new physics data to C++
+  function sendPhysics() {
+    // TODO(anyone) There's a loss of precision when these values get to C++
+    componentInspector.onPhysics(
+      stepSizeItem.value,
+      realTimeFactorItem.value
+    );
+  }
+
+  FontMetrics {
+    id: fontMetrics
+    font.family: "Roboto"
+  }
+
+  /**
+   * Used to create a spin box
+   */
+
+  Component {
+    id: writablePositiveNumber
+    IgnSpinBox {
+      id: writableSpin
+      value: writableSpin.activeFocus ? writableSpin.value : numberValue
+      minimumValue: minPhysParam
+      maximumValue: maxPhysParam
+      decimals: 6
+      stepSize: 0.001
+      onEditingFinished: {
+        sendPhysics()
+      }
+    }
+  }
+
+  Component {
+    id: plotIcon
+    Image {
+      property string componentInfo: ""
+      source: "plottable_icon.svg"
+      anchors.top: parent.top
+      anchors.left: parent.left
+
+      Drag.mimeData: { "text/plain" : (model === null) ? "" :
+      "Component," + model.entity + "," + model.typeId + "," +
+                     model.dataType + "," + componentInfo + "," + model.shortName
+      }
+      Drag.dragType: Drag.Automatic
+      Drag.supportedActions : Qt.CopyAction
+      Drag.active: dragMouse.drag.active
+      // a point to drag from
+      Drag.hotSpot.x: 0
+      Drag.hotSpot.y: y
+      MouseArea {
+        id: dragMouse
+        anchors.fill: parent
+        drag.target: (model === null) ? null : parent
+        onPressed: parent.grabToImage(function(result) {parent.Drag.imageSource = result.url })
+        onReleased: parent.Drag.drop();
+        cursorShape: Qt.DragCopyCursor
+      }
+    }
+  }
+
+  Column {
+    anchors.fill: parent
+
+    // Header
+    Rectangle {
+      id: header
+      width: parent.width
+      height: typeHeader.height
+      color: "transparent"
+
+      RowLayout {
+        anchors.fill: parent
+        Item {
+          width: margin
+        }
+        Image {
+          id: icon
+          sourceSize.height: indentation
+          sourceSize.width: indentation
+          fillMode: Image.Pad
+          Layout.alignment : Qt.AlignVCenter
+          source: content.show ?
+              "qrc:/Gazebo/images/minus.png" : "qrc:/Gazebo/images/plus.png"
+        }
+        TypeHeader {
+          id: typeHeader
+        }
+        Item {
+          Layout.fillWidth: true
+        }
+      }
+      MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: {
+          content.show = !content.show
+        }
+        onEntered: {
+          header.color = highlightColor
+        }
+        onExited: {
+          header.color = "transparent"
+        }
+      }
+    }
+
+    // Content
+    Rectangle {
+      id: content
+      property bool show: false
+      width: parent.width
+      height: show ? grid.height : 0
+      clip: true
+      color: "transparent"
+
+      Behavior on height {
+        NumberAnimation {
+          duration: 200;
+          easing.type: Easing.InOutQuad
+        }
+      }
+
+      GridLayout {
+        id: grid
+        width: parent.width
+        columns: 3
+
+        // Left spacer
+        Item {
+          Layout.rowSpan: 3
+          width: margin + indentation
+        }
+
+        Rectangle {
+          color: "transparent"
+          height: 40
+          Layout.preferredWidth: stepSizeText.width + indentation*3
+          Loader {
+            id: loaderStepSize
+            width: iconWidth
+            height: iconHeight
+            y:10
+            sourceComponent: plotIcon
+          }
+          Component.onCompleted: loaderStepSize.item.componentInfo = "stepSize"
+
+          Text {
+            id : stepSizeText
+            text: ' Step Size (s)'
+            leftPadding: 5
+            color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
+            font.pointSize: 12
+            anchors.centerIn: parent
+          }
+        }
+        Item {
+          Layout.fillWidth: true
+          height: 40
+          Loader {
+            id: stepSizeLoader
+            anchors.fill: parent
+            property double numberValue: model.data[0]
+            sourceComponent: writablePositiveNumber
+            onLoaded: {
+              stepSizeItem = stepSizeLoader.item
+            }
+          }
+        }
+        Rectangle {
+          color: "transparent"
+          height: 40
+          Layout.preferredWidth: realTimeFactorText.width + indentation*3
+          Loader {
+            id: loaderRealTimeFactor
+            width: iconWidth
+            height: iconHeight
+            y:10
+            sourceComponent: plotIcon
+          }
+          Component.onCompleted: loaderRealTimeFactor.item.componentInfo = "realTimeFactor"
+
+          Text {
+            id : realTimeFactorText
+            text: ' Real time factor'
+            leftPadding: 5
+            color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
+            font.pointSize: 12
+            anchors.centerIn: parent
+          }
+        }
+        Item {
+          Layout.fillWidth: true
+          height: 40
+          Loader {
+            id: realTimeFactorLoader
+            anchors.fill: parent
+            property double numberValue: model.data[1]
+            sourceComponent: writablePositiveNumber
+            onLoaded: {
+              realTimeFactorItem = realTimeFactorLoader.item
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -21,6 +21,7 @@
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/entity_factory.pb.h>
 #include <ignition/msgs/pose.pb.h>
+#include <ignition/msgs/physics.pb.h>
 
 #include <string>
 #include <utility>
@@ -28,6 +29,7 @@
 
 #include <ignition/msgs/Utility.hh>
 
+#include <sdf/Physics.hh>
 #include <sdf/Root.hh>
 #include <sdf/Error.hh>
 
@@ -42,7 +44,9 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/PoseCmd.hh"
+#include "ignition/gazebo/components/PhysicsCmd.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/Conversions.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
 
@@ -146,6 +150,19 @@ class PoseCommand : public UserCommandBase
                          math::equal(_a.Rot().W(), _b.Rot().W(), 1e-6);
                      }};
 };
+
+/// \brief Command to modify the physics parameters of a simulation.
+class PhysicsCommand : public UserCommandBase
+{
+  /// \brief Constructor
+  /// \param[in] _msg Message containing the new physics parameters.
+  /// \param[in] _iface Pointer to user commands interface.
+  public: PhysicsCommand(msgs::Physics *_msg,
+      std::shared_ptr<UserCommandsInterface> &_iface);
+
+  // Documentation inherited
+  public: bool Execute() final;
+};
 }
 }
 }
@@ -184,6 +201,13 @@ class ignition::gazebo::systems::UserCommandsPrivate
   /// It does not mean that the entity will be successfully moved.
   /// \return True if successful.
   public: bool PoseService(const msgs::Pose &_req, msgs::Boolean &_res);
+
+  /// \brief Callback for physics service
+  /// \param[in] _req Request containing updates to the physics parameters.
+  /// \param[in] _res True if message successfully received and queued.
+  /// It does not mean that the physics parameters will be successfully updated.
+  /// \return True if successful.
+  public: bool PhysicsService(const msgs::Physics &_req, msgs::Boolean &_res);
 
   /// \brief Queue of commands pending execution.
   public: std::vector<std::unique_ptr<UserCommandBase>> pendingCmds;
@@ -248,6 +272,13 @@ void UserCommands::Configure(const Entity &_entity,
       &UserCommandsPrivate::PoseService, this->dataPtr.get());
 
   ignmsg << "Pose service on [" << poseService << "]" << std::endl;
+
+  // Physics service
+  std::string physicsService{"/world/" + validWorldName + "/set_physics"};
+  this->dataPtr->node.Advertise(physicsService,
+      &UserCommandsPrivate::PhysicsService, this->dataPtr.get());
+
+  ignmsg << "Physics service on [" << physicsService << "]" << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -349,6 +380,24 @@ bool UserCommandsPrivate::PoseService(const msgs::Pose &_req,
   msg->CopyFrom(_req);
   auto cmd = std::make_unique<PoseCommand>(msg, this->iface);
 
+  // Push to pending
+  {
+    std::lock_guard<std::mutex> lock(this->pendingMutex);
+    this->pendingCmds.push_back(std::move(cmd));
+  }
+
+  _res.set_data(true);
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool UserCommandsPrivate::PhysicsService(const msgs::Physics &_req,
+    msgs::Boolean &_res)
+{
+  // Create command and push it to queue
+  auto msg = _req.New();
+  msg->CopyFrom(_req);
+  auto cmd = std::make_unique<PhysicsCommand>(msg, this->iface);
   // Push to pending
   {
     std::lock_guard<std::mutex> lock(this->pendingMutex);
@@ -688,6 +737,39 @@ bool PoseCommand::Execute()
   return true;
 }
 
+//////////////////////////////////////////////////
+PhysicsCommand::PhysicsCommand(msgs::Physics *_msg,
+    std::shared_ptr<UserCommandsInterface> &_iface)
+    : UserCommandBase(_msg, _iface)
+{
+}
+
+//////////////////////////////////////////////////
+bool PhysicsCommand::Execute()
+{
+  auto physicsMsg = dynamic_cast<const msgs::Physics *>(this->msg);
+  if (nullptr == physicsMsg)
+  {
+    ignerr << "Internal error, null physics message" << std::endl;
+    return false;
+  }
+
+  auto worldEntity = this->iface->ecm->EntityByComponents(components::World());
+  if (worldEntity == kNullEntity)
+  {
+    ignmsg << "Failed to find world entity" << std::endl;
+    return false;
+  }
+
+  if (!this->iface->ecm->EntityHasComponentType(worldEntity,
+    components::PhysicsCmd().TypeId()))
+  {
+    this->iface->ecm->CreateComponent(worldEntity,
+        components::PhysicsCmd(*physicsMsg));
+  }
+
+  return true;
+}
 
 IGNITION_ADD_PLUGIN(UserCommands, System,
   UserCommands::ISystemConfigure,

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -274,7 +274,7 @@ void UserCommands::Configure(const Entity &_entity,
   ignmsg << "Pose service on [" << poseService << "]" << std::endl;
 
   // Physics service
-  std::string physicsService{"/world/" + validWorldName + "/set_physics"};
+  std::string physicsService{"/world/" + worldName + "/set_physics"};
   this->dataPtr->node.Advertise(physicsService,
       &UserCommandsPrivate::PhysicsService, this->dataPtr.get());
 

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -28,7 +28,9 @@
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/Physics.hh"
 #include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/test_config.hh"
@@ -671,4 +673,66 @@ TEST_F(UserCommandsTest, Pose)
   poseComp = ecm->Component<components::Pose>(boxEntity);
   ASSERT_NE(nullptr, poseComp);
   EXPECT_NEAR(500.0, poseComp->Data().Pos().Y(), 0.2);
+}
+
+/////////////////////////////////////////////////
+TEST_F(UserCommandsTest, Physics)
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/shapes.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Create a system just to get the ECM
+  EntityComponentManager *ecm{nullptr};
+  test::Relay testSystem;
+  testSystem.OnPreUpdate([&](const gazebo::UpdateInfo &,
+                             gazebo::EntityComponentManager &_ecm)
+      {
+        ecm = &_ecm;
+      });
+
+  server.AddSystem(testSystem.systemPtr);
+
+  // Run server and check we have the ECM
+  EXPECT_EQ(nullptr, ecm);
+  server.Run(true, 1, false);
+  EXPECT_NE(nullptr, ecm);
+
+  // Check that the physics properties are the ones specified in the sdf
+  auto worldEntity = ecm->EntityByComponents(components::World());
+  EXPECT_NE(kNullEntity, worldEntity);
+  auto physicsComp = ecm->Component<components::Physics>(worldEntity);
+  ASSERT_NE(nullptr, physicsComp);
+  EXPECT_DOUBLE_EQ(0.001, physicsComp->Data().MaxStepSize());
+  EXPECT_DOUBLE_EQ(1.0, physicsComp->Data().RealTimeFactor());
+
+  // Set physics properties
+  msgs::Physics req;
+  req.set_max_step_size(0.123);
+  req.set_real_time_factor(4.567);
+
+  msgs::Boolean res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/default/set_physics"};
+
+  transport::Node node;
+  EXPECT_TRUE(node.Request(service, req, timeout, res, result));
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(res.data());
+
+  // Run two iterations, in the first one the PhysicsCmd component is created
+  // in the second one it is processed
+  server.Run(true, 2, false);
+
+  // Check updated physics properties
+  physicsComp = ecm->Component<components::Physics>(worldEntity);
+  EXPECT_DOUBLE_EQ(0.123, physicsComp->Data().MaxStepSize());
+  EXPECT_DOUBLE_EQ(4.567, physicsComp->Data().RealTimeFactor());
 }


### PR DESCRIPTION
# :arrow_left:  Backport port

Port 5 to 3

I'm backporting this commit to be able to fetch the MaxStepSize in the system plugin of `ignition_ros2_control` in Citadel. Refer to this [conversation](https://github.com/ignitionrobotics/ign_ros2_control/pull/1#discussion_r624242888). With this PR merged and released we will be able to release `ign_ros2_control` in Foxy and Citadel.

Branch comparison: https://github.com/ignitionrobotics/ign-gazebo/compare/ign-gazebo3...ahcorde/backport/536

**Note to maintainers**: Remember to **Rebase-merge**