### PR TITLE
Fix selection buffer crash on resize

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -887,7 +887,7 @@ Entity IgnRenderer::UniqueId()
 void IgnRenderer::HandleMouseEvent()
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-  this->BroadcastHoverPos();
+//  this->BroadcastHoverPos();
   this->BroadcastLeftClick();
   this->BroadcastRightClick();
   this->HandleMouseContextMenu();

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -887,7 +887,7 @@ Entity IgnRenderer::UniqueId()
 void IgnRenderer::HandleMouseEvent()
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-//  this->BroadcastHoverPos();
+  this->BroadcastHoverPos();
   this->BroadcastLeftClick();
   this->BroadcastRightClick();
   this->HandleMouseContextMenu();

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -438,6 +438,7 @@ void IgnRenderer::Render()
     {
       IGN_PROFILE("IgnRenderer::Render Pre-render camera");
       this->dataPtr->camera->PreRender();
+      this->dataPtr->camera->Render();
     }
     this->textureDirty = false;
   }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

related ign-rendering PR: https://github.com/ignitionrobotics/ign-rendering/pull/378
related issue: https://github.com/ignitionrobotics/ign-rendering/issues/362

## Summary

If a window resize and mouse click happens in the same frame, the gui will crash with a backtrace pointing to the selection buffer in ign-rendering. This is more of a workaround - adding a render call ensures that the ogre resources are ready before they are used by the selection buffer (for mouse picking).

**Note**: we need to merge this PR before the one in ign-rendering: https://github.com/ignitionrobotics/ign-rendering/pull/378

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
