### PR TITLE
Fix logic to disable server default plugins loading

### DIFF
--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -826,7 +826,8 @@ ignition::gazebo::loadPluginInfo(bool _isPlayback)
   // 1. Check contents of environment variable
   std::string envConfig;
   bool configSet = ignition::common::env(gazebo::kServerConfigPathEnv,
-                                         envConfig);
+                                         envConfig,
+                                         true);
 
   if (configSet)
   {


### PR DESCRIPTION
## Summary

https://github.com/ignitionrobotics/ign-gazebo/pull/281 introduced the new default behavior of loading server plugins from a configuration file. After the discussion in https://github.com/ignitionrobotics/ign-gazebo/pull/281#issuecomment-692661480, if `IGN_GAZEBO_SERVER_CONFIG` is set but empty, no server plugins should loaded and the `server.config` file should be ignored.

I'm testing this functionality and it seems not working correctly. In fact, the return value of `ignition::common::env` complies with the intended logic only in [the variant that accepts the `_allowEmpty=true` argument](https://github.com/ignitionrobotics/ign-common/blob/465bb7780e552b278de559fafaffe3d061a99782/include/ignition/common/Util.hh#L211-L229), which was missing.

To provide extra downstream content, I'm experimenting loading plugins with the new method introduced in #936. I'm trying to implement https://github.com/robotology/gym-ignition/issues/378, but as soon as I removed the only plugin that I was loading, the server automatically reverted to the default list of plugins part of `server.config`. This was already known, as ticketed in https://github.com/robotology/gym-ignition/issues/289.

cc @mjcarroll 

Note: accordingly to the documentation, this logic will not likely work in Windows due to the its behavior with empty environment variables.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**