### PR TITLE
Allow referencing links in nested models in LiftDrag

### DIFF
--- a/examples/worlds/lift_drag_nested.sdf
+++ b/examples/worlds/lift_drag_nested.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  This the same example as lift_drag.sdf but modified to show that links in
+  This is the same example as lift_drag.sdf but modified to show that links in
   nested models can be references in the link_name parameter.
 
   This file was adapted from osrf/gazebo/worlds/single_rotor_demo.world
@@ -219,7 +219,7 @@
             </material>
           </visual>
         </link>
-    </model>
+      </model>
       <joint name="rod_1_joint" type="revolute">
         <parent>body</parent>
         <child>rod_1</child>

--- a/examples/worlds/lift_drag_nested.sdf
+++ b/examples/worlds/lift_drag_nested.sdf
@@ -1,0 +1,293 @@
+<?xml version="1.0" ?>
+<!--
+  This the same example as lift_drag.sdf but modified to show that links in
+  nested models can be references in the link_name parameter.
+
+  This file was adapted from osrf/gazebo/worlds/single_rotor_demo.world
+
+  Try sending commands:
+
+    ign topic -t "/model/lift_drag_demo_model/joint/rod_1_joint/cmd_force" -m ignition.msgs.Double  -p "data: 0.7"
+
+  Listen to joint states:
+
+    ign topic -e -t /world/lift_drag/model/lift_drag_demo_model/joint_state
+
+-->
+<sdf version="1.8">
+  <world name="lift_drag">
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="lift_drag_demo_model">
+      <pose>0 0 0 0 0 0</pose>
+      <link name="body">
+        <pose>0.0 0 0.5 0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>1.8</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>1.8</iyy>
+            <iyz>0.0</iyz>
+            <izz>1.8</izz>
+          </inertia>
+          <mass>10.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.1</mu>
+                <mu2>0.1</mu2>
+              </ode>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="rod_1">
+        <pose>0 0 1.25 0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>0.012</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>0.012</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0012</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.02 0.02 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.02 0.02 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.3 0.3 0.3 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+      <model name="blade_1">
+        <link name="link">
+          <pose>0 0 1.5 0.0 0 0</pose>
+          <inertial>
+            <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+            <inertia>
+              <ixx>0.0000465</ixx>
+              <ixy>0.0</ixy>
+              <ixz>0.0</ixz>
+              <iyy>0.0000006</iyy>
+              <iyz>0.0</iyz>
+              <izz>0.0000470</izz>
+            </inertia>
+            <mass>0.01</mass>
+          </inertial>
+          <collision name="collision">
+            <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+            <geometry>
+              <box>
+                <size>0.2 1.0 0.01</size>
+              </box>
+            </geometry>
+          </collision>
+          <visual name="visual">
+            <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+            <geometry>
+              <box>
+                <size>0.2 1.0 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0.5 0.2 0.2 1.0</ambient>
+              <diffuse>.421 0.225 0.0 1.0</diffuse>
+            </material>
+          </visual>
+        </link>
+      </model>
+      <model name="blade_2">
+        <link name="link">
+          <pose>0 0 1.5 0.0 0 3.141593</pose>
+          <inertial>
+            <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+            <inertia>
+              <ixx>0.0000465</ixx>
+              <ixy>0.0</ixy>
+              <ixz>0.0</ixz>
+              <iyy>0.0000006</iyy>
+              <iyz>0.0</iyz>
+              <izz>0.0000470</izz>
+            </inertia>
+            <mass>0.01</mass>
+          </inertial>
+          <collision name="collision">
+            <pose>0.0 0.5 0 0.0 0.0 0.0</pose>
+            <geometry>
+              <box>
+                <size>0.2 1.0 0.01</size>
+              </box>
+            </geometry>
+          </collision>
+          <visual name="visual">
+            <pose>0.0 0.5 0 0.0 0.0 0</pose>
+            <geometry>
+              <box>
+                <size>0.2 1.0 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0.2 0.5 0.2 1.0</ambient>
+              <diffuse>.421 0.225 0.0 1.0</diffuse>
+            </material>
+          </visual>
+        </link>
+    </model>
+      <joint name="rod_1_joint" type="revolute">
+        <parent>body</parent>
+        <child>rod_1</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <axis>
+          <limit>
+            <lower>-1e16</lower>
+            <upper>1e16</upper>
+          </limit>
+          <xyz>0.0 0.0 -1.0</xyz>
+          <dynamics>
+            <damping>0.0001</damping>
+          </dynamics>
+        </axis>
+        <physics>
+          <ode>
+            <cfm_damping>1</cfm_damping>
+          </ode>
+        </physics>
+      </joint>
+      <joint name="blade_1_joint" type="fixed">
+        <parent>rod_1</parent>
+        <child>blade_1</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      </joint>
+      <joint name="blade_2_joint" type="fixed">
+        <parent>rod_1</parent>
+        <child>blade_2</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      </joint>
+
+      <plugin
+        filename="ignition-gazebo-joint-state-publisher-system"
+        name="ignition::gazebo::systems::JointStatePublisher"></plugin>
+
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <a0>0.1</a0>
+        <cla>0.1</cla>
+        <cda>0.001</cda>
+        <cma>0.0</cma>
+        <cp>0.0 0.5 0</cp>
+        <area>0.2</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>blade_1::link</link_name>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <a0>0.1</a0>
+        <cla>0.1</cla>
+        <cda>0.001</cda>
+        <cma>0.0</cma>
+        <cp>0.0 0.5 0</cp>
+        <area>0.2</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>blade_2::link</link_name>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-apply-joint-force-system"
+        name="ignition::gazebo::systems::ApplyJointForce">
+        <joint_name>rod_1_joint</joint_name>
+      </plugin>
+    </model>
+  </world>
+</sdf>

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -39,7 +39,8 @@ namespace systems
   ///
   /// link_name   : Name of the link affected by the group of lift/drag
   ///               properties. This can be a scoped name to reference links in
