### PR TITLE
Cleanup and alphabetize plugin headers

### DIFF
--- a/src/gui/plugins/align_tool/AlignTool.cc
+++ b/src/gui/plugins/align_tool/AlignTool.cc
@@ -24,24 +24,26 @@
 #include <queue>
 #include <string>
 #include <vector>
+
+#include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
-#include <ignition/gazebo/rendering/RenderUtil.hh>
-#include <ignition/common/Console.hh>
 #include <ignition/plugin/Register.hh>
-#include <ignition/transport/Node.hh>
-#include <ignition/rendering/Visual.hh>
 #include <ignition/rendering/Geometry.hh>
 #include <ignition/rendering/Material.hh>
+#include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/RenderTypes.hh>
 #include <ignition/rendering/RenderingIface.hh>
-#include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/Scene.hh>
-#include "ignition/gazebo/components/World.hh"
-#include "ignition/gazebo/components/Name.hh"
+#include <ignition/rendering/Visual.hh>
+#include <ignition/transport/Node.hh>
 
 #include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
+#include "ignition/gazebo/rendering/RenderUtil.hh"
+
 #include "AlignTool.hh"
 
 namespace ignition::gazebo

--- a/src/gui/plugins/align_tool/AlignTool.hh
+++ b/src/gui/plugins/align_tool/AlignTool.hh
@@ -20,8 +20,8 @@
 
 #include <memory>
 
-#include <ignition/gui/Plugin.hh>
 #include <ignition/gazebo/gui/GuiSystem.hh>
+#include <ignition/gui/Plugin.hh>
 #include <ignition/rendering/Node.hh>
 
 namespace ignition

--- a/src/gui/plugins/grid_config/GridConfig.cc
+++ b/src/gui/plugins/grid_config/GridConfig.cc
@@ -18,9 +18,9 @@
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
-#include <ignition/plugin/Register.hh>
 #include <ignition/math/Color.hh>
 #include <ignition/math/Pose3.hh>
+#include <ignition/plugin/Register.hh>
 #include <ignition/rendering.hh>
 
 #include "ignition/gazebo/gui/GuiEvents.hh"

--- a/src/gui/plugins/playback_scrubber/PlaybackScrubber.cc
+++ b/src/gui/plugins/playback_scrubber/PlaybackScrubber.cc
@@ -27,19 +27,17 @@
 #include <string>
 #include <utility>
 
-#include <ignition/math/Helpers.hh>
-
 #include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/Helpers.hh>
 #include <ignition/gui/MainWindow.hh>
+#include <ignition/math/Helpers.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/transport/Publisher.hh>
-#include "ignition/gazebo/components/LogPlaybackStatistics.hh"
-#include "ignition/gazebo/components/World.hh"
-#include "ignition/gazebo/components/Name.hh"
+
 #include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/components/LogPlaybackStatistics.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 
 namespace ignition::gazebo

--- a/src/gui/plugins/playback_scrubber/PlaybackScrubber.hh
+++ b/src/gui/plugins/playback_scrubber/PlaybackScrubber.hh
@@ -21,8 +21,8 @@
 #include <chrono>
 #include <memory>
 
-#include <ignition/gui/Plugin.hh>
 #include <ignition/gazebo/gui/GuiSystem.hh>
+#include <ignition/gui/Plugin.hh>
 
 namespace ignition
 {

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -28,17 +28,16 @@
 #include <sdf/parser.hh>
 
 #include <ignition/common/Console.hh>
-#include <ignition/common/Profiler.hh>
 #include <ignition/common/Filesystem.hh>
+#include <ignition/common/Profiler.hh>
+#include <ignition/fuel_tools/ClientConfig.hh>
+#include <ignition/fuel_tools/FuelClient.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/transport/Publisher.hh>
-#include <ignition/fuel_tools/FuelClient.hh>
-#include <ignition/fuel_tools/ClientConfig.hh>
 
-#include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 
 namespace ignition::gazebo

--- a/src/gui/plugins/shapes/Shapes.cc
+++ b/src/gui/plugins/shapes/Shapes.cc
@@ -31,7 +31,6 @@
 #include <ignition/transport/Node.hh>
 #include <ignition/transport/Publisher.hh>
 
-#include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 
 namespace ignition::gazebo

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -27,19 +27,16 @@
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/MainWindow.hh>
 #include <ignition/plugin/Register.hh>
-#include <ignition/transport/Node.hh>
-#include <ignition/transport/Publisher.hh>
-#include <ignition/rendering/Visual.hh>
 #include <ignition/rendering/Geometry.hh>
 #include <ignition/rendering/Grid.hh>
+#include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/RenderTypes.hh>
 #include <ignition/rendering/RenderingIface.hh>
-#include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/Scene.hh>
+#include <ignition/rendering/Visual.hh>
+#include <ignition/transport/Node.hh>
+#include <ignition/transport/Publisher.hh>
 
-#include "ignition/gazebo/components/Name.hh"
-#include "ignition/gazebo/components/ParentEntity.hh"
-#include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 
 namespace ignition::gazebo


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This is part of the effort to move some of the plugin living in ign-gazebo to ign-gui. Refer to this issue https://github.com/ignitionrobotics/ign-gazebo/issues/835

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**