### PR TITLE
Add bitrate param to camera video recorder system

### DIFF
--- a/src/systems/camera_video_recorder/CameraVideoRecorder.cc
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.cc
@@ -121,6 +121,9 @@ class ignition::gazebo::systems::CameraVideoRecorderPrivate
   /// \brief Use sim time as timestamp during video recording
   /// By default (false), video encoding is done using real time.
   public: bool recordVideoUseSimTime = false;
+
+  /// \brief Video recorder bitrate (bps)
+  public: unsigned int recordVideoBitrate = 2070000;
 };
 
 //////////////////////////////////////////////////
@@ -241,6 +244,10 @@ void CameraVideoRecorder::Configure(
   // Get whether sim time should be used for recording.
   this->dataPtr->recordVideoUseSimTime = _sdf->Get<bool>("use_sim_time",
       this->dataPtr->recordVideoUseSimTime).first;
+
+  // Get video recoder bitrate param
+  this->dataPtr->recordVideoBitrate = _sdf->Get<unsigned int>("bitrate",
+      this->dataPtr->recordVideoBitrate).first;
 
   // recorder stats topic
   std::string recorderStatsTopic = this->dataPtr->sensorTopic + "/stats";
@@ -379,7 +386,8 @@ void CameraVideoRecorderPrivate::OnPostRender()
           &CameraVideoRecorderPrivate::OnImage, this);
 
       this->videoEncoder.Start(this->recordVideoFormat,
-          this->tmpVideoFilename, width, height);
+          this->tmpVideoFilename, width, height, 25,
+          this->recordVideoBitrate);
 
       this->recordStartTime = std::chrono::steady_clock::time_point(
             std::chrono::duration(std::chrono::seconds(0)));


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

By default the video recorder records at a bit rate of 2Mbps. The PR adds a `<bitrate>` param so users can specify custom bitrate.

## Test it

edit `camera_video_record_dbl_pendulum.sdf` example world file, and add `<bitrate>8000000</bitrate>` to the plugin to record a video at 8Mbps.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

