### PR TITLE
removed unneeded plugin update

### DIFF
--- a/include/ignition/gazebo/gui/GuiRunner.hh
+++ b/include/ignition/gazebo/gui/GuiRunner.hh
@@ -48,10 +48,6 @@ class IGNITION_GAZEBO_VISIBLE GuiRunner : public QObject
   /// \brief Destructor
   public: ~GuiRunner() override;
 
-  /// \brief Callback when a plugin has been added.
-  /// \param[in] _objectName Plugin's object name.
-  public slots: void OnPluginAdded(const QString &_objectName);
-
   /// \brief Make a new state request to the server.
   public slots: void RequestState();
 

--- a/include/ignition/gazebo/gui/GuiRunner.hh
+++ b/include/ignition/gazebo/gui/GuiRunner.hh
@@ -48,6 +48,11 @@ class IGNITION_GAZEBO_VISIBLE GuiRunner : public QObject
   /// \brief Destructor
   public: ~GuiRunner() override;
 
+  /// \brief Callback when a plugin has been added.
+  /// This function has no effect and is left here for ABI compatibility.
+  /// \param[in] _objectName Plugin's object name.
+  public slots: void OnPluginAdded(const QString &_objectName);
+
   /// \brief Make a new state request to the server.
   public slots: void RequestState();
 

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -176,8 +176,6 @@ std::unique_ptr<ignition::gui::Application> createGui(
     // which makes it complicated to mix configurations across worlds.
     // We could have a way to use world-agnostic topics like Gazebo-classic's ~
     auto runner = new ignition::gazebo::GuiRunner(worldsMsg.data(0));
-    runner->connect(app.get(), &ignition::gui::Application::PluginAdded, runner,
-        &ignition::gazebo::GuiRunner::OnPluginAdded);
     ++runnerCount;
     runner->setParent(ignition::gui::App());
 
@@ -214,8 +212,6 @@ std::unique_ptr<ignition::gui::Application> createGui(
 
       // GUI runner
       auto runner = new ignition::gazebo::GuiRunner(worldName);
-      runner->connect(app.get(), &ignition::gui::Application::PluginAdded,
-                      runner, &ignition::gazebo::GuiRunner::OnPluginAdded);
       runner->setParent(ignition::gui::App());
       ++runnerCount;
 

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -103,6 +103,13 @@ void GuiRunner::RequestState()
 }
 
 /////////////////////////////////////////////////
+void GuiRunner::OnPluginAdded(const QString &)
+{
+  // This function used to call Update on the plugin, but that's no longer
+  // necessary. The function is left here for ABI compatibility.
+}
+
+/////////////////////////////////////////////////
 void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
 {
   this->OnState(_res);

--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -103,26 +103,6 @@ void GuiRunner::RequestState()
 }
 
 /////////////////////////////////////////////////
-void GuiRunner::OnPluginAdded(const QString &_objectName)
-{
-  auto plugin = gui::App()->PluginByName(_objectName.toStdString());
-  if (!plugin)
-  {
-    ignerr << "Failed to get plugin [" << _objectName.toStdString()
-           << "]" << std::endl;
-    return;
-  }
-
-  auto guiSystem = dynamic_cast<GuiSystem *>(plugin.get());
-
-  // Do nothing for pure ign-gui plugins
-  if (!guiSystem)
-    return;
-
-  guiSystem->Update(this->updateInfo, this->ecm);
-}
-
-/////////////////////////////////////////////////
 void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
 {
   this->OnState(_res);

--- a/src/gui/plugins/joint_position_controller/JointPositionController_TEST.cc
+++ b/src/gui/plugins/joint_position_controller/JointPositionController_TEST.cc
@@ -68,8 +68,6 @@ TEST_F(JointPositionControllerGui, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Load))
 
   // Create GUI runner to handle gazebo::gui plugins
   auto runner = new gazebo::GuiRunner("test");
-  runner->connect(app.get(), &gui::Application::PluginAdded,
-                  runner, &gazebo::GuiRunner::OnPluginAdded);
   runner->setParent(gui::App());
 
   // Add plugin
@@ -143,8 +141,6 @@ TEST_F(JointPositionControllerGui,
 
   // Create GUI runner to handle gazebo::gui plugins
   auto runner = new gazebo::GuiRunner("test");
-  runner->connect(app.get(), &gui::Application::PluginAdded,
-                  runner, &gazebo::GuiRunner::OnPluginAdded);
   runner->setParent(gui::App());
 
   // Load plugin
@@ -217,4 +213,3 @@ TEST_F(JointPositionControllerGui,
   // Cleanup
   plugins.clear();
 }
-

--- a/src/gui/plugins/joint_position_controller/JointPositionController_TEST.cc
+++ b/src/gui/plugins/joint_position_controller/JointPositionController_TEST.cc
@@ -83,6 +83,17 @@ TEST_F(JointPositionControllerGui, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Load))
   EXPECT_EQ(plugins.size(), 1);
 
   auto plugin = plugins[0];
+
+  int sleep = 0;
+  int maxSleep = 30;
+  while (plugin->ModelName() != "No model selected" && sleep < maxSleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    QCoreApplication::processEvents();
+    sleep++;
+  }
+
+  EXPECT_LT(sleep, maxSleep);
   EXPECT_EQ(plugin->Title(), "Joint position controller");
   EXPECT_EQ(plugin->ModelEntity(), gazebo::kNullEntity);
   EXPECT_EQ(plugin->ModelName(), QString("No model selected"))
@@ -171,6 +182,16 @@ TEST_F(JointPositionControllerGui,
   auto plugin = plugins[0];
   EXPECT_EQ(plugin->Title(), "JointPositionController!");
 
+  int sleep = 0;
+  int maxSleep = 30;
+  while (plugin->ModelName() != "No model selected" && sleep < maxSleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    QCoreApplication::processEvents();
+    sleep++;
+  }
+  EXPECT_LT(sleep, maxSleep);
+
   EXPECT_EQ(plugin->ModelEntity(), gazebo::kNullEntity);
   EXPECT_EQ(plugin->ModelName(), QString("No model selected"))
       << plugin->ModelName().toStdString();
@@ -192,8 +213,7 @@ TEST_F(JointPositionControllerGui,
     runner->RequestState();
   });
 
-  int sleep = 0;
-  int maxSleep = 30;
+  sleep = 0;
   while (plugin->ModelName() != "model_name" && sleep < maxSleep)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/gui/plugins/plot_3d/Plot3D_TEST.cc
+++ b/src/gui/plugins/plot_3d/Plot3D_TEST.cc
@@ -74,8 +74,6 @@ TEST_F(Plot3D, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Load))
 
   // Create GUI runner to handle gazebo::gui plugins
   auto runner = new gazebo::GuiRunner("test");
-  runner->connect(app.get(), &gui::Application::PluginAdded,
-                  runner, &gazebo::GuiRunner::OnPluginAdded);
   runner->setParent(gui::App());
 
   // Add plugin


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
When a plugin was added an `Update` was called immediately. With #497 updates are also being called in a loop, which was causing deadlocks since both could be called at the same time. This PR removes the initial update (after the plugin is inserted) since updates are already happening periodically. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**