### PR TITLE
Make Gazebo aware of SetCameraPassCountPerGpuFlush

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2019,7 +2019,7 @@ void IgnRenderer::Initialize()
 
   auto root = scene->RootVisual();
 
-  scene->SetNumCameraPassesPerGpuFlush( 6u );
+  scene->SetCameraPassCountPerGpuFlush( 6u );
 
   // Camera
   this->dataPtr->camera = scene->CreateCamera();

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2019,7 +2019,7 @@ void IgnRenderer::Initialize()
 
   auto root = scene->RootVisual();
 
-  scene->SetCameraPassCountPerGpuFlush( 6u );
+  scene->SetCameraPassCountPerGpuFlush(6u);
 
   // Camera
   this->dataPtr->camera = scene->CreateCamera();

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -2019,6 +2019,8 @@ void IgnRenderer::Initialize()
 
   auto root = scene->RootVisual();
 
+  scene->SetNumCameraPassesPerGpuFlush( 6u );
+
   // Camera
   this->dataPtr->camera = scene->CreateCamera();
   root->AddChild(this->dataPtr->camera);

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -196,6 +196,7 @@ void SensorsPrivate::WaitForInit()
       igndbg << "Initializing render context" << std::endl;
       this->renderUtil.Init();
       this->scene = this->renderUtil.Scene();
+      this->scene->SetNumCameraPassesPerGpuFlush( 6u );
       this->initialized = true;
     }
 

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -262,6 +262,15 @@ void SensorsPrivate::RunOnce()
       // publish data
       IGN_PROFILE("RunOnce");
       this->sensorManager.RunOnce(this->updateTime);
+    }
+
+    {
+      IGN_PROFILE("PostRender");
+      // Update the scene graph manually to improve performance
+      // We only need to do this once per frame It is important to call
+      // sensors::RenderingSensor::SetManualSceneUpdate and set it to true
+      // so we don't waste cycles doing one scene graph update per sensor
+      this->scene->PostRenderGpuFlush();
       this->eventManager->Emit<events::PostRender>();
     }
 

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -270,7 +270,7 @@ void SensorsPrivate::RunOnce()
       // We only need to do this once per frame It is important to call
       // sensors::RenderingSensor::SetManualSceneUpdate and set it to true
       // so we don't waste cycles doing one scene graph update per sensor
-      this->scene->PostRenderGpuFlush();
+      this->scene->PostRender();
       this->eventManager->Emit<events::PostRender>();
     }
 

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -196,7 +196,7 @@ void SensorsPrivate::WaitForInit()
       igndbg << "Initializing render context" << std::endl;
       this->renderUtil.Init();
       this->scene = this->renderUtil.Scene();
-      this->scene->SetCameraPassCountPerGpuFlush( 6u );
+      this->scene->SetCameraPassCountPerGpuFlush(6u);
       this->initialized = true;
     }
 

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -196,7 +196,7 @@ void SensorsPrivate::WaitForInit()
       igndbg << "Initializing render context" << std::endl;
       this->renderUtil.Init();
       this->scene = this->renderUtil.Scene();
-      this->scene->SetNumCameraPassesPerGpuFlush( 6u );
+      this->scene->SetCameraPassCountPerGpuFlush( 6u );
       this->initialized = true;
     }
 


### PR DESCRIPTION
# 🎉 New feature

See ignitionrobotics/ign-rendering/issues/323

## Summary

ign-rendering has a new feature aimed to improve performance but also fixes a few bugs related to particle simulations; which is controlled via `Scene::SetCameraPassCountPerGpuFlush`.

A value of 0 will use the legacy mode (i.e. previous behavior) to ease porting from older version.
A value > 0 controls performance vs RAM tradeoff (note that it is an upper limit; a very high value doesn't immediately waste RAM. See `Scene::SetCameraPassCountPerGpuFlush` documentation for details)

This PR depends on https://github.com/ignitionrobotics/ign-rendering/pull/353 **otherwise it will not compile**.

## Test it

Just run the code again. This PR changes SetCameraPassCountPerGpuFlush explicitly to 6 to take advantage of the new feature. Set it to 0 for legacy.

As for performance, there won't be _yet_ measurable differences because most sensors are currently downloading rendering data immediately after submitting rendering; which forces a flush per sensor. The final improvement will come when we make use of AsyncTickets in Ogre 2.2

However after the PR it can be immediately tested that particles FXs involving GpuRays behave differently, because pre-PR each cubemap face would be rendered at different timestamps; post-PR they are all rendered at the same timestamp (even in legacy mode).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
