### PR TITLE
Fix crash on GUI entity removal with levels

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -181,7 +181,8 @@ namespace ignition
       /// the component.
       /// \param[in] _data Data used to construct the component.
       /// \return A pointer to the component that was created. nullptr is
-      /// returned if the component was not able to be created.
+      /// returned if the component was not able to be created. If _entity
+      /// does not exist, nullptr will be returned.
       public: template<typename ComponentTypeT>
               ComponentTypeT *CreateComponent(
                   const Entity _entity,
@@ -210,7 +211,7 @@ namespace ignition
       /// \param[in] _default The value that should be used to construct
       /// the component in case the component doesn't exist.
       /// \return The component of the specified type assigned to the specified
-      /// entity.
+      /// entity. If _entity does not exist, nullptr is returned.
       public: template<typename ComponentTypeT>
               ComponentTypeT *ComponentDefault(Entity _entity,
               const typename ComponentTypeT::Type &_default =

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -569,6 +569,10 @@ bool EntityComponentManager::CreateComponentImplementation(
     const Entity _entity, const ComponentTypeId _componentTypeId,
     const components::BaseComponent *_data)
 {
+  // make sure that the entity exists
+  if (!this->HasEntity(_entity))
+    return false;
+
   // if this is the first time this component type is being created, make sure
   // the component type to be created is valid
   if (!this->HasComponentType(_componentTypeId) &&
@@ -597,7 +601,7 @@ bool EntityComponentManager::CreateComponentImplementation(
   switch (compAddResult)
   {
     case detail::ComponentAdditionResult::FAILED_ADDITION:
-      ignwarn << "Attempt to create a component of type [" << _componentTypeId
+      ignerr << "Attempt to create a component of type [" << _componentTypeId
         << "] attached to entity [" << _entity << "] failed.\n";
       return false;
     case detail::ComponentAdditionResult::NEW_ADDITION:

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -250,6 +250,27 @@ TEST_P(EntityComponentManagerFixture, EntitiesAndComponents)
   EXPECT_TRUE(manager.EntityHasComponentType(entity, IntComponent::typeId));
   EXPECT_EQ(123, intComp->Data());
 
+  // Try to create/query a component from an entity that does not exist. nullptr
+  // should be returned since a component cannot be attached to a non-existent
+  // entity
+  EXPECT_FALSE(manager.HasEntity(kNullEntity));
+  /*
+   * TODO(adlarkin) test with the following methods once the deprecation
+   * process has been sorted out:
+   *  EntityHasComponent
+   *  EntityHasComponentType
+   */
+  EXPECT_EQ(nullptr, manager.CreateComponent<IntComponent>(kNullEntity,
+        IntComponent(123)));
+  EXPECT_EQ(nullptr, manager.ComponentDefault<IntComponent>(kNullEntity, 123));
+  EXPECT_EQ(nullptr, manager.Component<IntComponent>(kNullEntity));
+  EXPECT_FALSE(manager.ComponentData<IntComponent>(kNullEntity).has_value());
+  EXPECT_EQ(ComponentState::NoChange, manager.ComponentState(kNullEntity,
+        IntComponent::typeId));
+  // (make sure the entity wasn't implicitly created during the invalid
+  // component calls)
+  EXPECT_FALSE(manager.HasEntity(kNullEntity));
+
   // Remove all entities
   manager.RequestRemoveEntities();
   EXPECT_EQ(3u, manager.EntityCount());


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>


# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/pull/856#pullrequestreview-686953945

## Summary
After debugging the segfault pointed out in the link above, it seems like the levels system still tries to add components to entities even after they're removed (I'm not 100% certain if levels is to blame for this, but when I removed an entity in the `shapes.sdf` world, I did not see this behavior). This caused a segfault in #856 because [components are not created if an entity doesn't exist](https://github.com/ignitionrobotics/ign-gazebo/blob/ee3d3d08fe81ced1edc81f48f5792f166d7a1578/src/EntityComponentManager.cc#L599-L602), but the non existing entity (and component) were still [marked as modified](https://github.com/ignitionrobotics/ign-gazebo/blob/ee3d3d08fe81ced1edc81f48f5792f166d7a1578/src/EntityComponentManager.cc#L587-L590). This "mismatch" in data is problematic when [`EntityComponentManagerPrivate::CalculateStateThreadLoad`](https://github.com/ignitionrobotics/ign-gazebo/blob/ee3d3d08fe81ced1edc81f48f5792f166d7a1578/src/EntityComponentManager.cc#L1023) is called in [`EntityComponentmanager::State`](https://github.com/ignitionrobotics/ign-gazebo/blob/ee3d3d08fe81ced1edc81f48f5792f166d7a1578/src/EntityComponentManager.cc#L1089), so, this PR adds a check when calling `EntityComponentManager::CreateComponentImplementation` to make sure that the entity exists.

While the bug fix here ended up being a simple one, I found something interesting when comparing #856 to the `main` branch. In the `main` branch, components are always created, regardless of whether an entity exists or not (I was also able to confirm this by testing the levels world that caused a segfault in #856 - as you can see, there's no checking for if the entity exists): https://github.com/ignitionrobotics/ign-gazebo/blob/c07b49c51caae6da1566c383d2b6ff91f4cb8097/src/EntityComponentManager.cc#L530-L566

So, on the `main` branch, we don't see this segfault since both 1) the component is created, and 2) the (non existent) entity and the component are marked as modified. This actually seems like incorrect behavior to me, and I believe that we should fix `main` (and other released versions as well) to prevent creating components for entities that do not exist. @iche033, what do you think?

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**