### PR TITLE
Removed duplicated code with rendering::sceneFromFirstRenderEngine

### DIFF
--- a/src/gui/plugins/grid_config/GridConfig.cc
+++ b/src/gui/plugins/grid_config/GridConfig.cc
@@ -149,42 +149,7 @@ void GridConfig::UpdateGrid()
 /////////////////////////////////////////////////
 void GridConfig::LoadGrid()
 {
-  auto loadedEngNames = rendering::loadedEngines();
-  if (loadedEngNames.empty())
-    return;
-
-  // assume there is only one engine loaded
-  auto engineName = loadedEngNames[0];
-  if (loadedEngNames.size() > 1)
-  {
-    igndbg << "More than one engine is available. "
-      << "Grid config plugin will use engine ["
-        << engineName << "]" << std::endl;
-  }
-  auto engine = rendering::engine(engineName);
-  if (!engine)
-  {
-    ignerr << "Internal error: failed to load engine [" << engineName
-      << "]. Grid plugin won't work." << std::endl;
-    return;
-  }
-
-  if (engine->SceneCount() == 0)
-    return;
-
-  // assume there is only one scene
-  // load scene
-  auto scene = engine->SceneByIndex(0);
-  if (!scene)
-  {
-    ignerr << "Internal error: scene is null." << std::endl;
-    return;
-  }
-
-  if (!scene->IsInitialized() || nullptr == scene->RootVisual())
-  {
-    return;
-  }
+  auto scene = rendering::sceneFromFirstRenderEngine();
 
   // load grid
   // if gridPtr found, load the existing gridPtr to class

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -164,42 +164,7 @@ void TransformControl::SnapToGrid()
 /////////////////////////////////////////////////
 void TransformControl::LoadGrid()
 {
-  auto loadedEngNames = rendering::loadedEngines();
-  if (loadedEngNames.empty())
-    return;
-
-  // assume there is only one engine loaded
-  auto engineName = loadedEngNames[0];
-  if (loadedEngNames.size() > 1)
-  {
-    igndbg << "More than one engine is available. "
-      << "Grid config plugin will use engine ["
-        << engineName << "]" << std::endl;
-  }
-  auto engine = rendering::engine(engineName);
-  if (!engine)
-  {
-    ignerr << "Internal error: failed to load engine [" << engineName
-      << "]. Grid plugin won't work." << std::endl;
-    return;
-  }
-
-  if (engine->SceneCount() == 0)
-    return;
-
-  // assume there is only one scene
-  // load scene
-  auto scene = engine->SceneByIndex(0);
-  if (!scene)
-  {
-    ignerr << "Internal error: scene is null." << std::endl;
-    return;
-  }
-
-  if (!scene->IsInitialized() || scene->VisualCount() == 0)
-  {
-    return;
-  }
+  auto scene = rendering::sceneFromFirstRenderEngine();
 
   // load grid
   // if gridPtr found, load the existing gridPtr to class

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.cc
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.cc
@@ -218,38 +218,7 @@ void CameraVideoRecorderPrivate::OnPostRender()
   // get scene
   if (!this->scene)
   {
-    auto loadedEngNames = rendering::loadedEngines();
-    if (loadedEngNames.empty())
-      return;
-
-    // assume there is only one engine loaded
-    auto engineName = loadedEngNames[0];
-    if (loadedEngNames.size() > 1)
-    {
-      igndbg << "More than one engine is available. "
-        << "Camera video recorder system will use engine ["
-          << engineName << "]" << std::endl;
-    }
-    auto engine = rendering::engine(engineName);
-    if (!engine)
-    {
-      ignerr << "Internal error: failed to load engine [" << engineName
-        << "]. Camera video recorder system won't work." << std::endl;
-      return;
-    }
-
-    if (engine->SceneCount() == 0)
-      return;
-
-    // assume there is only one scene
-    // load scene
-    auto s = engine->SceneByIndex(0);
-    if (!s)
-    {
-      ignerr << "Internal error: scene is null." << std::endl;
-      return;
-    }
-    this->scene = s;
+    this->scene = rendering::sceneFromFirstRenderEngine();
   }
 
   // return if scene not ready or no sensors available.


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# Enhancement

## Summary

Related to this PR in ignition-renderin https://github.com/ignitionrobotics/ign-rendering/pull/320#event-4749407284. It uses the helper function rendering::sceneFromFirstRenderEngine to get the first scene that can be found in any rendering engine.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
