### PR TITLE
Use UINT64_MAX for kComponentTpyeIdInvalid instead of relying on underflow

### DIFF
--- a/include/ignition/gazebo/Types.hh
+++ b/include/ignition/gazebo/Types.hh
@@ -98,7 +98,7 @@ namespace ignition
     static const ComponentId kComponentIdInvalid = -1;
 
     /// \brief Id that indicates an invalid component type.
-    static const ComponentTypeId kComponentTypeIdInvalid = -1;
+    static const ComponentTypeId kComponentTypeIdInvalid = UINT64_MAX;
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
`kComponentTypeIdInvalid` was defined as `-1`. However, the type for this alias variable is `ComponentTypeId`, which is `uint64_t`. So, using `-1` results in underflow. While this _shouldn't_ be a problem if we're always using the alias, I've explicitly set the invalid type alias to `UINT64_MAX` to prevent any weird bugs that may arise from underflow.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**