### PR TITLE
Multi-LRAUV Swimming Race Example

### DIFF
--- a/examples/standalone/multi_lrauv_race/CMakeLists.txt
+++ b/examples/standalone/multi_lrauv_race/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+find_package(ignition-transport11 QUIET REQUIRED OPTIONAL_COMPONENTS log)
+set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
+
+find_package(ignition-gazebo6 REQUIRED)
+set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
+
+add_executable(multi_lrauv_race multi_lrauv_race.cc)
+target_link_libraries(multi_lrauv_race
+  ignition-transport${IGN_TRANSPORT_VER}::core
+  ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER})

--- a/examples/standalone/multi_lrauv_race/README.md
+++ b/examples/standalone/multi_lrauv_race/README.md
@@ -1,0 +1,25 @@
+# Multi-LRAUV Swimming Race Example
+
+This example shows the usage of the Thruster plugin and rudder joint control on
+multiple autonomous underwater vehicles (AUV) with buoyancy, lift drag, and
+hydrodynamics plugins. The multiple vehicles are differentiated by namespaces.
+
+## Build Instructions
+
+From this directory, run the following to compile:
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+
+## Execute Instructions
+
+From the `build` directory, run Ignition and the example controller:
+
+    ign gazebo -r ../../../worlds/multi_lrauv_race.sdf
+    ./multi_lrauv_race
+
+The example controller will output pseudorandom propeller and rudder commands
+to move the vehicles forward. The low speed is by design to model the actual
+vehicle velocity.

--- a/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
+++ b/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
@@ -36,7 +36,7 @@ double random_angle_within_limits(double min=-0.261799, double max=0.261799)
     (static_cast<float>(RAND_MAX / (max - min)));
 }
 
-// Nominal speed is thruster 300 rpm = 31.4 radians
+// Nominal speed is thruster 300 rpm = 31.4 radians per second
 double random_thrust_within_limits(double min=-31.4, double max=31.4)
 {
   return min + static_cast<float>(rand()) /
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
       propellerPubs[i].Publish(propellerMsg);
 
       std::cout << "Commanding " << ns[i] << " rudder angle " << rudderCmds[i]
-        << ", thrust " << propellerCmds[i] << std::endl;
+        << " rad, thrust " << propellerCmds[i] << " rad/s" << std::endl;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));

