### PR TITLE
Fix `INTEGRATION_log_system` regression

### DIFF
--- a/include/ignition/gazebo/components/Model.hh
+++ b/include/ignition/gazebo/components/Model.hh
@@ -68,7 +68,7 @@ namespace serializers
       std::string sdf(std::istreambuf_iterator<char>(_in), {});
 
       sdf::Errors errors = root.LoadSdfString(sdf);
-      if (!root.Element()->HasElement("model"))
+      if (!root.Model())
       {
         ignerr << "Unable to unserialize sdf::Model" << std::endl;
         return _in;


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

## Summary

I introduced a regression in Pull request #841, where tests were segfaulting in `INTEGRATION_log_system`. This should fix it. Thanks to @jennuine for the suggestion.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