-  ///               nested models.
+  ///               nested models. \sa entitiesFromScopedName to learn more
+  ///               about scoped names.
   /// air_density : Density of the fluid this model is suspended in.
   /// area        : Surface area of the link.
   /// a0          : The initial "alpha" or initial angle of attack. a0 is also
@@ -60,6 +61,8 @@ namespace systems
   ///               coefficient curve.
   /// cda_stall   : The ratio of coefficient of drag and alpha slope after
   ///               stall.
+  /// control_joint_name: Name of joint that actuates a control surface for this
+  ///                     lifting body (Optional)
   class LiftDrag
       : public System,
         public ISystemConfigure,

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -38,7 +38,8 @@ namespace systems
   /// The following parameters are used by the system:
   ///
   /// link_name   : Name of the link affected by the group of lift/drag
-  ///               properties.
+  ///               properties. This can be a scoped name to reference links in
+  ///               nested models.
   /// air_density : Density of the fluid this model is suspended in.
   /// area        : Surface area of the link.
   /// a0          : The initial "alpha" or initial angle of attack. a0 is also

--- a/test/integration/lift_drag_system.cc
+++ b/test/integration/lift_drag_system.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/msgs/double.pb.h>
+#include <ignition/common/Filesystem.hh>
 #include <ignition/msgs/Utility.hh>
 
 #include <ignition/common/Console.hh>
@@ -48,8 +49,8 @@ using namespace gazebo;
 
 struct VerticalForceTestParam
 {
-  const char *fileName;
-  const char *bladeName;
+  const std::string fileName;
+  const std::string bladeName;
 };
 
 std::ostream &operator<<(std::ostream &_out, const VerticalForceTestParam &_val)