--- a/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
+++ b/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * In each iteration, for each vehicle, generate a random fin angle and thrust
+ * within reasonable limits, and send the command to the vehicle.
+ *
+ * Usage:
+ *   $ multi_lrauv_race
+ */
+
+#include <chrono>
+#include <thread>
+
+#include <ignition/msgs.hh>
+#include <ignition/transport.hh>
+
+// Fin joint limits from tethys model.sdf
+double random_angle_within_limits(double min=-0.261799, double max=0.261799)
+{
+  return min + static_cast<float>(rand()) /
+    (static_cast<float>(RAND_MAX / (max - min)));
+}
+
+// Nominal speed is thruster 300 rpm = 31.4 radians
+double random_thrust_within_limits(double min=-31.4, double max=31.4)
+{
+  return min + static_cast<float>(rand()) /
+    (static_cast<float>(RAND_MAX / (max - min)));
+}
+
+int main(int argc, char** argv)
+{
+  // Initialize random seed
+  srand(time(NULL));
+
+  std::vector<std::string> ns;
+  ns.push_back("tethys");
+  ns.push_back("triton");
+  ns.push_back("daphne");
+
+  ignition::transport::Node node;
+
+  std::vector<std::string> rudderTopics;
+  rudderTopics.resize(ns.size(), "");
+  std::vector<ignition::transport::Node::Publisher> rudderPubs;
+  rudderPubs.resize(ns.size());
+
+  std::vector<std::string> propellerTopics;
+  propellerTopics.resize(ns.size(), "");
+  std::vector<ignition::transport::Node::Publisher> propellerPubs;
+  propellerPubs.resize(ns.size());
+
+  // Set up topic names and publishers
+  for (int i = 0; i < ns.size(); i++)
+  {
+    rudderTopics[i] = ignition::transport::TopicUtils::AsValidTopic(
+      "/model/" + ns[i] + "/joint/vertical_fins_joint/0/cmd_pos");
+    rudderPubs[i] = node.Advertise<ignition::msgs::Double>(rudderTopics[i]);
+
+    propellerTopics[i] = ignition::transport::TopicUtils::AsValidTopic(
+      "/model/" + ns[i] + "/joint/propeller_joint/cmd_pos");
+    propellerPubs[i] = node.Advertise<ignition::msgs::Double>(
+      propellerTopics[i]);
+  }
+
+  std::vector<double> rudderCmds;
+  rudderCmds.resize(ns.size(), 0.0);
+  std::vector<double> propellerCmds;
+  propellerCmds.resize(ns.size(), 0.0);
+
+  float artificial_speedup = 1;
+  
+  while (true)
+  {
+    for (int i = 0; i < ns.size(); i++)
+    {
+      rudderCmds[i] = random_angle_within_limits(-0.01, 0.01);
+      ignition::msgs::Double rudderMsg;
+      rudderMsg.set_data(rudderCmds[i]);
+      rudderPubs[i].Publish(rudderMsg);
+
+      propellerCmds[i] = random_thrust_within_limits(
+        -31.4 * artificial_speedup, 0);
+      ignition::msgs::Double propellerMsg;
+      propellerMsg.set_data(propellerCmds[i]);
+      propellerPubs[i].Publish(propellerMsg);
+
+      std::cout << "Commanding " << ns[i] << " rudder angle " << rudderCmds[i]
+        << ", thrust " << propellerCmds[i] << std::endl;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+}

--- a/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
+++ b/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
@@ -36,8 +36,8 @@ double random_angle_within_limits(double min=-0.261799, double max=0.261799)
     (static_cast<float>(RAND_MAX / (max - min)));
 }
 
-// Nominal speed is thruster 300 rpm = 31.4 radians per second
-double random_thrust_within_limits(double min=-31.4, double max=31.4)
+// Nominal speed is thruster 300 rpm ~ 31.4 radians per second ~ 6.14 Newtons
+double random_thrust_within_limits(double min=-6.14, double max=6.14)
 {
   return min + static_cast<float>(rand()) /
     (static_cast<float>(RAND_MAX / (max - min)));
@@ -95,13 +95,13 @@ int main(int argc, char** argv)
       rudderPubs[i].Publish(rudderMsg);
 
       propellerCmds[i] = random_thrust_within_limits(
-        -31.4 * artificial_speedup, 0);
+        -6.14 * artificial_speedup, 0);
       ignition::msgs::Double propellerMsg;
       propellerMsg.set_data(propellerCmds[i]);
       propellerPubs[i].Publish(propellerMsg);
 
       std::cout << "Commanding " << ns[i] << " rudder angle " << rudderCmds[i]
-        << " rad, thrust " << propellerCmds[i] << " rad/s" << std::endl;
+        << " rad, thrust " << propellerCmds[i] << " Newtons" << std::endl;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));

