### PR TITLE
Remove unneeded camera follow offset checks

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1644,10 +1644,6 @@ void IgnRenderer::HandleMouseViewControl()
             << std::endl;
   }
 
-  math::Vector3d camWorldPos;
-  if (!this->dataPtr->followTarget.empty())
-    this->dataPtr->camera->WorldPosition();
-
   this->dataPtr->viewControl.SetCamera(this->dataPtr->camera);
 
   if (this->dataPtr->mouseEvent.Type() == common::MouseEvent::SCROLL)
@@ -1700,13 +1696,7 @@ void IgnRenderer::HandleMouseViewControl()
 
 
   if (!this->dataPtr->followTarget.empty())
-  {
-    math::Vector3d dPos = this->dataPtr->camera->WorldPosition() - camWorldPos;
-    if (dPos != math::Vector3d::Zero)
-    {
-      this->dataPtr->followOffsetDirty = true;
-    }
-  }
+    this->dataPtr->followOffsetDirty = true;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

When handling mouse movements in camera follow mode, , there is a check to see if camera has actually moved or not. If it has moved, the camera offset is marked as dirty. However, I found that this check always passes because a variable (`camWorldPos`) is never set. It also looks like the check is just unnecessary and we are just doing additional calculations so I just removed the check.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**


