### PR TITLE
👩‍🌾 Make depth camera tests more robust

### DIFF
--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -34,6 +34,7 @@
 
 using namespace ignition;
 using namespace gazebo;
+using namespace std::chrono_literals;
 
 /// \brief Test DepthCameraTest system
 class DepthCameraTest : public ::testing::Test
@@ -87,15 +88,15 @@ TEST_F(DepthCameraTest, IGN_UTILS_TEST_DISABLED_ON_MAC(DepthCameraBox))
   size_t iters100 = 100u;
   server.Run(true, iters100, false);
 
-  auto waitTime = std::chrono::duration_cast< std::chrono::milliseconds>(
-      std::chrono::duration<double>(0.001));
-  int i = 0;
-  while (i < 300)
+  int sleep{0};
+  int maxSleep{30};
+  while (depthBuffer == nullptr && sleep < maxSleep)
   {
-    std::this_thread::sleep_for(waitTime);
-    i++;
+    std::this_thread::sleep_for(100ms);
+    sleep++;
   }
-  EXPECT_NE(depthBuffer, nullptr);
+  EXPECT_LT(sleep, maxSleep);
+  ASSERT_NE(depthBuffer, nullptr);
 
   // Take into account box of 1 m on each side and 0.05 cm sensor offset
   double expectedRangeAtMidPointBox1 = 2.45;

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -356,9 +356,9 @@ TEST_F(PosePublisherTest, UpdateFrequency)
   std::size_t nExpMessages = 100;
   // Wait for 100 messages to be received
   bool received = false;
-  for (int sleep = 0; sleep < 300; ++sleep)
+  for (int sleep = 0; sleep < 30; ++sleep)
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     {
       std::lock_guard<std::mutex> lock(mutex);
@@ -678,9 +678,9 @@ TEST_F(PosePublisherTest, StaticPoseUpdateFrequency)
   std::size_t nExpMessages = 100;
   // Wait for 100 messages to be received
   bool received = false;
-  for (int sleep = 0; sleep < 300; ++sleep)
+  for (int sleep = 0; sleep < 30; ++sleep)
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     {
       std::lock_guard<std::mutex> lock(mutex);
@@ -738,9 +738,9 @@ TEST_F(PosePublisherTest, NestedModelLoadPlugin)
 
   // Wait for messages to be received
   int sleep = 0;
-  while (poseMsgs.empty() && sleep++ < 300)
+  while (poseMsgs.empty() && sleep++ < 30)
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
   EXPECT_TRUE(!poseMsgs.empty());

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -34,6 +34,7 @@
 
 using namespace ignition;
 using namespace gazebo;
+using namespace std::chrono_literals;
 
 /// \brief Test RgbdCameraTest system
 class RgbdCameraTest : public ::testing::Test
@@ -87,14 +88,14 @@ TEST_F(RgbdCameraTest, IGN_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraBox))
   size_t iters100 = 100u;
   server.Run(true, iters100, false);
 
-  auto waitTime = std::chrono::duration_cast< std::chrono::milliseconds>(
-      std::chrono::duration<double>(0.001));
-  int i = 0;
-  while (nullptr == depthBuffer && i < 500)
+  int sleep{0};
+  int maxSleep{30};
+  while (depthBuffer == nullptr && sleep < maxSleep)
   {
-    std::this_thread::sleep_for(waitTime);
-    i++;
+    std::this_thread::sleep_for(100ms);
+    sleep++;
   }
+  EXPECT_LT(sleep, maxSleep);
   ASSERT_NE(depthBuffer, nullptr);
 
   // Take into account box of 1 m on each side and 0.05 cm sensor offset

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -82,7 +82,7 @@ TEST_P(SceneBroadcasterTest, PoseInfo)
   server.Run(true, 1, false);
 
   unsigned int sleep{0u};
-  unsigned int maxSleep{10u};
+  unsigned int maxSleep{30u};
   // cppcheck-suppress unmatchedSuppression
   // cppcheck-suppress knownConditionTrueFalse
   while (!received && sleep++ < maxSleep)
@@ -468,7 +468,7 @@ TEST_P(SceneBroadcasterTest, State)
 
   // Run server
   unsigned int sleep{0u};
-  unsigned int maxSleep{10u};
+  unsigned int maxSleep{30u};
   while (!received && sleep++ < maxSleep)
   {
     IGN_SLEEP_MS(100);
@@ -592,7 +592,7 @@ TEST_P(SceneBroadcasterTest, StateStatic)
 
   // Run server
   unsigned int sleep{0u};
-  unsigned int maxSleep{10u};
+  unsigned int maxSleep{30u};
   while (!received && sleep++ < maxSleep)
   {
     IGN_SLEEP_MS(100);

--- a/test/integration/thermal_sensor_system.cc
+++ b/test/integration/thermal_sensor_system.cc
@@ -190,7 +190,7 @@ TEST_F(ThermalSensorTest,
 
   // wait for image
   bool received = false;
-  for (unsigned int i = 0; i < 20; ++i)
+  for (unsigned int i = 0; i < 30; ++i)
   {
     {
       std::lock_guard<std::mutex> lock(g_mutex);


### PR DESCRIPTION
Signed-off-by: Louise Poubel <louise@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This test has been flaky on Linux, failing with:

```
165: /var/lib/jenkins/workspace/ignition_gazebo-ci-ign-gazebo5-bionic-amd64/ign-gazebo/test/integration/depth_camera.cc:98: Failure
165: Expected: (depthBuffer) != (nullptr), actual: NULL vs (nullptr)
165/182 Test #165: INTEGRATION_depth_camera ...............................***Exception: SegFault  1.83 sec
```

Here's the test history:

https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo5-bionic-amd64/19/testReport/(root)/INTEGRATION_depth_camera/test_ran/history/

Most likely, it's quitting before it receives the message. This PR allows more time to receive the message, and stops waiting when the message is received.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/207