### PR TITLE
Fix joint controller with empty joint velocity data

### DIFF
--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -208,19 +208,22 @@ void JointController::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   // Force mode.
   if (this->dataPtr->useForceCommands)
   {
-    double error = jointVelComp->Data().at(0) - targetVel;
-    double force = this->dataPtr->velPid.Update(error, _info.dt);
+    if (!jointVelComp->Data().empty())
+    {
+      double error = jointVelComp->Data().at(0) - targetVel;
+      double force = this->dataPtr->velPid.Update(error, _info.dt);
 
-    auto forceComp =
-        _ecm.Component<components::JointForceCmd>(this->dataPtr->jointEntity);
-    if (forceComp == nullptr)
-    {
-      _ecm.CreateComponent(this->dataPtr->jointEntity,
-                           components::JointForceCmd({force}));
-    }
-    else
-    {
-      forceComp->Data()[0] = force;
+      auto forceComp =
+          _ecm.Component<components::JointForceCmd>(this->dataPtr->jointEntity);
+      if (forceComp == nullptr)
+      {
+        _ecm.CreateComponent(this->dataPtr->jointEntity,
+                             components::JointForceCmd({force}));
+      }
+      else
+      {
+        forceComp->Data()[0] = force;
+      }
     }
   }
   // Velocity mode.
@@ -236,7 +239,7 @@ void JointController::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
           this->dataPtr->jointEntity,
           components::JointVelocityCmd({targetVel}));
     }
-    else
+    else if (!vel->Data().empty())
     {
       vel->Data()[0] = targetVel;
     }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Joint controller system assumes that joint velocity data is always available and tries to access the data by indexing into an `std::vector` object. However, if the physics system is not loaded, the vector will be empty and the system will throw an `'std::out_of_range'` error. This PR checks for empty vector before doing any indexing.

One example of this happening is when trying to run the collada exporter of a model that has a joint controller but in a world without the physics system. 

To reproduce:

Here's the world file

<details> <summary> tmp_world.sdf </summary>

```
<sdf version="1.6">
  <world name="marble_hd2_sensor_config_1">
    <plugin 
      filename="ignition-gazebo-collada-world-exporter-system" 
      name="ignition::gazebo::systems::ColladaWorldExporter">
    </plugin>
    <include>
      <static>true</static>
      <name>body</name>
      <pose>0 0 0 0 0 0</pose>
      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/marble_hd2_sensor_config_1</uri>
    </include>
  </world> 
</sdf>
```
</details>

and run this cmd:

```
ign gazebo -s -r --iterations 1 tmp_world.sdf
```

Without the changes in this PR, you should get a crash with backtrace pointing to the joint controller system

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

