### PR TITLE
Send mouse hover event only on spawn preview to improve framerate

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -889,7 +889,7 @@ void IgnRenderer::HandleMouseEvent()
 /////////////////////////////////////////////////
 void IgnRenderer::BroadcastHoverPos()
 {
-  if (this->dataPtr->hoverDirty)
+  if (this->dataPtr->spawnPreview && this->dataPtr->hoverDirty)
   {
     math::Vector3d pos = this->ScreenToScene(this->dataPtr->mouseHoverPos);
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Scene3D appear to be slow when there are high poly count meshes in the scene. This turns out that it's not a rendering issue. The problem is that we are making ray queries every frame through the `ScreenToScene` call in the `BroadcastHoverPos` function. I believe this is intended mainly for spawning entities. The `hoverDirty` variable is never set to `false` even when the mouse is outside the 3D window. It's only set to `false` in spawn entity mode. So it's incurring unnecessary computation every frame.

Note with this change, we will only broadcast the hover event on spawn entity mode. The gain here is a big improvement in frame rate.

To reproduce the issue:

launch ign-gazebo and drag and drop a high polycount model into the scene, e.g. [Urban 2 Story](https://app.ignitionrobotics.org/OpenRobotics/fuel/models/Urban%202%20Story) model. Try moving the camera and notice that it's laggy.

Before this change, I get ~3-4 FPS, and after this change, I get 40-50 FPS


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