@@ -66,8 +67,9 @@ class VerticalForceParamFixture:
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
-    ignition::common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
-           (std::string(PROJECT_BINARY_PATH) + "/lib").c_str());
+    ignition::common::setenv(
+        "IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+        common::joinPaths(PROJECT_BINARY_PATH, "lib").c_str());
   }
 };
 
@@ -76,13 +78,14 @@ class VerticalForceParamFixture:
 TEST_P(VerticalForceParamFixture, VerifyVerticalForce)
 {
   using namespace std::chrono_literals;
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-                           PROJECT_SOURCE_PATH "/test/worlds/models");
+  ignition::common::setenv(
+      "IGN_GAZEBO_RESOURCE_PATH",
+      common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "models"));
 
   // Start server
   ServerConfig serverConfig;
   const auto sdfFile =
-      std::string(PROJECT_SOURCE_PATH "/") + GetParam().fileName;
+      common::joinPaths(PROJECT_SOURCE_PATH, GetParam().fileName);
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);
@@ -229,6 +232,8 @@ TEST_P(VerticalForceParamFixture, VerifyVerticalForce)
 INSTANTIATE_TEST_SUITE_P(
     LiftDragTests, VerticalForceParamFixture,
     ::testing::Values(
-        VerticalForceTestParam{"test/worlds/lift_drag.sdf", "wing_1"},
-        VerticalForceTestParam{"test/worlds/lift_drag_nested_model.sdf",
-                               "wing_1::base_link"}));
+        VerticalForceTestParam{
+            common::joinPaths("test", "worlds", "lift_drag.sdf"), "wing_1"},
+        VerticalForceTestParam{
+            common::joinPaths("test", "worlds", "lift_drag_nested_model.sdf"),
+            "wing_1::base_link"}));

--- a/test/integration/lift_drag_system.cc
+++ b/test/integration/lift_drag_system.cc
@@ -36,6 +36,7 @@
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
+#include "ignition/gazebo/Util.hh"
 #include "ignition/gazebo/test_config.hh"
 
 #include "../helpers/Relay.hh"
@@ -45,10 +46,23 @@
 using namespace ignition;
 using namespace gazebo;
 
-/// \brief Test fixture for LiftDrag system
-class LiftDragTestFixture : public ::testing::Test
+struct VerticalForceTestParam
 {
-  // Documentation inherited
+  const char *fileName;
+  const char *bladeName;
+};
+
+std::ostream &operator<<(std::ostream &_out, const VerticalForceTestParam &_val)
+{
+  _out << "[" << _val.fileName << ", " << _val.bladeName << "]";
+  return _out;
+}
+
+
+/// \brief Test fixture for LiftDrag system
+class VerticalForceParamFixture:
+      public ::testing::TestWithParam<VerticalForceTestParam>
+{
   protected: void SetUp() override
   {
     ignition::common::Console::SetVerbosity(4);
@@ -59,14 +73,16 @@ class LiftDragTestFixture : public ::testing::Test
 
 /////////////////////////////////////////////////
 /// Measure / verify force torques against analytical answers.
-TEST_F(LiftDragTestFixture, VerifyVerticalForce)
+TEST_P(VerticalForceParamFixture, VerifyVerticalForce)
 {
   using namespace std::chrono_literals;
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+                           PROJECT_SOURCE_PATH "/test/worlds/models");
 
   // Start server
   ServerConfig serverConfig;
   const auto sdfFile =
-      std::string(PROJECT_SOURCE_PATH) + "/test/worlds/lift_drag.sdf";
+      std::string(PROJECT_SOURCE_PATH "/") + GetParam().fileName;
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);
@@ -76,9 +92,19 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
   server.SetUpdatePeriod(0ns);
 
   const std::string bodyName = "body";
-  const std::string bladeName = "wing_1";
+  const std::string bladeName = GetParam().bladeName;
   const std::string jointName = "body_joint";
   const double desiredVel = -0.2;
+
+  auto firstEntityFromScopedName = [](const std::string &_scopedName,
+                                 const EntityComponentManager &_ecm) -> Entity
+  {
+    auto entities = entitiesFromScopedName(_scopedName, _ecm);
+    if (entities.size() > 0)
+      return *entities.begin();
+    else
+      return kNullEntity;
+  };
 
   test::Relay testSystem;
   std::vector<math::Vector3d> linearVelocities;
@@ -88,27 +114,14 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
       {
         // Create velocity and acceleration components if they dont't exist.
         // This signals physics system to populate the component
-        auto bladeLink = _ecm.EntityByComponents(components::Link(),
-                                                 components::Name(bladeName));
+        auto bladeLink = firstEntityFromScopedName(bladeName, _ecm);
 
-        if (nullptr == _ecm.Component<components::AngularVelocity>(bladeLink))
-        {
-          _ecm.CreateComponent(bladeLink, components::AngularVelocity());
-        }
+        enableComponent<components::AngularVelocity>(_ecm, bladeLink);
 
-        auto bodyLink = _ecm.EntityByComponents(components::Link(),
-                                                components::Name(bodyName));
+        auto bodyLink = firstEntityFromScopedName(bodyName, _ecm);
 
-        if (nullptr ==
-            _ecm.Component<components::WorldLinearVelocity>(bodyLink))
-        {
-          _ecm.CreateComponent(bodyLink, components::WorldLinearVelocity());
-        }
-        if (nullptr ==
-            _ecm.Component<components::WorldLinearAcceleration>(bodyLink))
-        {
-          _ecm.CreateComponent(bodyLink, components::WorldLinearAcceleration());
-        }
+        enableComponent<components::WorldLinearVelocity>(_ecm, bodyLink);
+        enableComponent<components::WorldLinearAcceleration>(_ecm, bodyLink);
       });
 
   server.AddSystem(testSystem.systemPtr);
