### PR TITLE
Add a way to perform startup checks using `TestFixture`.

### DIFF
--- a/examples/standalone/gtest_setup/gravity_TEST.cc
+++ b/examples/standalone/gtest_setup/gravity_TEST.cc
@@ -64,6 +64,16 @@ TEST(ExampleTests, Gravity)
       iterations++;
     });
 
+  fixture.OnConfigure(
+    [](const Entity &_entity,
+      const std::shared_ptr<const sdf::Element> &_sdf,
+      EntityComponentManager &_ecm,
+      EventManager &_eventMgr)> _cb)
+    {
+      std::cout << "Configure " <<std::endl;
+    }
+  );
+
   // Setup simulation server
   fixture.Server()->Run(true, 1000, false);
 

--- a/include/ignition/gazebo/TestFixture.hh
+++ b/include/ignition/gazebo/TestFixture.hh
@@ -43,7 +43,7 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 ///   const gazebo::EntityComponentManager &_ecm)
 ///   {
 ///     // Add expectations here
-///   }
+///   }.Finalize(); // Important to initiallize the system
 ///
 /// // Run the server
 /// fixture.Server()->Run(true, 1000, false);
@@ -84,6 +84,9 @@ class TestFixture
   /// \return Reference to self.
   public: TestFixture &OnPostUpdate(std::function<void(
       const UpdateInfo &, const EntityComponentManager &)> _cb);
+
+  /// \brief Finalize all the functions and add fixture to server.
+  public: TestFixture &Finalize();
 
   /// \brief Get pointer to underlying server.
   public: std::shared_ptr<gazebo::Server> Server() const;

--- a/include/ignition/gazebo/TestFixture.hh
+++ b/include/ignition/gazebo/TestFixture.hh
@@ -61,6 +61,15 @@ class TestFixture
   /// \brief Wrapper around a system's pre-update callback
   /// \param[in] _cb Function to be called every pre-update
   /// \return Reference to self.
+  public: TestFixture &OnConfigure(std::function<void(
+      const Entity &_entity,
+      const std::shared_ptr<const sdf::Element> &_sdf,
+      EntityComponentManager &_ecm,
+      EventManager &_eventMgr)> _cb);
+
+  /// \brief Wrapper around a system's pre-update callback
+  /// \param[in] _cb Function to be called every pre-update
+  /// \return Reference to self.
   public: TestFixture &OnPreUpdate(std::function<void(
       const UpdateInfo &, EntityComponentManager &)> _cb);
 

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -42,6 +42,7 @@
 
 #include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/Conversions.hh"
+#include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/EventManager.hh"
 #include "ignition/gazebo/Export.hh"
@@ -174,16 +175,33 @@ namespace ignition
 
       /// \brief Add system after the simulation runner has been instantiated
       /// \note This actually adds system to a queue. The system is added to the
-      /// runner at the begining of the a simulation cycle (call to Run)
-      /// \param[in] _system System to be added
-      /// \tparam SystemType It may be `const SystemPluginPtr &` or `System *`.
+      /// runner at the begining of the a simulation cycle (call to Run). It is
+      /// also responsible for calling `Configure` on the system.
+      /// \param[in] _system SystemPluginPtr to be added
+      /// \param[in] _entity Entity of system to be added. Nullopt if system
+      /// doesn't connect to an entity.
+      /// \param[in] _sdf Pointer to the SDF of the entity. Nullopt defaults to
+      /// world.
       public:
-      template<typename SystemType>
-      void AddSystem(SystemType _system)
-      {
-        std::lock_guard<std::mutex> lock(this->pendingSystemsMutex);
-        this->pendingSystems.push_back(SystemInternal(_system));
-      }
+      void AddSystem(
+        const SystemPluginPtr& _system,
+        std::optional<Entity> _entity = std::nullopt,
+        std::optional<sdf::ElementPtr> _sdf = std::nullopt);
+
+      /// \brief Add system after the simulation runner has been instantiated
+      /// \note This actually adds system to a queue. The system is added to the
+      /// runner at the begining of the a simulation cycle (call to Run). It is
+      /// also responsible for calling `Configure` on the system.
+      /// \param[in] _system System to be added
+      /// \param[in] _entity Entity of system to be added. Nullopt if system
+      /// doesn't connect to an entity.
+      /// \param[in] _sdf Pointer to the SDF of the entity. Nullopt defaults to
+      /// world.
+      public:
+      void AddSystem(
+        System * _system,
+        std::optional<Entity> _entity = std::nullopt,
+        std::optional<sdf::ElementPtr> _sdf = std::nullopt);
 
       /// \brief Update all the systems
       public: void UpdateSystems();

