### PR TITLE
Populate joint forces through physics

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -116,6 +116,7 @@
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/ParentLinkName.hh"
 #include "ignition/gazebo/components/ExternalWorldWrenchCmd.hh"
+#include "ignition/gazebo/components/JointForce.hh"
 #include "ignition/gazebo/components/JointForceCmd.hh"
 #include "ignition/gazebo/components/Physics.hh"
 #include "ignition/gazebo/components/PhysicsEnginePlugin.hh"
@@ -2768,6 +2769,24 @@ void PhysicsPrivate::UpdateSim(EntityComponentManager &_ecm,
         }
         return true;
       });
+  
+  // Update joint forces
+  _ecm.Each<components::Joint, components::JointForce>(
+      [&](const Entity &_entity, components::Joint *,
+          components::JointForce *_jointVel) -> bool
+      {
+        if (auto jointPhys = this->entityJointMap.Get(_entity))
+        {
+          _jointVel->Data().resize(jointPhys->GetDegreesOfFreedom());
+          for (std::size_t i = 0; i < jointPhys->GetDegreesOfFreedom();
+               ++i)
+          {
+            _jointVel->Data()[i] = jointPhys->GetForce(i);
+          }
+        }
+        return true;
+      });
+
   IGN_PROFILE_END();
 
   // TODO(louise) Skip this if there are no collision features


### PR DESCRIPTION
# 🎉 New feature

Closes #883 

## Summary
Exports joint forces through physics.cc to enable force-torque sensors and efforts through joint state publisher.

## Test it
* Pull https://github.com/ignitionrobotics/ign-physics/pull/143 and this PR.
* Open up any world file with joint_state_publisher plugin (for eg. lift_drag.sdf)
* Listen the joint_states topic through ros2 bridge or Ignition

## Checklist
- [x ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**