@@ -122,8 +135,8 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
         auto joint = _ecm.EntityByComponents(components::Joint(),
                                              components::Name(jointName));
 
-        auto bodyLink = _ecm.EntityByComponents(components::Link(),
-                                                components::Name(bodyName));
+        auto bodyLink = firstEntityFromScopedName(bodyName, _ecm);
+
         auto linVelComp =
             _ecm.Component<components::WorldLinearVelocity>(bodyLink);
 
@@ -151,10 +164,9 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
   wrenchRecorder.OnPreUpdate([&](const gazebo::UpdateInfo &,
                               const gazebo::EntityComponentManager &_ecm)
       {
-        auto bladeLink = _ecm.EntityByComponents(components::Link(),
-                                                 components::Name(bladeName));
-        auto bodyLink = _ecm.EntityByComponents(components::Link(),
-                                                components::Name(bodyName));
+        auto bladeLink = firstEntityFromScopedName(bladeName, _ecm);
+        auto bodyLink = firstEntityFromScopedName(bodyName, _ecm);
+
         auto linVelComp =
             _ecm.Component<components::WorldLinearVelocity>(bodyLink);
         auto wrenchComp =
@@ -213,3 +225,10 @@ TEST_F(LiftDragTestFixture, VerifyVerticalForce)
     EXPECT_GT(vertForce, 0);
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    LiftDragTests, VerticalForceParamFixture,
+    ::testing::Values(
+        VerticalForceTestParam{"test/worlds/lift_drag.sdf", "wing_1"},
+        VerticalForceTestParam{"test/worlds/lift_drag_nested_model.sdf",
+                               "wing_1::base_link"}));

--- a/test/worlds/lift_drag_nested_model.sdf
+++ b/test/worlds/lift_drag_nested_model.sdf
@@ -1,0 +1,149 @@
+<?xml version="1.0" ?>
+<!-- Adapted from osrf/gazebo/test/worlds/lift_drag_plugin.world  -->
+<sdf version="1.8">
+  <world name="default">
+
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            <emissive>0.8 0.8 0.8 1</emissive>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="lift_drag_demo_model">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="body">
+        <inertial>
+          <pose>0.0 0 0 0.0 0.0 0.0</pose>
+          <inertia>
+            <ixx>0.465</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>0.006</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.470</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <pose>0.0 0 0 0.0 0.0 0.0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <pose>0.0 0 0 0.0 0.0 0.0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.5 0.2 0.2 1.0</ambient>
+            <diffuse>.421 0.225 0.0 1.0</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <!-- The IGN_GAZEBO_RESOURCE_PATH environment variable must be set properly for these includes to work -->
+      <include>
+        <uri>file://lift_drag_wing</uri>
+        <name>wing_1</name>
+        <pose>0 5.5 0.5 0.1 0 0</pose>
+      </include>
+
+      <include>
+        <uri>file://lift_drag_wing</uri>
+        <name>wing_2</name>
+        <pose>0 -5.5 0.5 -0.1 0 0</pose>
+      </include>
+
+
+      <joint name="body_joint" type="prismatic">
+        <parent>world</parent>
+        <child>body</child>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <axis>
+          <xyz>1.0 0.0 0.0</xyz>
+          <dynamics>
+            <damping>0.000000</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <joint name="wing_1_joint" type="fixed">
+        <parent>body</parent>
+        <child>wing_1::base_link</child>
+      </joint>
+      <joint name="wing_2_joint" type="fixed">
+        <parent>body</parent>
+        <child>wing_2::base_link</child>
+      </joint>
+
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <a0>0.1</a0>
+        <cla>4.000</cla>
+        <cda>20.0</cda>
+        <cma>0.00</cma>
+        <alpha_stall>10.0</alpha_stall>
+        <cla_stall>-0.2</cla_stall>
+        <cda_stall>1.0</cda_stall>
+        <cma_stall>0.0</cma_stall>
+        <cp>0.0 5.0 0</cp>
+        <area>10</area>
+        <air_density>1.2041</air_density>
+        <forward>-1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>wing_1::base_link</link_name>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-lift-drag-system"
+        name="ignition::gazebo::systems::LiftDrag">
+        <a0>0.1</a0>
+        <cla>4.000</cla>
+        <cda>20.0</cda>
+        <cma>0.00</cma>
+        <alpha_stall>10.0</alpha_stall>
+        <cla_stall>-0.2</cla_stall>
+        <cda_stall>1.0</cda_stall>
+        <cma_stall>0.0</cma_stall>
+        <cp>0.0 -5.0 0</cp>
+        <area>10</area>
+        <air_density>1.2041</air_density>
+        <forward>-1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>wing_2::base_link</link_name>
+      </plugin>
+    </model>
+  </world>
+</sdf>

--- a/test/worlds/models/lift_drag_wing/model.config
+++ b/test/worlds/models/lift_drag_wing/model.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<model>
+    <name>lift_drag_wing</name>
+    <version>1.0</version>
+    <sdf version="1.8">model.sdf</sdf>
+</model>
+

--- a/test/worlds/models/lift_drag_wing/model.sdf
+++ b/test/worlds/models/lift_drag_wing/model.sdf
@@ -1,0 +1,36 @@
+<?xml version='1.0'?>
+<sdf version='1.8'>
+  <model name="lift_drag_wing">
+    <link name="base_link">
+      <inertial>
+        <inertia>
+          <ixx>0.465</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>0.006</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.470</izz>
+        </inertia>
+        <mass>1.0</mass>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>1.0 10.0 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>1.0 10.0 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <ambient>0.5 0.2 0.2 1.0</ambient>
+          <diffuse>.421 0.225 0.0 1.0</diffuse>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Closes #479 

## Summary
This updates the `LiftDrag` system so that links in nested models can be referenced in the `link_name` parameter. This an example of using the `entitiesFromScopedName` function in `Util.hh`.

## Test it
Run the `INTEGRATION_lift_drag` test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
