### PR TITLE
Drag and drop mesh into scene

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -38,6 +38,7 @@
 #include <ignition/common/KeyFrame.hh>
 #include <ignition/common/MeshManager.hh>
 #include <ignition/common/Profiler.hh>
+#include <ignition/common/StringUtils.hh>
 #include <ignition/common/Uuid.hh>
 #include <ignition/common/VideoEncoder.hh>
 
@@ -3388,7 +3389,57 @@ void Scene3D::OnDropped(const QString &_drop, int _mouseX, int _mouseY)
   math::Vector3d pos = renderWindow->ScreenToScene({_mouseX, _mouseY});
 
   msgs::EntityFactory req;
-  req.set_sdf_filename(_drop.toStdString());
+  std::string dropStr = _drop.toStdString();
+  if (QUrl(_drop).isLocalFile())
+  {
+    // mesh to sdf model
+    common::rtrim(dropStr);
+    std::string lowerStr = common::lowercase(dropStr);
+
+    if (!common::EndsWith(lowerStr, ".dae")
+          && !common::EndsWith(lowerStr, ".stl"))
+    {
+      ignwarn << "Only DAE and STL meshes are supported."
+              << std::endl;
+      return;
+    }
+
+    // Fixes whitespace
+    dropStr = common::replaceAll(dropStr, "%20", " ");
+
+    std::string filename = common::basename(dropStr);
+    std::vector<std::string> splitName = common::split(filename, ".");
+
+    std::string sdf = "<?xml version='1.0'?>"
+      "<sdf version='1.8'>"
+        "<model name='" + splitName[0] + "'>"
+          "<link name='link'>"
+            "<visual name='visual'>"
+              "<geometry>"
+                "<mesh>"
+                  "<uri>" + dropStr + "</uri>"
+                "</mesh>"
+              "</geometry>"
+            "</visual>"
+            "<collision name='collision'>"
+              "<geometry>"
+                "<mesh>"
+                  "<uri>" + dropStr + "</uri>"
+                "</mesh>"
+              "</geometry>"
+            "</collision>"
+          "</link>"
+        "</model>"
+      "</sdf>";
+
+    req.set_sdf(sdf);
+  }
+  else
+  {
+    // model from fuel
+    req.set_sdf_filename(dropStr);
+  }
+
   req.set_allow_renaming(true);
   msgs::Set(req.mutable_pose(),
       math::Pose3d(pos.X(), pos.Y(), pos.Z(), 1, 0, 0, 0));


### PR DESCRIPTION
# 🎉 New feature

## Summary
Allows a user to drag and drop a DAE or STL mesh into the scene.

![Peek 2021-07-21 13-41](https://user-images.githubusercontent.com/8602001/126558299-8ccd540c-573d-43f6-83fa-e8b33ee6e88c.gif)

## Test it

1. `ign gazebo -v 4`
1. Drag a DAE or STL model and drop it into the scene

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**