### PR TITLE
Add linear velocity components to links that have linear velocity cmds applied

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1671,6 +1671,11 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
         worldLinearVelFeature->SetWorldLinearVelocity(
             math::eigen3::convert(worldLinearVel));
 
+        // create linear velocity components for the link, if they don't
+        // already exist. The component data is set in PhysicsPivate::UpdateSim
+        _ecm.ComponentDefault<components::LinearVelocity>(_entity);
+        _ecm.ComponentDefault<components::WorldLinearVelocity>(_entity);
+
         return true;
       });
 
@@ -1848,7 +1853,12 @@ void PhysicsPrivate::UpdateSim(EntityComponentManager &_ecm)
 
           // Populate world poses, velocities and accelerations of the link. For
           // now these components are updated only if another system has created
-          // the corresponding component on the entity.
+          // the corresponding component on the entity. An exception to this is
+          // if a LinearVelocityCmd component is applied to a link - if this
+          // happens, then LinearVelocity and WorldLinearVelocity components
+          // are created for this link in case the user who applied the velocity
+          // command would like to read the link's velocity in a future
+          // simulation step.
           auto worldPoseComp = _ecm.Component<components::WorldPose>(_entity);
           if (worldPoseComp)
           {

--- a/test/worlds/lin_vel_cmd.sdf
+++ b/test/worlds/lin_vel_cmd.sdf
@@ -1,0 +1,92 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

Fixes #966

## Summary
When a link has a `LinearVelocityCmd` applied to it in a given simulation step, there's no way to read what the link's linear velocity is in future simulation steps since [the `LinearVelocityCmd` is "zeroed out" after it is applied](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.9.0-pre2/src/systems/physics/Physics.cc#L2149-L2154). This PR adds a `LinearVelocity` and `WorldLinearVelocity` component to a link when a `LinearVelocityCmd` is applied to it, so that users have a way to read a link's linear velocity in future simulation steps. I've added a test case to check this in the physics system integration test, and have verified that running the test to read linear velocity data from a link with a `LinearVelocityCmd` applied to it fails without the other changes made in this PR.

We should probably make similar updates for `LinearVelocityCmd`s applied to models, but this will be easier to do starting in `ign-gazebo5` since we can make use of #736 and #685 (if a `LinearVelocityCmd` is applied to a model and we want to create `LinearVelocity` and `WorldLinearVelocity` components for the model, we could populate the data in these components with the new velocity information from the [model's canonical link](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo3_3.9.0-pre2/src/systems/physics/Physics.cc#L1799)).

On a somewhat related note to this, we could also make similar changes for `AngularVelocityCmd`, so that users who apply `AngularVelocityCmd`s can read the corresponding entity's angular velocity data in future simulation steps. We could either open a new PR for this, or add it to this one if this change seems like something worthwhile.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**