### PR TITLE
Deprecate particle emitter, and use scatter ratio in new particle mes…

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -7,6 +7,9 @@ release will remove the deprecated code.
 
 ## Ignition Gazebo 5.x to 6.x
 
+* The ParticleEmitter system is deprecated. Please use the ParticleEmitter2
+system.
+
 * Marker example has been moved to Ignition GUI.
 
 * Some GUI plugins have been moved to Ignition GUI. Gazebo users don't need to

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1560,13 +1560,7 @@ msgs::ParticleEmitter ignition::gazebo::convert(const sdf::ParticleEmitter &_in)
     header->add_value(_in.Topic());
   }
 
-  // todo(anyone) Use particle_scatter_ratio in particle_emitter.proto from
-  // Fortress on.
-  auto header = out.mutable_header()->add_data();
-  header->set_key("particle_scatter_ratio");
-  std::string *value = header->add_value();
-  *value = std::to_string(_in.ScatterRatio());
-
+  out.mutable_particle_scatter_ratio()->set_data(_in.ScatterRatio());
   return out;
 }
 

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1612,6 +1612,8 @@ sdf::ParticleEmitter ignition::gazebo::convert(const msgs::ParticleEmitter &_in)
     out.SetScaleRate(_in.scale_rate().data());
   if (_in.has_color_range_image())
     out.SetColorRangeImage(_in.color_range_image().data());
+  if (_in.has_particle_scatter_ratio())
+    out.SetScatterRatio(_in.particle_scatter_ratio().data());
 
   for (int i = 0; i < _in.header().data_size(); ++i)
   {
@@ -1619,10 +1621,6 @@ sdf::ParticleEmitter ignition::gazebo::convert(const msgs::ParticleEmitter &_in)
     if (data.key() == "topic" && data.value_size() > 0)
     {
       out.SetTopic(data.value(0));
-    }
-    else if (data.key() == "particle_scatter_ratio" && data.value_size() > 0)
-    {
-      out.SetScatterRatio(std::stof(data.value(0)));
     }
   }
 

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -997,9 +997,7 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ("topic", header.key());
   EXPECT_EQ("my_topic", header.value(0));
 
-  auto headerScatterRatio = emitterMsg.header().data(1);
-  EXPECT_EQ("particle_scatter_ratio", headerScatterRatio.key());
-  EXPECT_FLOAT_EQ(0.9f, std::stof(headerScatterRatio.value(0)));
+  EXPECT_FLOAT_EQ(0.9f, emitterMsg.particle_scatter_ratio());
 
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 0), msgs::Convert(emitterMsg.pose()));
 

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -997,7 +997,7 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ("topic", header.key());
   EXPECT_EQ("my_topic", header.value(0));
 
-  EXPECT_FLOAT_EQ(0.9f, emitterMsg.particle_scatter_ratio());
+  EXPECT_FLOAT_EQ(0.9f, emitterMsg.particle_scatter_ratio().data());
 
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 0), msgs::Convert(emitterMsg.pose()));
 

--- a/src/systems/particle_emitter/ParticleEmitter.hh
+++ b/src/systems/particle_emitter/ParticleEmitter.hh
@@ -119,7 +119,7 @@ namespace systems
         public ISystemPreUpdate
   {
     /// \brief Constructor
-    public: ParticleEmitter();
+    public: IGN_DEPRECATED(6) ParticleEmitter();
 
     // Documentation inherited
     public: void Configure(const Entity &_entity,

--- a/test/integration/particle_emitter2.cc
+++ b/test/integration/particle_emitter2.cc
@@ -119,23 +119,9 @@ TEST_F(ParticleEmitter2Test, SDFLoad)
                 EXPECT_EQ("/path/to/dummy_image.png",
                     _emitter->Data().color_range_image().data());
 
-                // particle scatter ratio is temporarily stored in header
-                bool hasParticleScatterRatio = false;
-                for (int i = 0; i < _emitter->Data().header().data_size(); ++i)
-                {
-                  for (int j = 0;
-                      j < _emitter->Data().header().data(i).value_size(); ++j)
-                  {
-                    if (_emitter->Data().header().data(i).key() ==
-                        "particle_scatter_ratio")
-                    {
-                      EXPECT_DOUBLE_EQ(0.01, math::parseFloat(
-                          _emitter->Data().header().data(i).value(0)));
-                      hasParticleScatterRatio = true;
-                    }
-                  }
-                }
-                EXPECT_TRUE(hasParticleScatterRatio);
+                EXPECT_TRUE(_emitter->Data().has_particle_scatter_ratio());
+                EXPECT_FLOAT_EQ(0.01f,
+                    _emitter->Data().particle_scatter_ratio().data());
               }
               else
               {


### PR DESCRIPTION
# 🎉 New feature


## Summary

Use the `particle_scatter_ratio` in the particle emitter message available in fortress. This also starts the process of tick-tocking the ParticleEmitterSystem.


## Test it

Run the test suite.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
