### PR TITLE
Fix msg in entity_creation example

### DIFF
--- a/examples/standalone/entity_creation/entity_creation.cc
+++ b/examples/standalone/entity_creation/entity_creation.cc
@@ -79,7 +79,7 @@ void createEntityFromStr(const std::string modelStr)
   if (executed)
   {
     if (result)
-      std::cout << "Sphere was created : [" << res.data() << "]" << std::endl;
+      std::cout << "Entity was created : [" << res.data() << "]" << std::endl;
     else
     {
       std::cout << "Service call failed" << std::endl;


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Minor fix to a msg in the `entity_creation` example. 

The example spawns a spot light and a sphere using the `createEntityFromStr` function but that function always prints out `Sphere was created : [1]`. So modified msg to be generic 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
