### PR TITLE
Remove meshes from Gazebo

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -1585,6 +1585,9 @@ void SceneManager::RemoveEntity(Entity _id)
     auto it = this->dataPtr->visuals.find(_id);
     if (it != this->dataPtr->visuals.end())
     {
+      ignition::common::MeshManager *meshManager =
+          ignition::common::MeshManager::Instance();
+      meshManager->RemoveMesh(it->second->Name());
       this->dataPtr->scene->DestroyVisual(it->second);
       this->dataPtr->visuals.erase(it);
       return;

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -39,6 +39,7 @@
 #include <ignition/transport/Node.hh>
 
 #include "ignition/common/Profiler.hh"
+#include "ignition/common/MeshManager.hh"
 
 #include "ignition/gazebo/components/Light.hh"
 #include "ignition/gazebo/components/LightCmd.hh"
@@ -806,6 +807,16 @@ bool RemoveCommand::Execute()
            << std::endl;
     return false;
   }
+
+  auto modelsdf = this->iface->ecm->Component<components::ModelSdf>(entity);
+  if (!modelsdf)
+  {
+    ignerr << "Invalid Model pointer. This shouldn't happen\n";
+  }
+
+  ignition::common::MeshManager *meshManager =
+      ignition::common::MeshManager::Instance();
+  meshManager->RemoveMesh(modelsdf->Data().Name());
 
   igndbg << "Requesting removal of entity [" << entity << "]" << std::endl;
   this->iface->creator->RequestRemoveEntity(entity);


### PR DESCRIPTION
# 🎉 Enhancement

## Summary

This PR allows to remove a meshes when an entity is removed or the remove UserCommand is called.

Related with https://github.com/ignitionrobotics/ign-gui/issues/208

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

