### PR TITLE
Be more specific when looking for physics plugins

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -498,10 +498,13 @@ void Physics::Configure(const Entity &_entity,
     return;
   }
 
-  auto classNames = pluginLoader.AllPlugins();
+  auto classNames = pluginLoader.PluginsImplementing<
+      physics::ForwardStep::Implementation<
+      physics::FeaturePolicy3d>>();
   if (classNames.empty())
   {
-    ignerr << "No plugins found in library [" << pathToLib << "]." << std::endl;
+    ignerr << "No physics plugins found in library [" << pathToLib << "]."
+           << std::endl;
     return;
   }
 
@@ -511,7 +514,11 @@ void Physics::Configure(const Entity &_entity,
     auto plugin = pluginLoader.Instantiate(className);
 
     if (!plugin)
+    {
+      ignwarn << "Failed to instantiate [" << className << "] from ["
+              << pathToLib << "]" << std::endl;
       continue;
+    }
 
     this->dataPtr->engine = ignition::physics::RequestEngine<
       ignition::physics::FeaturePolicy3d,


### PR DESCRIPTION
## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This came up on #617 while experimenting with different ways of loading plugins. More specifically, we were trying to use the `RTLD_GLOBAL` flag to load plugins, which made the plugin loader find all plugins already loaded, not only those from the current library. In that situation, it was useful to filter plugins by interface before iterating over them.

We ended up not using that flag, but I think it's a good idea to filter the plugins beforehand anyway in case a user tries to load some funky plugin.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

I'd expect this change not to break any of the existing tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