--- a/examples/worlds/multi_lrauv_race.sdf
+++ b/examples/worlds/multi_lrauv_race.sdf
@@ -1,0 +1,365 @@
+<?xml version="1.0" ?>
+
+<!-- Run demo with ign-gazebo examples/standalone/multi_lrauv_race
+  (example is provided in ign-gazebo6+). -->
+
+<sdf version="1.6">
+  <world name="multi_lrauv">
+    <scene>
+      <!-- For turquoise ambient to match particle effect -->
+      <ambient>0.0 1.0 1.0</ambient>
+      <background>0.0 0.7 0.8</background>
+    </scene>
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-contact-system"
+      name="ignition::gazebo::systems::Contact">
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-buoyancy-system"
+      name="ignition::gazebo::systems::Buoyancy">
+      <uniform_fluid_density>1000</uniform_fluid_density>
+    </plugin>
+
+    <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
+      to ParticleEmitter in Ignition G.
+      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
+    <plugin
+      filename="ignition-gazebo-particle-emitter2-system"
+      name="ignition::gazebo::systems::ParticleEmitter2">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
+      to ParticleEmitter in Ignition G.
+      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
+    <include>
+      <pose>-5 0 0 0 0 0</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabel/models/Turquoise turbidity generator</uri>
+    </include>
+
+    <include>
+      <pose>0 0 1 0 0 1.57</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+
+      <!-- Joint controllers -->
+      <plugin
+        filename="ignition-gazebo-joint-position-controller-system"
+        name="ignition::gazebo::systems::JointPositionController">
+        <joint_name>horizontal_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-joint-position-controller-system"
+        name="ignition::gazebo::systems::JointPositionController">
+        <joint_name>vertical_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-thruster-system"
+        name="ignition::gazebo::systems::Thruster">
+        <namespace>tethys</namespace>
+        <joint_name>propeller_joint</joint_name>
+        <thrust_coefficient>0.004422</thrust_coefficient>
+        <fluid_density>1000</fluid_density>
+        <propeller_diameter>0.2</propeller_diameter>
+      </plugin>
+
+      <!-- Lift and drag -->
+
+      <!-- Vertical fin -->
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 1 0</upward>
+        <forward>1 0 0</forward>
+        <link_name>vertical_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <!-- Horizontal fin -->
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 0 1</upward>
+        <forward>1 0 0</forward>
+        <link_name>horizontal_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-hydrodynamics-system"
+        name="ignition::gazebo::systems::Hydrodynamics">
+        <link_name>base_link</link_name>
+        <xDotU>-4.876161</xDotU>
+        <yDotV>-126.324739</yDotV>
+        <zDotW>-126.324739</zDotW>
+        <kDotP>0</kDotP>
+        <mDotQ>-33.46</mDotQ>
+        <nDotR>-33.46</nDotR>
+        <xUU>-6.2282</xUU>
+        <xU>0</xU>
+        <yVV>-601.27</yVV>
+        <yV>0</yV>
+        <zWW>-601.27</zWW>
+        <zW>0</zW>
+        <kPP>-0.1916</kPP>
+        <kP>0</kP>
+        <mQQ>-632.698957</mQQ>
+        <mQ>0</mQ>
+        <nRR>-632.698957</nRR>
+        <nR>0</nR>
+      </plugin>
+
+    </include>
+
+    <include>
+      <pose>5 0 1 0 0 1.57</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <name>triton</name>
+
+      <!-- Joint controllers -->
+      <plugin
+        filename="ignition-gazebo-joint-position-controller-system"
+        name="ignition::gazebo::systems::JointPositionController">
+        <joint_name>horizontal_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-joint-position-controller-system"
+        name="ignition::gazebo::systems::JointPositionController">
+        <joint_name>vertical_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-thruster-system"
+        name="ignition::gazebo::systems::Thruster">
+        <namespace>triton</namespace>
+        <joint_name>propeller_joint</joint_name>
+        <thrust_coefficient>0.004422</thrust_coefficient>
+        <fluid_density>1000</fluid_density>
+        <propeller_diameter>0.2</propeller_diameter>
+      </plugin>
+
+      <!-- Lift and drag -->
+
+      <!-- Vertical fin -->
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 1 0</upward>
+        <forward>1 0 0</forward>
+        <link_name>vertical_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <!-- Horizontal fin -->
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 0 1</upward>
+        <forward>1 0 0</forward>
+        <link_name>horizontal_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-hydrodynamics-system"
+        name="ignition::gazebo::systems::Hydrodynamics">
+        <link_name>base_link</link_name>
+        <xDotU>-4.876161</xDotU>
+        <yDotV>-126.324739</yDotV>
+        <zDotW>-126.324739</zDotW>
+        <kDotP>0</kDotP>
+        <mDotQ>-33.46</mDotQ>
+        <nDotR>-33.46</nDotR>
+        <xUU>-6.2282</xUU>
+        <xU>0</xU>
+        <yVV>-601.27</yVV>
+        <yV>0</yV>
+        <zWW>-601.27</zWW>
+        <zW>0</zW>
+        <kPP>-0.1916</kPP>
+        <kP>0</kP>
+        <mQQ>-632.698957</mQQ>
+        <mQ>0</mQ>
+        <nRR>-632.698957</nRR>
+        <nR>0</nR>
+      </plugin>
+
+    </include>
+
+    <include>
+      <pose>-5 0 1 0 0 1.57</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <name>daphne</name>
+
+      <!-- Joint controllers -->
+      <plugin
+        filename="ignition-gazebo-joint-position-controller-system"
+        name="ignition::gazebo::systems::JointPositionController">
+        <joint_name>horizontal_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-joint-position-controller-system"
+        name="ignition::gazebo::systems::JointPositionController">
+        <joint_name>vertical_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-thruster-system"
+        name="ignition::gazebo::systems::Thruster">
+        <namespace>daphne</namespace>
+        <joint_name>propeller_joint</joint_name>
+        <thrust_coefficient>0.004422</thrust_coefficient>
+        <fluid_density>1000</fluid_density>
+        <propeller_diameter>0.2</propeller_diameter>
+      </plugin>
+
+      <!-- Lift and drag -->
+
+      <!-- Vertical fin -->
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 1 0</upward>
+        <forward>1 0 0</forward>
+        <link_name>vertical_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <!-- Horizontal fin -->
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 0 1</upward>
+        <forward>1 0 0</forward>
+        <link_name>horizontal_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <plugin
+        filename="ignition-gazebo-hydrodynamics-system"
+        name="ignition::gazebo::systems::Hydrodynamics">
+        <link_name>base_link</link_name>
+        <xDotU>-4.876161</xDotU>
+        <yDotV>-126.324739</yDotV>
+        <zDotW>-126.324739</zDotW>
+        <kDotP>0</kDotP>
+        <mDotQ>-33.46</mDotQ>
+        <nDotR>-33.46</nDotR>
+        <xUU>-6.2282</xUU>
+        <xU>0</xU>
+        <yVV>-601.27</yVV>
+        <yV>0</yV>
+        <zWW>-601.27</zWW>
+        <zW>0</zW>
+        <kPP>-0.1916</kPP>
+        <kP>0</kP>
+        <mQQ>-632.698957</mQQ>
+        <mQ>0</mQ>
+        <nRR>-632.698957</nRR>
+        <nR>0</nR>
+      </plugin>
+
+    </include>
+
+    <!-- Swimming race lane signs -->
+    <include>
+      <pose>0 0 -1 0 0 3.1415926</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabel/models/ABCSign_5m</uri>
+      <name>start_line</name>
+    </include>
+    <include>
+      <pose>0 -25 -1 0 0 3.1415926</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabel/models/ABCSign_5m</uri>
+      <name>finish_line</name>
+    </include>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Mabel Zhang <mabel@openrobotics.org>

