### PR TITLE
Fix tests that use multiple root level models or lights

### DIFF
--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -114,8 +114,6 @@ TEST_F(UserCommandsTest, Create)
       "<sdf version='1.6'>" +
       "<light name='accepted_light' type='directional'>" +
       "</light>" +
-      "<light name='ignored_light' type='directional'>" +
-      "</light>" +
       "</sdf>";
 
   auto badStr = std::string("<?xml version='1.0' ?>") +

--- a/test/worlds/models/include_nested/model.sdf
+++ b/test/worlds/models/include_nested/model.sdf
@@ -41,27 +41,4 @@
       <pose relative_to="include_nested_frame_01">0 0 0 0 0 0</pose>
     </link>
   </model>
-
-  <!-- As the second model in an included file, this should be ignored or
-  eventually cause an error. For now, the duplicate is to ensure that the model
-  of the same name in 'nested_models' is added and not this one -->
-  <model name="model_01">
-    <link name="link_01">
-      <pose>0 0 0 0 0 0</pose>
-      <collision name="collision_01">
-        <geometry>
-          <box>
-            <size>1 1 1</size>
-          </box>
-        </geometry>
-      </collision>
-      <visual name="visual_01">
-        <geometry>
-          <box>
-            <size>1 1 1</size>
-          </box>
-        </geometry>
-      </visual>
-    </link>
-  </model>
 </sdf>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
libsdformat11 issued warnings when multiple root level models, lights,
or actors are found in a single file. In libsdformat12, these are now
errors.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
