### PR TITLE
Fix mouse view control target position

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1588,6 +1588,7 @@ void IgnRenderer::HandleMouseViewControl()
         // the move event overrides the press event before it is processed)
         // so we double check to see if target is set or not
         (this->dataPtr->mouseEvent.Type() == common::MouseEvent::MOVE &&
+        this->dataPtr->mouseEvent.Dragging() &&
         std::isinf(this->dataPtr->target.X())))
     {
       this->dataPtr->target = this->ScreenToScene(

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -251,7 +251,8 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     public: rendering::RayQueryPtr rayQuery;
 
     /// \brief View control focus target
-    public: math::Vector3d target;
+    public: math::Vector3d target = math::Vector3d(
+        math::INF_D, math::INF_D, math::INF_D);
 
     /// \brief Rendering utility
     public: RenderUtil renderUtil;
@@ -1581,11 +1582,22 @@ void IgnRenderer::HandleMouseViewControl()
   }
   else
   {
-    if (this->dataPtr->mouseEvent.Type() == common::MouseEvent::PRESS)
+    if (this->dataPtr->mouseEvent.Type() == common::MouseEvent::PRESS ||
+        // the rendering thread may miss the press event due to
+        // race condition when doing a drag operation (press and move, where
+        // the move event overrides the press event before it is processed)
+        // so we double check to see if target is set or not
+        (this->dataPtr->mouseEvent.Type() == common::MouseEvent::MOVE &&
+        std::isinf(this->dataPtr->target.X())))
     {
       this->dataPtr->target = this->ScreenToScene(
           this->dataPtr->mouseEvent.PressPos());
       this->dataPtr->viewControl.SetTarget(this->dataPtr->target);
+    }
+    // unset the target on release (by setting to inf)
+    else if (this->dataPtr->mouseEvent.Type() == common::MouseEvent::RELEASE)
+    {
+      this->dataPtr->target = ignition::math::INF_D;
     }
 
     // Pan with left button


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

There is a race condition when processing mouse events for view control which causes unexpected camera movement. 

The mouse events are fired by the Qt thread, and processed by the rendering thread. There are times when we get 2 consecutive events fired in a short period of time before the render thread is able to process the events. This happens for a drag action, which composes of a mouse PRESS event that is immediately followed by MOVE events. The MOVE events overrides the PRESS event before the rendering thread has a chance to process it in view control. Because the PRESS event is not processed, the target / focus point for mouse movement is not set (it retains the old value), you get unexpected large motions of camera movement .

The bug happens in more complex worlds and it may be easier to reproduce on a less powerful machine. For me, I can reproduce the problem in `tunnel.sdf` world:

1. Launch ign-gazebo with tunnel.sdf world: `ign gazebo -v 4 tunnel.sdf`
1. Open Entity Tree plugin
1. Right click on `backpack_1` and select `Move To`
1. Before clicking on anything else, press and drag on `backpack_1` (make sure to press and drag quickly) and see if you get unexpected camera movement
1. If camera movement is correct, move onto another artifact, e.g. `Move to` -> `toolbox_1`, and try the drag action again
1. Repeat step 3. to 5. until you get unexpected camera movement.

For me, it happens around once in 5-10 times in this world. You can also try inserting more complex models like [Urban 2 Story](https://app.ignitionrobotics.org/OpenRobotics/fuel/models/Urban%202%20Story) to increase computational load and slow down rendering.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

