### PR TITLE
Set protobuf_MODULE_COMPATIBLE before any find_package call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ endif()
 # Search for project-specific dependencies
 #============================================================================
 
+# This option is needed to use the PROTOBUF_GENERATE_CPP
+# in case protobuf is found with the CMake config files
+# It needs to be set before any find_package(...) call 
+# as protobuf could be find transitively by any dependency
+set(protobuf_MODULE_COMPATIBLE TRUE)
+
 ign_find_package(sdformat9 REQUIRED VERSION 9.3.0)
 set(SDF_VER ${sdformat9_VERSION_MAJOR})
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/956 

## Summary
In some environments where Protobuf is compiled using CMake (so not in debian-based distributions, as there protobuf is compiled via autotools), it is necessary to set the `protobuf_MODULE_COMPATIBLE` variable before any call to `find_package`, as any call to `find_package` could call transitively `find_package(protobuf)`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**