### PR TITLE
Suggestions to model CLI (#893)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,11 @@ set(gui_sources
   PARENT_SCOPE
 )
 
-ign_add_component(model SOURCES cmd/ModelCommandAPI.cc GET_TARGET_NAME model_lib_target)
-ign_add_component(ign SOURCES ign.cc GET_TARGET_NAME ign_lib_target)
+ign_add_component(ign
+  SOURCES
+    ign.cc
+    cmd/ModelCommandAPI.cc
+  GET_TARGET_NAME ign_lib_target)
 target_link_libraries(${ign_lib_target}
   PRIVATE
     ${PROJECT_LIBRARY_TARGET_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,7 +140,14 @@ ign_build_tests(TYPE UNIT
     ignition-gazebo${PROJECT_VERSION_MAJOR}
 )
 
-if(TARGET UNIT_ign_TEST)
+# Command line tests need extra settings
+foreach(CMD_TEST
+  UNIT_ign_TEST
+  UNIT_ModelCommandAPI_TEST)
+
+  if(NOT TARGET ${CMD_TEST})
+    continue()
+  endif()
 
   # Running `ign gazebo` on macOS has problems when run with /usr/bin/ruby
   # due to System Integrity Protection (SIP). Try to find ruby from
@@ -149,33 +156,27 @@ if(TARGET UNIT_ign_TEST)
     find_program(BREW_RUBY ruby HINTS /usr/local/opt/ruby/bin)
   endif()
 
-  add_dependencies(UNIT_ign_TEST
+  add_dependencies(${CMD_TEST}
     ${ign_lib_target}
     TestModelSystem
     TestSensorSystem
     TestWorldSystem
   )
 
-  target_compile_definitions(UNIT_ign_TEST PRIVATE
+  target_compile_definitions(${CMD_TEST} PRIVATE
       "BREW_RUBY=\"${BREW_RUBY} \"")
 
-  target_compile_definitions(UNIT_ign_TEST PRIVATE
+  target_compile_definitions(${CMD_TEST} PRIVATE
       "IGN_PATH=\"${IGNITION-TOOLS_BINARY_DIRS}\"")
 
   set(_env_vars)
   list(APPEND _env_vars "IGN_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")
   list(APPEND _env_vars "IGN_GAZEBO_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:TestModelSystem>")
 
-  set_tests_properties(UNIT_ign_TEST PROPERTIES
+  set_tests_properties(${CMD_TEST} PROPERTIES
     ENVIRONMENT "${_env_vars}")
-endif()
 
-if(TARGET UNIT_ModelCommandAPI_TEST)
-
-  target_compile_definitions(UNIT_ModelCommandAPI_TEST PRIVATE
-  "IGN_PATH=\"${IGNITION-TOOLS_BINARY_DIRS}\"")
-
-endif()
+endforeach()
 
 if(NOT WIN32)
   add_subdirectory(cmd)

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -478,6 +478,15 @@ ComponentKey EntityComponentManager::CreateComponentImplementation(
     const Entity _entity, const ComponentTypeId _componentTypeId,
     const components::BaseComponent *_data)
 {
+  // make sure the entity exists
+  if (!this->HasEntity(_entity))
+  {
+    ignerr << "Trying to create a component of type [" << _componentTypeId
+      << "] attached to entity [" << _entity << "], but this entity does not "
+      << "exist. This create component request will be ignored." << std::endl;
+    return ComponentKey();
+  }
+
   // If type hasn't been instantiated yet, create a storage for it
   if (!this->HasComponentType(_componentTypeId))
   {

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -433,6 +433,16 @@ TEST_P(EntityComponentManagerFixture, EntitiesAndComponents)
   EXPECT_FALSE(manager.EntityHasComponentType(entity, DoubleComponent::typeId));
   EXPECT_FALSE(manager.EntityHasComponentType(entity2, IntComponent::typeId));
 
+  // Try to add a component to an entity that does not exist
+  EXPECT_FALSE(manager.HasEntity(kNullEntity));
+  EXPECT_FALSE(manager.EntityHasComponentType(kNullEntity,
+        IntComponent::typeId));
+  EXPECT_EQ(ComponentKey(), manager.CreateComponent<IntComponent>(kNullEntity,
+        IntComponent(123)));
+  EXPECT_FALSE(manager.HasEntity(kNullEntity));
+  EXPECT_FALSE(manager.EntityHasComponentType(kNullEntity,
+        IntComponent::typeId));
+
   // Remove all entities
   manager.RequestRemoveEntities();
   EXPECT_EQ(3u, manager.EntityCount());

--- a/src/ModelCommandAPI_TEST.cc
+++ b/src/ModelCommandAPI_TEST.cc
@@ -15,8 +15,6 @@
  *
 */
 
-#include "cmd/ModelCommandAPI.hh"
-
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -26,8 +24,8 @@
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
 
-static const std::string kIgnModelCommand(std::string(IGN_PATH) +
-                                          "/ign model ");
+static const std::string kIgnModelCommand(
+    std::string(BREW_RUBY) + std::string(IGN_PATH) + "/ign model ");
 
 
 /////////////////////////////////////////////////
@@ -49,6 +47,8 @@ void ReplaceNegativeZeroValues(std::string &_text)
 /////////////////////////////////////////////////
 std::string customExecStr(std::string _cmd)
 {
+  std::cout << "Running command [" << _cmd << "]" << std::endl;
+
   _cmd += " 2>&1";
   FILE *pipe = popen(_cmd.c_str(), "r");
 
@@ -70,6 +70,7 @@ std::string customExecStr(std::string _cmd)
   return result;
 }
 
+/////////////////////////////////////////////////
 // Test `ign model` command when no Gazebo server is running.
 TEST(ModelCommandAPI, NoServerRunning)
 {
@@ -82,6 +83,7 @@ TEST(ModelCommandAPI, NoServerRunning)
   EXPECT_EQ(expectedOutput, output);
 }
 
+/////////////////////////////////////////////////
 // Tests `ign model` command.
 TEST(ModelCommandAPI, Commands)
 {
@@ -117,93 +119,96 @@ TEST(ModelCommandAPI, Commands)
       "\nRequesting state for world [diff_drive]...\n\n"
       "Model: [8]\n"
       "  - Name: vehicle_blue\n"
-      "  - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "  - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "      [0.000000 | 2.000000 | 0.325000]\n"
       "      [0.000000 | 0.000000 | 0.000000]\n"
-      "\n"
       "  - Link [9]\n"
       "    - Name: chassis\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [1.143950]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.126164 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.416519 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.481014]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [-0.151427 | 0.000000 | 0.175000]\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
       "  - Link [12]\n"
       "    - Name: left_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [2.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.145833 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.145833 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.125000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.554283 | 0.625029 | -0.025000]\n"
       "        [-1.570700 | 0.000000 | 0.000000]\n"
       "  - Link [15]\n"
       "    - Name: right_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [2.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.145833 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.145833 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.125000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.554282 | -0.625029 | -0.025000]\n"
       "        [-1.570700 | 0.000000 | 0.000000]\n"
       "  - Link [18]\n"
       "    - Name: caster\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [1.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.100000 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.100000 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.100000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [-0.957138 | 0.000000 | -0.125000]\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
       "  - Joint [21]\n"
       "    - Name: left_wheel_joint\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  revolute\n"
-      "    - Parent Link: left_wheel\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Axis unit vector [ XYZ ]: \n"
-      "      [0 | 0 | 1]\n"
+      "    - Type: revolute\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: left_wheel [12]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Axis unit vector [ XYZ ]:\n"
+      "        [0 | 0 | 1]\n"
       "  - Joint [22]\n"
       "    - Name: right_wheel_joint\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  revolute\n"
-      "    - Parent Link: right_wheel\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Axis unit vector [ XYZ ]: \n"
-      "      [0 | 0 | 1]\n"
+      "    - Type: revolute\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: right_wheel [15]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Axis unit vector [ XYZ ]:\n"
+      "        [0 | 0 | 1]\n"
       "  - Joint [23]\n"
       "    - Name: caster_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  ball\n"
-      "    - Parent Link: caster\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n";
+      "    - Type: ball\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: caster [18]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n";
     EXPECT_EQ(expectedOutput, output);
   }
 
@@ -216,9 +221,9 @@ TEST(ModelCommandAPI, Commands)
       "\nRequesting state for world [diff_drive]...\n\n"
       "Model: [8]\n"
       "  - Name: vehicle_blue\n"
-      "  - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "  - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "      [0.000000 | 2.000000 | 0.325000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n\n";
+      "      [0.000000 | 0.000000 | 0.000000]\n";
     EXPECT_EQ(expectedOutput, output);
   }
 
@@ -234,52 +239,56 @@ TEST(ModelCommandAPI, Commands)
       "    - Name: chassis\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [1.143950]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.126164 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.416519 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.481014]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [-0.151427 | 0.000000 | 0.175000]\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
       "  - Link [12]\n"
       "    - Name: left_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [2.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.145833 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.145833 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.125000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.554283 | 0.625029 | -0.025000]\n"
       "        [-1.570700 | 0.000000 | 0.000000]\n"
       "  - Link [15]\n"
       "    - Name: right_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [2.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.145833 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.145833 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.125000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.554282 | -0.625029 | -0.025000]\n"
       "        [-1.570700 | 0.000000 | 0.000000]\n"
       "  - Link [18]\n"
       "    - Name: caster\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [1.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.100000 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.100000 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.100000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [-0.957138 | 0.000000 | -0.125000]\n"
       "        [0.000000 | 0.000000 | 0.000000]\n";
     EXPECT_EQ(expectedOutput, output);
@@ -297,13 +306,14 @@ TEST(ModelCommandAPI, Commands)
       "    - Name: caster\n"
       "    - Parent: vehicle_blue [8]\n"
       "    - Mass (kg): [1.000000]\n"
-      "    - Inertial Pose:\n"
+      "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Inertial Matrix (kg⋅m^2): \n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Inertial Matrix (kg.m^2):\n"
       "        [0.100000 | 0.000000 | 0.000000]\n"
       "        [0.000000 | 0.100000 | 0.000000]\n"
       "        [0.000000 | 0.000000 | 0.100000]\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "        [-0.957138 | 0.000000 | -0.125000]\n"
       "        [0.000000 | 0.000000 | 0.000000]\n";
     EXPECT_EQ(expectedOutput, output);
@@ -320,34 +330,34 @@ TEST(ModelCommandAPI, Commands)
       "  - Joint [21]\n"
       "    - Name: left_wheel_joint\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  revolute\n"
-      "    - Parent Link: left_wheel\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Axis unit vector [ XYZ ]: \n"
-      "      [0 | 0 | 1]\n"
+      "    - Type: revolute\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: left_wheel [12]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Axis unit vector [ XYZ ]:\n"
+      "        [0 | 0 | 1]\n"
       "  - Joint [22]\n"
       "    - Name: right_wheel_joint\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  revolute\n"
-      "    - Parent Link: right_wheel\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "    - Axis unit vector [ XYZ ]: \n"
-      "      [0 | 0 | 1]\n"
+      "    - Type: revolute\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: right_wheel [15]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "    - Axis unit vector [ XYZ ]:\n"
+      "        [0 | 0 | 1]\n"
       "  - Joint [23]\n"
       "    - Name: caster_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  ball\n"
-      "    - Parent Link: caster\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n";
+      "    - Type: ball\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: caster [18]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n";
     EXPECT_EQ(expectedOutput, output);
   }
 
@@ -362,12 +372,12 @@ TEST(ModelCommandAPI, Commands)
       "  - Joint [23]\n"
       "    - Name: caster_wheel\n"
       "    - Parent: vehicle_blue [8]\n"
-      "    - Type:  ball\n"
-      "    - Parent Link: caster\n"
-      "    - Child Link:  chassis\n"
-      "    - Pose [ XYZ (m) ] [ RPY (rad) ]: \n"
-      "      [0.000000 | 0.000000 | 0.000000]\n"
-      "      [0.000000 | 0.000000 | 0.000000]\n";
+      "    - Type: ball\n"
+      "    - Parent Link: chassis [9]\n"
+      "    - Child Link: caster [18]\n"
+      "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n"
+      "        [0.000000 | 0.000000 | 0.000000]\n";
     EXPECT_EQ(expectedOutput, output);
   }
 }

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -56,12 +56,12 @@ install(FILES ${cmd_model_script_generated} DESTINATION lib/ruby/ignition)
 # Used for the installed version.
 set(ign_model_ruby_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/ignition/cmdmodel${PROJECT_VERSION_MAJOR}")
 
-set(ignmodel_configured "${CMAKE_CURRENT_BINARY_DIR}/ignmodel${PROJECT_VERSION_MAJOR}.yaml")
+set(model_configured "${CMAKE_CURRENT_BINARY_DIR}/model${PROJECT_VERSION_MAJOR}.yaml")
 configure_file(
-  "ignmodel.yaml.in"
-  ${ignmodel_configured})
+  "model.yaml.in"
+  ${model_configured})
 
-install(FILES ${ignmodel_configured} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/)
+install(FILES ${model_configured} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/)
 
 
 #===============================================================================
@@ -115,5 +115,5 @@ file(GENERATE
 set(ign_model_ruby_path "${cmd_model_script_generated_test}")
 
 configure_file(
-  "ignmodel.yaml.in"
-  "${cmd_model_ruby_test_dir}/ignmodel${PROJECT_VERSION_MAJOR}.yaml")
+  "model.yaml.in"
+  "${cmd_model_ruby_test_dir}/model${PROJECT_VERSION_MAJOR}.yaml")

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -43,10 +43,6 @@ install( FILES
 set(cmd_model_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmdmodel${PROJECT_VERSION_MAJOR}.rb")
 set(cmd_model_script_configured "${cmd_model_script_generated}.configured")
 
-# Set the model_library_location variable to the relative path to the library file
-# within the install directory structure.
-set(model_library_location "../../../${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:${model_lib_target}>")
-
 configure_file(
   "cmdmodel.rb.in"
   "${cmd_model_script_configured}"
@@ -105,10 +101,6 @@ configure_file(
 set(cmd_model_ruby_test_dir "${CMAKE_BINARY_DIR}/model/test/lib/ruby/ignition")
 set(cmd_model_script_generated_test "${cmd_model_ruby_test_dir}/cmdmodel${PROJECT_VERSION_MAJOR}.rb")
 set(cmd_model_script_configured_test "${cmd_model_script_generated_test}.configured")
-
-# Set the model_library_location variable to the full path of the library file
-# within the build directory
-set(model_library_location "$<TARGET_FILE:${model_lib_target}>")
 
 configure_file(
   "cmdmodel.rb.in"

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -98,7 +98,7 @@ configure_file(
 #===============================================================================
 # Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.
-set(cmd_model_ruby_test_dir "${CMAKE_BINARY_DIR}/model/test/lib/ruby/ignition")
+set(cmd_model_ruby_test_dir "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition")
 set(cmd_model_script_generated_test "${cmd_model_ruby_test_dir}/cmdmodel${PROJECT_VERSION_MAJOR}.rb")
 set(cmd_model_script_configured_test "${cmd_model_script_generated_test}.configured")
 
@@ -116,4 +116,4 @@ set(ign_model_ruby_path "${cmd_model_script_generated_test}")
 
 configure_file(
   "model.yaml.in"
-  "${cmd_model_ruby_test_dir}/model${PROJECT_VERSION_MAJOR}.yaml")
+  "${CMAKE_BINARY_DIR}/test/conf/model${PROJECT_VERSION_MAJOR}.yaml" @ONLY)

--- a/src/cmd/ModelCommandAPI.cc
+++ b/src/cmd/ModelCommandAPI.cc
@@ -21,8 +21,12 @@
 #include <vector>
 #include <map>
 
+#include <ignition/msgs/serialized.pb.h>
+#include <ignition/msgs/stringmsg.pb.h>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
 #include <ignition/gazebo/components/ChildLinkName.hh>
 #include <ignition/gazebo/components/Inertial.hh>
 #include <ignition/gazebo/components/Joint.hh>
@@ -34,29 +38,28 @@
 #include <ignition/gazebo/components/ParentEntity.hh>
 #include <ignition/gazebo/components/ParentLinkName.hh>
 #include <ignition/gazebo/components/Pose.hh>
-#include <ignition/gazebo/EntityComponentManager.hh>
-#include <ignition/msgs.hh>
-#include <ignition/msgs/serialized.pb.h>
+#include <ignition/gazebo/components/World.hh>
 #include <ignition/transport/Node.hh>
 
-namespace {
+using namespace ignition;
+using namespace gazebo;
 
 //////////////////////////////////////////////////
-// \brief Get the name of the world being used by calling
-// `/gazebo/worlds` service.
-// \return The name of the world if service is available,
-// an empty string otherwise.
+/// \brief Get the name of the world being used by calling
+/// `/gazebo/worlds` service.
+/// \return The name of the world if service is available,
+/// an empty string otherwise.
 std::string getWorldName()
 {
   // Create a transport node.
-  ignition::transport::Node node;
+  transport::Node node;
 
   bool result{false};
   const unsigned int timeout{5000};
   const std::string service{"/gazebo/worlds"};
 
   // Request and block
-  ignition::msgs::StringMsg_V res;
+  msgs::StringMsg_V res;
 
   if (!node.Request(service, timeout, res, result))
   {
@@ -76,10 +79,62 @@ std::string getWorldName()
 }
 
 //////////////////////////////////////////////////
+/// \brief Get entity info: name and entity ID
+/// \param[in] _entity Entity to get info
+/// \param[in] _ecm Entity component manager
+/// \return "<entity name> [<entity ID>]"
+std::string entityInfo(Entity _entity, const EntityComponentManager &_ecm)
+{
+  std::string info;
+
+  const auto nameComp = _ecm.Component<components::Name>( _entity);
+  if (nameComp)
+  {
+    info += nameComp->Data() + " ";
+  }
+  info += "[" + std::to_string(_entity) + "]";
+  return info;
+}
+
+//////////////////////////////////////////////////
+/// \brief Get entity info: name and entity ID
+/// \param[in] _entity Name of entity to get info
+/// \param[in] _ecm Entity component manager
+/// \return "<entity name> [<entity ID>]"
+std::string entityInfo(const std::string &_name,
+    const EntityComponentManager &_ecm)
+{
+  std::string info{_name};
+
+  auto entity = _ecm.EntityByComponents(components::Name(_name));
+  if (kNullEntity != entity)
+  {
+    info += " [" + std::to_string(entity) + "]";
+  }
+  return info;
+}
+
+//////////////////////////////////////////////////
+/// \brief Get pose info in a standard way
+/// \param[in] _pose Pose to print
+/// \param[in] _prefix Indentation prefix for every line
+/// \return Pose formatted in a standard way
+std::string poseInfo(math::Pose3d _pose, const std::string &_prefix)
+{
+  return
+    _prefix + "[" + std::to_string(_pose.X()) + " | "
+                  + std::to_string(_pose.Y()) + " | "
+                  + std::to_string(_pose.Z()) + "]\n" +
+    _prefix + "[" + std::to_string(_pose.Roll()) + " | "
+                  + std::to_string(_pose.Pitch()) + " | "
+                  + std::to_string(_pose.Yaw()) + "]";
+}
+
+//////////////////////////////////////////////////
 // \brief Set the state of a ECM instance with a world snapshot.
 // \param _ecm ECM instance to be populated.
 // \return boolean indicating if it was able to populate the ECM.
-bool populateECM(ignition::gazebo::EntityComponentManager &_ecm)
+bool populateECM(EntityComponentManager &_ecm)
 {
   const std::string world = getWorldName();
   if (world.empty())
@@ -89,7 +144,7 @@ bool populateECM(ignition::gazebo::EntityComponentManager &_ecm)
     return false;
   }
   // Create a transport node.
-  ignition::transport::Node node;
+  transport::Node node;
   bool result{false};
   const unsigned int timeout{5000};
   const std::string service{"/world/" + world + "/state"};
@@ -98,7 +153,7 @@ bool populateECM(ignition::gazebo::EntityComponentManager &_ecm)
             << "]..." << std::endl << std::endl;
 
   // Request and block
-  ignition::msgs::SerializedStepMap res;
+  msgs::SerializedStepMap res;
 
   if (!node.Request(service, timeout, res, result))
   {
@@ -121,90 +176,56 @@ bool populateECM(ignition::gazebo::EntityComponentManager &_ecm)
 
 
 //////////////////////////////////////////////////
-// \brief Print the model pose information.
+// \brief Print the model information.
 // \param[in] _entity Entity of the model requested.
 // \param[in] _ecm ECM ready for requests.
-void printPose(const uint64_t _entity,
-               const ignition::gazebo::EntityComponentManager &_ecm){
-  const auto modelPose = _ecm.EntitiesByComponents(
-    ignition::gazebo::components::ParentEntity(_entity),
-    ignition::gazebo::components::Pose());
-
+void printModelInfo(const uint64_t _entity,
+               const EntityComponentManager &_ecm)
+{
   const auto poseComp =
-      _ecm.Component<ignition::gazebo::components::Pose>(_entity);
+      _ecm.Component<components::Pose>(_entity);
   const auto nameComp =
-      _ecm.Component<ignition::gazebo::components::Name>(_entity);
-  if (poseComp)
+      _ecm.Component<components::Name>(_entity);
+  if (poseComp && nameComp)
   {
-    std::string poseInfo;
-    poseInfo += "\n      [" + std::to_string(poseComp->Data().X()) + " | "
-                            + std::to_string(poseComp->Data().Y()) + " | "
-                            + std::to_string(poseComp->Data().Z()) + "]\n"
-                  "      [" + std::to_string(poseComp->Data().Roll()) + " | "
-                            + std::to_string(poseComp->Data().Pitch()) + " | "
-                            + std::to_string(poseComp->Data().Yaw()) + "]";
-
     std::cout << "Model: [" << _entity << "]" << std::endl
               << "  - Name: " << nameComp->Data() << std::endl
-              << "  - Pose [ XYZ (m) ] [ RPY (rad) ]: "
-              << poseInfo << std::endl << std::endl;
+              << "  - Pose [ XYZ (m) ] [ RPY (rad) ]: " << std::endl
+              << poseInfo(poseComp->Data(), "      ") << std::endl;
   }
 }
 
 //////////////////////////////////////////////////
 // \brief Print the model links information.
-// \param[in] _entity Entity of the model requested.
+// \param[in] _modelEntity Entity of the model requested.
 // \param[in] _ecm ECM ready for requests.
-// \param[in] _linkName Link to be printed, if nullptr, print all links.
-void printLinks(const uint64_t _entity,
-                const ignition::gazebo::EntityComponentManager &_ecm,
+// \param[in] _linkName Link to be printed, if empty, print all links.
+void printLinks(const uint64_t _modelEntity,
+                const EntityComponentManager &_ecm,
                 const std::string &_linkName)
 {
   const auto links = _ecm.EntitiesByComponents(
-  ignition::gazebo::components::ParentEntity(_entity),
-  ignition::gazebo::components::Link());
+      components::ParentEntity(_modelEntity), components::Link());
   for (const auto &entity : links)
   {
-    const auto parentComp =
-        _ecm.Component<ignition::gazebo::components::ParentEntity>(entity);
-
-    const auto nameComp =
-        _ecm.Component<ignition::gazebo::components::Name>(entity);
+    const auto nameComp = _ecm.Component<components::Name>(entity);
 
     if (_linkName.length() && _linkName != nameComp->Data())
         continue;
 
-    if (parentComp)
-    {
-      std::string parentInfo;
-      const auto parentNameComp =
-          _ecm.Component<ignition::gazebo::components::Name>(
-          parentComp->Data());
+    std::cout << "  - Link [" << entity << "]" << std::endl
+              << "    - Name: " << nameComp->Data() << std::endl
+              << "    - Parent: " << entityInfo(_modelEntity, _ecm)
+              << std::endl;
 
-      if (parentNameComp)
-      {
-        parentInfo += parentNameComp->Data() + " ";
-      }
-      parentInfo += "[" + std::to_string(parentComp->Data()) + "]";
-      std::cout << "  - Link [" << entity << "]" << std::endl
-                << "    - Name: " << nameComp->Data() << std::endl
-                << "    - Parent: " << parentInfo << std::endl;
-    }
-
-    const auto inertialComp =
-        _ecm.Component<ignition::gazebo::components::Inertial>(entity);
+    const auto inertialComp = _ecm.Component<components::Inertial>(entity);
 
     if (inertialComp)
     {
-      const auto inertialMatrix =  inertialComp->Data().MassMatrix();
-      const auto massComp = inertialComp->Data().MassMatrix().Mass();
+      const auto inertialMatrix = inertialComp->Data().MassMatrix();
+      const auto mass = inertialComp->Data().MassMatrix().Mass();
 
-      const std::string inertialPose =
-        "\n        [" + std::to_string(inertialComp->Data().Pose().X()) + " | "
-                      + std::to_string(inertialComp->Data().Pose().Y()) + " | "
-                      + std::to_string(inertialComp->Data().Pose().Z()) + "]";
-
-      const std::string massInfo = "[" + std::to_string(massComp) + "]";
+      const std::string massInfo = "[" + std::to_string(mass) + "]";
       const std::string inertialInfo =
             "\n        [" + std::to_string(inertialMatrix.Ixx()) + " | "
                           + std::to_string(inertialMatrix.Ixy()) + " | "
@@ -216,45 +237,34 @@ void printLinks(const uint64_t _entity,
                           + std::to_string(inertialMatrix.Iyz()) + " | "
                           + std::to_string(inertialMatrix.Izz()) + "]";
       std::cout << "    - Mass (kg): " << massInfo << std::endl
-                << "    - Inertial Pose:" << inertialPose << std::endl
+                << "    - Inertial Pose  [ XYZ (m) ] [ RPY (rad) ]:"
+                << std::endl
+                << poseInfo(inertialComp->Data().Pose(), "        ")
+                << std::endl
                 << "    - Inertial Matrix (kg⋅m^2): "
                 << inertialInfo << std::endl;
     }
-      const std::string inertialPose =
-        "\n        [" + std::to_string(inertialComp->Data().Pose().X()) + " | "
-                      + std::to_string(inertialComp->Data().Pose().Y()) + " | "
-                      + std::to_string(inertialComp->Data().Pose().Z()) + "]";
 
-
-    const auto poseComp =
-        _ecm.Component<ignition::gazebo::components::Pose>(entity);
-
+    const auto poseComp = _ecm.Component<components::Pose>(entity);
     if (poseComp)
     {
-      const std::string poseInfo =
-            "\n        [" + std::to_string(poseComp->Data().X()) + " | "
-                          + std::to_string(poseComp->Data().Y()) + " | "
-                          + std::to_string(poseComp->Data().Z()) + "]\n"
-              "        [" + std::to_string(poseComp->Data().Roll()) + " | "
-                          + std::to_string(poseComp->Data().Pitch()) + " | "
-                          + std::to_string(poseComp->Data().Yaw()) + "]";
-
-      std::cout << "    - Pose [ XYZ (m) ] [ RPY (rad) ]: "
-                << poseInfo << std::endl;
+      std::cout << "    - Pose [ XYZ (m) ] [ RPY (rad) ]:" << std::endl
+                << poseInfo(poseComp->Data(), "        ") << std::endl;
     }
   }
 }
 
 //////////////////////////////////////////////////
 // \brief Print the model joints information.
-// \param[in] _entity Entity of the model requested.
+// \param[in] _modelEntity Entity of the model requested.
 // \param[in] _ecm ECM ready for requests.
 // \param[in] _jointName Joint to be printed, if nullptr, print all joints.
-void printJoints(const uint64_t entity,
-                const ignition::gazebo::EntityComponentManager &_ecm,
+void printJoints(const uint64_t _modelEntity,
+                const EntityComponentManager &_ecm,
                 const std::string &_jointName)
 {
-  static const std::map<sdf::JointType, std::string> jointTypes = {
+  static const std::map<sdf::JointType, std::string> jointTypes =
+  {
     {sdf::JointType::REVOLUTE, "revolute"},
     {sdf::JointType::BALL, "ball"},
     {sdf::JointType::CONTINUOUS, "continuous"},
@@ -267,101 +277,95 @@ void printJoints(const uint64_t entity,
   };
 
   const auto joints = _ecm.EntitiesByComponents(
-  ignition::gazebo::components::ParentEntity(entity),
-  ignition::gazebo::components::Joint());
+      components::ParentEntity(_modelEntity), components::Joint());
 
-  for (const auto &_entity : joints)
+  for (const auto &entity : joints)
   {
-    const auto parentComp =
-        _ecm.Component<ignition::gazebo::components::ParentEntity>(_entity);
-
-    const auto nameComp =
-        _ecm.Component<ignition::gazebo::components::Name>(_entity);
+    const auto nameComp = _ecm.Component<components::Name>(entity);
 
     if (_jointName.length() && _jointName != nameComp->Data())
-        continue;
+      continue;
 
-    if (parentComp)
+    std::cout << "  - Joint [" << entity << "]" << std::endl
+              << "    - Name: " << nameComp->Data() << std::endl
+              << "    - Parent: " << entityInfo(_modelEntity, _ecm)
+              << std::endl;
+
+    const auto jointTypeComp = _ecm.Component<components::JointType>(entity);
+    if (jointTypeComp)
     {
-      std::string parentInfo;
-      auto parentNameComp =
-          _ecm.Component<ignition::gazebo::components::Name>(
-          parentComp->Data());
-
-      if (parentNameComp)
-      {
-        parentInfo += parentNameComp->Data() + " ";
-      }
-      parentInfo += "[" + std::to_string(parentComp->Data()) + "]";
-
-      std::cout << "  - Joint [" << _entity << "]" << std::endl
-                << "    - Name: " << nameComp->Data() << std::endl
-                << "    - Parent: " << parentInfo << std::endl;
+      std::cout << "    - Type: " << jointTypes.at(jointTypeComp->Data())
+                << std::endl;
     }
 
-    const auto jointComp =
-        _ecm.Component<ignition::gazebo::components::JointType>(_entity);
     const auto childLinkComp =
-        _ecm.Component<ignition::gazebo::components::ChildLinkName>(_entity);
+        _ecm.Component<components::ChildLinkName>(entity);
     const auto parentLinkComp =
-        _ecm.Component<ignition::gazebo::components::ParentLinkName>(_entity);
-    const auto poseComp =
-        _ecm.Component<ignition::gazebo::components::Pose>(_entity);
-    const auto axisComp =
-        _ecm.Component<ignition::gazebo::components::JointAxis>(_entity);
+        _ecm.Component<components::ParentLinkName>(entity);
 
     if (childLinkComp && parentLinkComp)
     {
-      const std::string poseInfo =
-                "\n      [" + std::to_string(poseComp->Data().X()) + " | "
-                            + std::to_string(poseComp->Data().Y()) + " | "
-                            + std::to_string(poseComp->Data().Z()) + "]\n"
-                  "      [" + std::to_string(poseComp->Data().Roll()) + " | "
-                            + std::to_string(poseComp->Data().Pitch()) + " | "
-                            + std::to_string(poseComp->Data().Yaw()) + "]";
-
-      std::cout << "    - Type:  " << jointTypes.at(jointComp->Data())
-      << "\n"   << "    - Parent Link: " << childLinkComp->Data() << "\n"
-                << "    - Child Link:  " << parentLinkComp->Data() << "\n"
-                << "    - Pose [ XYZ (m) ] [ RPY (rad) ]: "
-                << poseInfo << std::endl;
+      std::cout << "    - Parent Link: "
+                << entityInfo(parentLinkComp->Data(), _ecm) << "\n"
+                << "    - Child Link: "
+                << entityInfo(childLinkComp->Data(), _ecm) << "\n";
     }
+
+    const auto poseComp = _ecm.Component<components::Pose>(entity);
+    if (poseComp)
+    {
+      std::cout << "    - Pose [ XYZ (m) ] [ RPY (rad) ]: " << std::endl
+                << poseInfo(poseComp->Data(), "        ") << std::endl;
+    }
+
+    const auto axisComp = _ecm.Component<components::JointAxis>(entity);
     if (axisComp)
     {
       std::cout << "    - Axis unit vector [ XYZ ]: \n"
-                   "      [" << axisComp->Data().Xyz().X() << " | "
-                             << axisComp->Data().Xyz().Y() << " | "
-                             << axisComp->Data().Xyz().Z() << "]\n";
+                   "        [" << axisComp->Data().Xyz().X() << " | "
+                               << axisComp->Data().Xyz().Y() << " | "
+                               << axisComp->Data().Xyz().Z() << "]\n";
     }
   }
-}
 }
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelList()
 {
-  ignition::gazebo::EntityComponentManager ecm{};
+  EntityComponentManager ecm{};
   if (!populateECM(ecm))
   {
     return;
   }
+
+  auto world = ecm.EntityByComponents(components::World());
+  if (kNullEntity == world)
+  {
+    std::cout << "No world found." << std::endl;
+    return;
+  }
+
   const auto models = ecm.EntitiesByComponents(
-    ignition::gazebo::components::ParentEntity(1),
-    ignition::gazebo::components::Model());
+    components::ParentEntity(world), components::Model());
+
+  if (models.size() == 0)
+  {
+    std::cout << "No models in world [" << world << "]" << std::endl;
+    return;
+  }
 
   std::cout << "Available models:" << std::endl;
 
   for (const auto &m : models)
   {
-    const auto nameComp =
-        ecm.Component<ignition::gazebo::components::Name>(m);
+    const auto nameComp = ecm.Component<components::Name>(m);
     std::cout << "    - " << nameComp->Data() << std::endl;
   }
 }
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelInfo(
-  const char *_model, int _pose, const char *_linkName, const char *_jointName)
+  const char *_modelName, int _pose, const char *_linkName, const char *_jointName)
 {
   std::string linkName{""};
   if (_linkName)
@@ -373,34 +377,32 @@ extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelInfo(
   if (!_pose && !_linkName && !_jointName)
     printAll = true;
 
-  if (!_model)
+  if (!_modelName)
   {
     std::cerr << std::endl << "Model name not found" << std::endl;
     return;
   }
-  const std::string model{_model};
 
-  ignition::gazebo::EntityComponentManager ecm{};
+  EntityComponentManager ecm{};
   if (!populateECM(ecm))
     return;
 
   // Get the desired model entity.
-  auto entity = ecm.EntityByComponents(
-    ignition::gazebo::components::Name(model),
-    ignition::gazebo::components::Model());
+  auto entity = ecm.EntityByComponents(components::Name(_modelName),
+      components::Model());
 
-  if (entity == ignition::gazebo::kNullEntity)
-    std::cout << "No model named <" << model << "> was found" << std::endl;
+  if (entity == kNullEntity)
+    std::cout << "No model named <" << _modelName << "> was found" << std::endl;
 
   // Get the pose of the model
   if (printAll | _pose)
-    printPose(entity, ecm);
+    printModelInfo(entity, ecm);
 
   // Get the links information
   if (printAll | (_linkName != nullptr))
     printLinks(entity, ecm, linkName);
 
-  // Get the links information
+  // Get the joints information
   if (printAll | (_jointName != nullptr))
     printJoints(entity, ecm, jointName);
 }

--- a/src/cmd/ModelCommandAPI.cc
+++ b/src/cmd/ModelCommandAPI.cc
@@ -190,7 +190,7 @@ void printModelInfo(const uint64_t _entity,
   {
     std::cout << "Model: [" << _entity << "]" << std::endl
               << "  - Name: " << nameComp->Data() << std::endl
-              << "  - Pose [ XYZ (m) ] [ RPY (rad) ]: " << std::endl
+              << "  - Pose [ XYZ (m) ] [ RPY (rad) ]:" << std::endl
               << poseInfo(poseComp->Data(), "      ") << std::endl;
   }
 }
@@ -237,11 +237,11 @@ void printLinks(const uint64_t _modelEntity,
                           + std::to_string(inertialMatrix.Iyz()) + " | "
                           + std::to_string(inertialMatrix.Izz()) + "]";
       std::cout << "    - Mass (kg): " << massInfo << std::endl
-                << "    - Inertial Pose  [ XYZ (m) ] [ RPY (rad) ]:"
+                << "    - Inertial Pose [ XYZ (m) ] [ RPY (rad) ]:"
                 << std::endl
                 << poseInfo(inertialComp->Data().Pose(), "        ")
                 << std::endl
-                << "    - Inertial Matrix (kg⋅m^2): "
+                << "    - Inertial Matrix (kg.m^2):"
                 << inertialInfo << std::endl;
     }
 
@@ -314,14 +314,14 @@ void printJoints(const uint64_t _modelEntity,
     const auto poseComp = _ecm.Component<components::Pose>(entity);
     if (poseComp)
     {
-      std::cout << "    - Pose [ XYZ (m) ] [ RPY (rad) ]: " << std::endl
+      std::cout << "    - Pose [ XYZ (m) ] [ RPY (rad) ]:" << std::endl
                 << poseInfo(poseComp->Data(), "        ") << std::endl;
     }
 
     const auto axisComp = _ecm.Component<components::JointAxis>(entity);
     if (axisComp)
     {
-      std::cout << "    - Axis unit vector [ XYZ ]: \n"
+      std::cout << "    - Axis unit vector [ XYZ ]:\n"
                    "        [" << axisComp->Data().Xyz().X() << " | "
                                << axisComp->Data().Xyz().Y() << " | "
                                << axisComp->Data().Xyz().Z() << "]\n";
@@ -365,7 +365,8 @@ extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelList()
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelInfo(
-  const char *_modelName, int _pose, const char *_linkName, const char *_jointName)
+    const char *_modelName, int _pose, const char *_linkName,
+    const char *_jointName)
 {
   std::string linkName{""};
   if (_linkName)

--- a/src/cmd/ModelCommandAPI.hh
+++ b/src/cmd/ModelCommandAPI.hh
@@ -16,22 +16,16 @@
 */
 
 #include "ignition/gazebo/Export.hh"
-#include "ignition/gazebo/Entity.hh"
-#include <ignition/gazebo/EntityComponentManager.hh>
-#include <string>
-
 
 /// \brief External hook to get a list of available models.
 extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelList();
 
 /// \brief External hook to dump model information.
-/// \param[in] _model Model name.
+/// \param[in] _modelName Model name.
 /// \param[in] _pose --pose option.
-/// \param[in] _link --link option.
 /// \param[in] _link_name Link name.
-/// \param[in] _joint --joint option.
 /// \param[in] _joint_name Joint name.
 extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelInfo(
-    const char *_model, int _pose, const char *_linkName,
+    const char *_modelName, int _pose, const char *_linkName,
     const char *_jointName);
 

--- a/src/cmd/cmdmodel.rb.in
+++ b/src/cmd/cmdmodel.rb.in
@@ -29,7 +29,7 @@ require 'date'
 require 'optparse'
 
 # Constants.
-LIBRARY_NAME = '@model_library_location@'
+LIBRARY_NAME = '@library_location@'
 LIBRARY_VERSION = '@PROJECT_VERSION_FULL@'
 COMMON_OPTIONS =
   "  -h [ --help ]              Print this help message.                   \n"\

--- a/src/cmd/cmdmodel.rb.in
+++ b/src/cmd/cmdmodel.rb.in
@@ -25,15 +25,18 @@ else
   include Fiddle
 end
 
-require 'date'
 require 'optparse'
 
 # Constants.
 LIBRARY_NAME = '@library_location@'
 LIBRARY_VERSION = '@PROJECT_VERSION_FULL@'
+
 COMMON_OPTIONS =
-  "  -h [ --help ]              Print this help message.                   \n"\
-  "                                                                        \n"\
+               "  -h [--help]                Print this help message.\n"\
+               "                                                    \n"        +
+               "  --force-version <VERSION>  Use a specific library version.\n"\
+               "                                                    \n"        +
+               '  --versions                 Show the available versions.'
 
 COMMANDS = { 'model' =>
   "Print information about models.\n\n"+
@@ -83,8 +86,8 @@ class Cmd
       opts.banner = usage
 
       opts.on('-h', '--help') do
-          puts usage
-          exit
+        puts usage
+        exit
       end
       opts.on('-m', '--model [arg]', String, 'Model name') do |m|
         options['model_name'] = m
@@ -118,22 +121,22 @@ class Cmd
 
     # Check that there is at least one command and there is a plugin that knows
     # how to handle it.
-    if ARGV.empty? || !COMMANDS.key?(ARGV[0])
-     puts usage
-     exit(-1)
-   end
+    if ARGV.empty? || !COMMANDS.key?(ARGV[0]) ||
+       options.empty?
+      puts usage
+      exit(-1)
+    end
 
     # Check that an option was selected.
-    if options.length == 5
+    if !(options.key?('list') || options.key?('model_name'))
      puts usage
      exit(-1)
-   end
+    end
 
     options['command'] = args[0]
 
     options
   end # parse()
-
 
   def execute(args)
     options = parse(args)
@@ -156,7 +159,6 @@ class Cmd
       puts "Library error for [#{plugin}]: #{e.to_s}"
       exit(-1)
     end
-
 
     if options.key?('list')
       Importer.extern 'void cmdModelList()'

--- a/src/cmd/cmdmodel.rb.in
+++ b/src/cmd/cmdmodel.rb.in
@@ -87,7 +87,7 @@ class Cmd
           exit
       end
       opts.on('-m', '--model [arg]', String, 'Model name') do |m|
-        options['model'] = m
+        options['model_name'] = m
       end
       opts.on('--list', String, 'List models available') do
         options['list'] = 1
@@ -162,10 +162,10 @@ class Cmd
       Importer.extern 'void cmdModelList()'
       Importer.cmdModelList()
       exit(0)
-    elsif options.key?('model')
-      Importer.extern 'void cmdModelInfo(const char *, int, const char *, 
+    elsif options.key?('model_name')
+      Importer.extern 'void cmdModelInfo(const char *, int, const char *,
           const char *)'
-      Importer.cmdModelInfo(options['model'], options['pose'], 
+      Importer.cmdModelInfo(options['model_name'], options['pose'],
       options['link_name'], options['joint_name'])
     else
       puts 'Command error: I do not have an implementation for '\

--- a/src/cmd/ignmodel.yaml.in
+++ b/src/cmd/ignmodel.yaml.in
@@ -1,6 +1,6 @@
---- # Subcommands available inside ignition-model.
+--- # Model subcommand available inside ignition gazebo.
 format: 1.0.0
-library_name: ignition-model
+library_name: ignition-gazebo-ign-model
 library_version: @PROJECT_VERSION_FULL@
 library_path: @ign_model_ruby_path@
 commands:

--- a/src/cmd/model.yaml.in
+++ b/src/cmd/model.yaml.in
@@ -1,6 +1,6 @@
 --- # Model subcommand available inside ignition gazebo.
 format: 1.0.0
-library_name: ignition-gazebo-ign-model
+library_name: ignition-gazebo-ign
 library_version: @PROJECT_VERSION_FULL@
 library_path: @ign_model_ruby_path@
 commands:

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -238,7 +238,6 @@ void DiffDrive::Configure(const Entity &_entity,
     this->dataPtr->limiterAng->SetMaxJerk(maxJerk);
   }
 
-
   double odomFreq = _sdf->Get<double>("odom_publish_frequency", 50).first;
   if (odomFreq > 0)
   {
@@ -324,6 +323,10 @@ void DiffDrive::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
 
   for (Entity joint : this->dataPtr->leftJoints)
   {
+    // skip this entity if it has been removed
+    if (!_ecm.HasEntity(joint))
+      continue;
+
     // Update wheel velocity
     auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
 
@@ -340,6 +343,10 @@ void DiffDrive::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
 
   for (Entity joint : this->dataPtr->rightJoints)
   {
+    // skip this entity if it has been removed
+    if (!_ecm.HasEntity(joint))
+      continue;
+
     // Update wheel velocity
     auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
 
@@ -358,7 +365,7 @@ void DiffDrive::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   // don't exist.
   auto leftPos = _ecm.Component<components::JointPosition>(
       this->dataPtr->leftJoints[0]);
-  if (!leftPos)
+  if (!leftPos && _ecm.HasEntity(this->dataPtr->leftJoints[0]))
   {
     _ecm.CreateComponent(this->dataPtr->leftJoints[0],
         components::JointPosition());
@@ -366,7 +373,7 @@ void DiffDrive::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
 
   auto rightPos = _ecm.Component<components::JointPosition>(
       this->dataPtr->rightJoints[0]);
-  if (!rightPos)
+  if (!rightPos && _ecm.HasEntity(this->dataPtr->rightJoints[0]))
   {
     _ecm.CreateComponent(this->dataPtr->rightJoints[0],
         components::JointPosition());

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -25,7 +25,7 @@ Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 * \subpage logicalaudiosensor "Logical Audio Sensor": Using the LogicalAudioSensor system to mimic logical audio emission and detection in simulation.
 * \subpage videorecorder "Video Recorder": Record videos from the 3D render window.
 * \subpage model_and_optimize_meshes  "Model and optimize meshes": Some recomendations when creating meshes  in blender for simulations.
-* \subpage model_command "Model Command": Print information about models.
+* \subpage model_command "Model Command": Use the CLI to get information about the models in a simulation.
 
 **Migration from Gazebo classic**
 

--- a/tutorials/model_command.md
+++ b/tutorials/model_command.md
@@ -10,7 +10,7 @@ For each model, it is possible to get information about its
 
 ## Example running the diff_drive world
 
-To try out this command we need first a running simulation. Let's load the diff_drive ignition simulation. In a terminal, run:
+To try out this command we need first a running simulation. Let's load the `diff_drive` example world. In a terminal, run:
 
     ign gazebo diff_drive.sdf
 
@@ -29,7 +29,7 @@ And available models should be printed:
 
 Once you get the name of the model you want to see, you may run the following commands to get its properties.
 
-`ign model -m <model_name>` to get the **complete information of the model**. e.g. 
+`ign model -m <model_name>` to get the **complete information of the model**. e.g.
 
     ign model -m vehicle_blue
 
@@ -38,7 +38,7 @@ Once you get the name of the model you want to see, you may run the following co
 
 			Model: [8]
 			- Name: vehicle_blue
-			- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+			- Pose [ XYZ (m) ] [ RPY (rad) ]:
 					[0.000000 | 2.000000 | 0.325000]
 					[0.000000 | 0.000000 | 0.000000]
 
@@ -48,11 +48,11 @@ Once you get the name of the model you want to see, you may run the following co
 					- Mass (kg): [1.143950]
 					- Inertial Pose:
 							[0.000000 | 0.000000 | 0.000000]
-					- Inertial Matrix (kg⋅m^2): 
+					- Inertial Matrix (kg⋅m^2):
 							[0.126164 | 0.000000 | 0.000000]
 							[0.000000 | 0.416519 | 0.000000]
 							[0.000000 | 0.000000 | 0.481014]
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 							[-0.151427 | 0.000000 | 0.175000]
 							[0.000000 | 0.000000 | 0.000000]
 			- Link [12]
@@ -61,11 +61,11 @@ Once you get the name of the model you want to see, you may run the following co
 					- Mass (kg): [2.000000]
 					- Inertial Pose:
 							[0.000000 | 0.000000 | 0.000000]
-					- Inertial Matrix (kg⋅m^2): 
+					- Inertial Matrix (kg⋅m^2):
 							[0.145833 | 0.000000 | 0.000000]
 							[0.000000 | 0.145833 | 0.000000]
 							[0.000000 | 0.000000 | 0.125000]
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 							[0.554283 | 0.625029 | -0.025000]
 							[-1.570700 | 0.000000 | 0.000000]
 			- Link [15]
@@ -74,11 +74,11 @@ Once you get the name of the model you want to see, you may run the following co
 					- Mass (kg): [2.000000]
 					- Inertial Pose:
 							[0.000000 | 0.000000 | 0.000000]
-					- Inertial Matrix (kg⋅m^2): 
+					- Inertial Matrix (kg⋅m^2):
 							[0.145833 | 0.000000 | 0.000000]
 							[0.000000 | 0.145833 | 0.000000]
 							[0.000000 | 0.000000 | 0.125000]
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 							[0.554282 | -0.625029 | -0.025000]
 							[-1.570700 | 0.000000 | 0.000000]
 			- Link [18]
@@ -87,11 +87,11 @@ Once you get the name of the model you want to see, you may run the following co
 					- Mass (kg): [1.000000]
 					- Inertial Pose:
 							[0.000000 | 0.000000 | 0.000000]
-					- Inertial Matrix (kg⋅m^2): 
+					- Inertial Matrix (kg⋅m^2):
 							[0.100000 | 0.000000 | 0.000000]
 							[0.000000 | 0.100000 | 0.000000]
 							[0.000000 | 0.000000 | 0.100000]
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 							[-0.957138 | 0.000000 | -0.125000]
 							[0.000000 | 0.000000 | 0.000000]
 			- Joint [21]
@@ -100,10 +100,10 @@ Once you get the name of the model you want to see, you may run the following co
 					- Type:  revolute
 					- Parent Link: left_wheel
 					- Child Link:  chassis
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 					[0.000000 | 0.000000 | 0.000000]
 					[0.000000 | 0.000000 | 0.000000]
-					- Axis position [ XYZ ]: 
+					- Axis position [ XYZ ]:
 					[0 | 0 | 1]
 			- Joint [22]
 					- Name: right_wheel_joint
@@ -111,10 +111,10 @@ Once you get the name of the model you want to see, you may run the following co
 					- Type:  revolute
 					- Parent Link: right_wheel
 					- Child Link:  chassis
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 					[0.000000 | 0.000000 | 0.000000]
 					[0.000000 | 0.000000 | 0.000000]
-					- Axis position [ XYZ ]: 
+					- Axis position [ XYZ ]:
 					[0 | 0 | 1]
 			- Joint [23]
 					- Name: caster_wheel
@@ -122,14 +122,14 @@ Once you get the name of the model you want to see, you may run the following co
 					- Type:  ball
 					- Parent Link: caster
 					- Child Link:  chassis
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 					[0.000000 | 0.000000 | 0.000000]
 					[0.000000 | 0.000000 | 0.000000]
 
 ```
 
 
-`ign model -m <model_name> --pose` to get the **pose** information. e.g. 
+`ign model -m <model_name> --pose` to get the **pose** information. e.g.
 
     ign model -m vehicle_blue --pose
 
@@ -145,12 +145,12 @@ Once you get the name of the model you want to see, you may run the following co
 ```
 
 
-To get the information of **all the model links** enter 
+To get the information of **all the model links** enter
 
     ign model -m <model_name> --link
 
 
-Or you can get the information of a **single link** by adding the name as argument. e.g. 
+Or you can get the information of a **single link** by adding the name as argument. e.g.
 
     ign model -m vehicle_blue --link caster
 
@@ -163,21 +163,21 @@ Or you can get the information of a **single link** by adding the name as argume
 					- Mass (kg): [1.000000]
 					- Inertial Pose:
 							[0.000000 | 0.000000 | 0.000000]
-					- Inertial Matrix (kg⋅m^2): 
+					- Inertial Matrix (kg⋅m^2):
 							[0.100000 | 0.000000 | 0.000000]
 							[0.000000 | 0.100000 | 0.000000]
 							[0.000000 | 0.000000 | 0.100000]
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 							[-0.957138 | 0.000000 | -0.125000]
 							[0.000000 | -0.000000 | 0.000000]
 ```
 
 
-To get the information of **all the model joints** enter 
+To get the information of **all the model joints** enter
 
     ign model -m <model_name> --joint
 
-Or you can get the information of a **single joint** by adding the name as argument. e.g. 
+Or you can get the information of a **single joint** by adding the name as argument. e.g.
 
     ign model -m vehicle_blue --joint caster_wheel
 
@@ -190,7 +190,7 @@ Or you can get the information of a **single joint** by adding the name as argum
 					- Type:  ball
 					- Parent Link: caster
 					- Child Link:  chassis
-					- Pose [ XYZ (m) ] [ RPY (rad) ]: 
+					- Pose [ XYZ (m) ] [ RPY (rad) ]:
 						[0.000000 | 0.000000 | 0.000000]
 						[0.000000 | -0.000000 | 0.000000]
 ```


### PR DESCRIPTION
Pull request #893 is working well for me. These are some suggestions ranging from small styling nitpicks (indentation, empty spaces) to large infrastructure changes (no separate component).

Everything is a suggestion, let me know what you think, @WagnerMarcos !

Here's a summary of the changes:

* Don't create a separate `model` component, because this would make users install a new `libignition-gazebo3-model.so` library). Instead, put the new functionality into the existing `ign` component / library. I kept the yaml and ruby files separate, which I think addresses the concerns in https://github.com/ignitionrobotics/ign-gazebo/pull/893#discussion_r673146560
* (hopefully) made the new test pass on macOS by applying all the logic that's applied to `ign_TEST` (these are the changes with `CMD_TEST`, as well as `BREW*`)
* Various styling updates to the output:
    * Consistent indentation
    * Removed double spaces, or spaces at the end of a line
    * Consistent entity + name printing (added helper function `entityInfo`) - some entities missed their IDs
    * Consistent pose printing (added helper function `poseInfo`) - the inertial pose was missing RPY
* Fixed joint parent and child links, which were swapped
* Fixed running the `ign model` command without arguments (now it prints help)
* Using `ignition::gazebo` namespace to make code shorter and more readable
* Did more null pointer checking for the components
* Removed the hardcoded world entity as 1 (that assumption may change)