### PR TITLE
Fix updating GUI plugin on load

### DIFF
--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -105,7 +105,7 @@ void GuiRunner::RequestState()
 /////////////////////////////////////////////////
 void GuiRunner::OnPluginAdded(const QString &_objectName)
 {
-  auto plugin = gui::App()->findChild<GuiSystem *>(_objectName);
+  auto plugin = gui::App()->PluginByName(_objectName.toStdString());
   if (!plugin)
   {
     ignerr << "Failed to get plugin [" << _objectName.toStdString()
@@ -113,7 +113,13 @@ void GuiRunner::OnPluginAdded(const QString &_objectName)
     return;
   }
 
-  plugin->Update(this->updateInfo, this->ecm);
+  auto guiSystem = dynamic_cast<GuiSystem *>(plugin.get());
+
+  // Do nothing for pure ign-gui plugins
+  if (!guiSystem)
+    return;
+
+  guiSystem->Update(this->updateInfo, this->ecm);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Ignition GUI has been sending an empty string until now, see https://github.com/ignitionrobotics/ign-gui/pull/249/. With that fix, the signal will send a unique string instead of the plugin name.

The current code is always getting the first plugin loaded, because they all have empty names. With this fix, the newly added plugin should be correctly got.

If the `ign-gui` PR is released without this fix, users will be spammed with error messages that they can't get the plugin with name `plugin<number>`. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