# 🎉 New feature

## Summary

An example world and controller for a multi-LRAUV swimming race in an underwater environment. Demonstrates how to control the basic set of plugins using a random controller.

Race results vary in every run. Don't take it personally if your favorite LRAUV doesn't win. (Disclosure: they are all the same! Except for their names -- uh oh, shouldn't have said that.)

## Remarks

@arjo129, two things I noticed:
1. `ThrusterPlugin` takes a negative value for going forward. Is that the convention?
   I noticed in the LRAUV model.sdf that the `propeller_joint` is set to negative effort and velocity:
   ```
          <effort>-1</effort>
          <velocity>-1</velocity>
   ```
   Is the actual robot propeller just designed to go forward when rotated in that direction?

2. The robots are going a lot faster here than in our downstream version. All the parameters are the same, and the command values are in the same bounds (other than the thrust being (-31.4 rad/s, 0) as opposed to (0, +31.4 rad/s). Is something different here (did hydrodynamics get faster)?

## Test it

Terminal 1:
```
cd examples/worlds/
ign gazebo -r multi_lrauv_race.sdf
```

Terminal 2:
```
cd examples/standalone/multi_lrauv_race
mkdir build && cd build
cmake ..
make
./multi_lrauv_race
```

You should see something like this:

https://user-images.githubusercontent.com/7608908/120051799-23e1f800-bff0-11eb-894f-295abb4589e7.mp4

## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**