--- a/src/TestFixture.cc
+++ b/src/TestFixture.cc
@@ -41,10 +41,18 @@ using namespace gazebo;
 /// \brief
 class HelperSystem :
   public System,
+  public ISystemConfigure,
   public ISystemPreUpdate,
   public ISystemUpdate,
   public ISystemPostUpdate
 {
+  // Documentation inherited
+  public: void Configure(
+                const Entity &_entity,
+                const std::shared_ptr<const sdf::Element> &_sdf,
+                EntityComponentManager &_ecm,
+                EventManager &_eventMgr) override;
+
   // Documentation inherited
   public: void PreUpdate(const UpdateInfo &_info,
                 EntityComponentManager &_ecm) override;
@@ -55,7 +63,14 @@ class HelperSystem :
 
   // Documentation inherited
   public: void PostUpdate(const UpdateInfo &_info,
-              const EntityComponentManager &_ecm) override;
+                const EntityComponentManager &_ecm) override;
+
+  /// \brief Function to call every time  we configure a world
+  public: std::function<void(const Entity &_entity,
+                const std::shared_ptr<const sdf::Element> &_sdf,
+                EntityComponentManager &_ecm,
+                EventManager &_eventMgr)>
+      configureCallback;
 
   /// \brief Function to call every pre-update
   public: std::function<void(const UpdateInfo &, EntityComponentManager &)>
@@ -69,6 +84,17 @@ class HelperSystem :
   public: std::function<void(const UpdateInfo &,
       const EntityComponentManager &)> postUpdateCallback;
 };
+
+/////////////////////////////////////////////////
+void HelperSystem::Configure(
+                const Entity &_entity,
+                const std::shared_ptr<const sdf::Element> &_sdf,
+                EntityComponentManager &_ecm,
+                EventManager &_eventMgr)
+{
+  if (this->configureCallback)
+    this->configureCallback(_entity, _sdf, _ecm, _eventMgr);
+}
 
 /////////////////////////////////////////////////
 void HelperSystem::PreUpdate(const UpdateInfo &_info,
@@ -118,6 +144,18 @@ void TestFixture::Implementation::Init(const ServerConfig &_config)
 
   this->server = std::make_shared<gazebo::Server>(_config);
   this->server->AddSystem(systemPtr);
+}
+
+//////////////////////////////////////////////////
+TestFixture &TestFixture::OnConfigure(std::function<void(
+          const Entity &_entity,
+          const std::shared_ptr<const sdf::Element> &_sdf,
+          EntityComponentManager &_ecm,
+          EventManager &_eventMgr)> _cb)
+{
+  if (nullptr != this->dataPtr->helperSystem)
+    this->dataPtr->helperSystem->configureCallback = std::move(_cb);
+  return *this;
 }
 
 //////////////////////////////////////////////////

--- a/src/TestFixture.cc
+++ b/src/TestFixture.cc
@@ -140,10 +140,15 @@ TestFixture::TestFixture(const ServerConfig &_config)
 void TestFixture::Implementation::Init(const ServerConfig &_config)
 {
   this->helperSystem = new HelperSystem();
-  auto systemPtr = dynamic_cast<System *>(this->helperSystem);
-
   this->server = std::make_shared<gazebo::Server>(_config);
-  this->server->AddSystem(systemPtr);
+}
+
+//////////////////////////////////////////////////
+TestFixture &TestFixture::Finalize()
+{
+  auto systemPtr = dynamic_cast<System *>(this->dataPtr->helperSystem);
+  this->dataPtr->server->AddSystem(systemPtr);
+  return *this;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

## Summary
This PR targets #926. It adds a way to perform setup time checks to the test fixture. Whats new is that there is an `OnConfigure` API to perform first time test fixtures.
```
 fixture.
  OnConfigure(
    [&worldEntity, &modelEntity](const ignition::gazebo::Entity &_entity,
      const std::shared_ptr<const sdf::Element> &_sdf,
      ignition::gazebo::EntityComponentManager &_ecm,
      ignition::gazebo::EventManager &_eventMgr)
    {
      worldEntity = ignition::gazebo::worldEntity(_ecm);
      ignition::gazebo::World world(worldEntity);

      modelEntity = world.ModelByName(_ecm, "sphere");
      EXPECT_NE(ignition::gazebo::kNullEntity, modelEntity);
    })
```


## Test it
The same procedure as in #926. 
```bash
    cd examples/standalone/gtest_setup
    mkdir build
    cd build
    cmake ..
    make
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

