### PR TITLE
👩‍🌾 Make thermal sensor test more robust

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -722,18 +722,23 @@ void RenderUtil::Update()
       this->dataPtr->sceneManager.CreateLight(
           std::get<0>(light), std::get<1>(light), std::get<2>(light));
 
-      // create a new id for the light visual
-      auto attempts = 100000u;
-      for (auto i = 0u; i < attempts; ++i)
+      // TODO(anyone) This needs to be updated for when sensors and GUI use
+      // the same scene
+      // create a new id for the light visual, if we're not loading sensors
+      if (!this->dataPtr->enableSensors)
       {
-        Entity id = std::numeric_limits<uint64_t>::min() + i;
-        if (!this->dataPtr->sceneManager.HasEntity(id))
+        auto attempts = 100000u;
+        for (auto i = 0u; i < attempts; ++i)
         {
-          rendering::VisualPtr lightVisual =
-            this->dataPtr->sceneManager.CreateLightVisual(
-              id, std::get<1>(light), std::get<0>(light));
-          this->dataPtr->matchLightWithVisuals[std::get<0>(light)] = id;
-          break;
+          Entity id = std::numeric_limits<uint64_t>::min() + i;
+          if (!this->dataPtr->sceneManager.HasEntity(id))
+          {
+            rendering::VisualPtr lightVisual =
+              this->dataPtr->sceneManager.CreateLightVisual(
+                id, std::get<1>(light), std::get<0>(light));
+            this->dataPtr->matchLightWithVisuals[std::get<0>(light)] = id;
+            break;
+          }
         }
       }
     }

--- a/test/integration/thermal_sensor_system.cc
+++ b/test/integration/thermal_sensor_system.cc
@@ -191,7 +191,7 @@ TEST_F(ThermalSensorTest,
   EXPECT_DOUBLE_EQ(-10.0, entityTemp[boxVisual].Kelvin());
 
   // Run server
-  server.Run(true, 55, false);
+  server.Run(true, 10, false);
 
   // wait for image
   bool received = false;

--- a/test/integration/thermal_sensor_system.cc
+++ b/test/integration/thermal_sensor_system.cc
@@ -63,6 +63,11 @@ void thermalCb(const msgs::Image &_msg)
   std::lock_guard<std::mutex> g_lock(g_mutex);
   g_imageMsgs.push_back(_msg);
 
+  EXPECT_EQ(320u, _msg.width());
+  EXPECT_EQ(240u, _msg.height());
+  EXPECT_EQ(320u, _msg.step());
+  EXPECT_EQ(msgs::PixelFormatType::L_INT8, _msg.pixel_format_type());
+
   unsigned int width = _msg.width();
   unsigned int height = _msg.height();
   unsigned int size = width * height * sizeof(unsigned char);
@@ -174,9 +179,9 @@ TEST_F(ThermalSensorTest,
   const std::string cylinderVisual = "cylinder_visual";
   const std::string boxVisual = "box_visual";
   EXPECT_EQ(3u, entityTemp.size());
-  ASSERT_TRUE(entityTemp.find(sphereVisual) != entityTemp.end());
-  ASSERT_TRUE(entityTemp.find(cylinderVisual) != entityTemp.end());
-  ASSERT_TRUE(entityTemp.find(boxVisual) != entityTemp.end());
+  ASSERT_NE(entityTemp.find(sphereVisual), entityTemp.end());
+  ASSERT_NE(entityTemp.find(cylinderVisual), entityTemp.end());
+  ASSERT_NE(entityTemp.find(boxVisual), entityTemp.end());
   EXPECT_DOUBLE_EQ(600.0, entityTemp[sphereVisual].Kelvin());
   // the user specified temp is larger than the max value representable by an
   // 8 bit 3 degree resolution camera - this value should be clamped
@@ -186,20 +191,19 @@ TEST_F(ThermalSensorTest,
   EXPECT_DOUBLE_EQ(-10.0, entityTemp[boxVisual].Kelvin());
 
   // Run server
-  server.Run(true, 35, false);
+  server.Run(true, 55, false);
 
   // wait for image
   bool received = false;
-  for (unsigned int i = 0; i < 30; ++i)
+  int sleep{0};
+  int maxSleep{40};
+  for (; sleep < maxSleep && !received; ++sleep)
   {
-    {
-      std::lock_guard<std::mutex> lock(g_mutex);
-      received = !g_imageMsgs.empty();
-    }
-    if (received)
-      break;
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::lock_guard<std::mutex> lock(g_mutex);
+    received = !g_imageMsgs.empty();
   }
+  EXPECT_LT(sleep, maxSleep);
   EXPECT_TRUE(received);
   ASSERT_NE(nullptr, g_image);
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/667

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

I spent some time debugging #667. It's interesting that the test is pretty [robust on Dome](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo4-bionic-amd64/lastBuild/testReport/(root)/ThermalSensorTest/ThermalSensorSystemInvalidConfig/history/), but very [flaky on Edifice](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo5-bionic-amd64/lastBuild/testReport/(root)/ThermalSensorTest/ThermalSensorSystemInvalidConfig/history/) and [Fortress](https://build.osrfoundation.org/job/ignition_gazebo-ci-main-bionic-amd64/lastBuild/testReport/(root)/ThermalSensorTest/ThermalSensorSystemInvalidConfig/history/).

Even more interesting is that the test only runs for 10 iterations on Dome:

https://github.com/ignitionrobotics/ign-gazebo/blob/9cafd6d9f43f73fb82b809b38cee4b316a390489/test/integration/thermal_sensor_system.cc#L182

But it runs for 35 iterations on Edifice and Fortress:

https://github.com/ignitionrobotics/ign-gazebo/blob/0c401c17c1d4b748233c61921c47da5725ce9d5c/test/integration/thermal_sensor_system.cc#L189

So in theory, the test should be more robust on the later versions.

I verified locally that 10 iterations are not enough for the test to pass on Edifice. Specifically, this piece of code for creating light visuals makes the rendering update take so long, that all 10 `Sensors::PostUpdate`s happen before the thermal sensor is ready to publish.

https://github.com/ignitionrobotics/ign-gazebo/blob/0c401c17c1d4b748233c61921c47da5725ce9d5c/src/rendering/RenderUtil.cc#L725-L738

The solution I have here is not to create light visuals when sensors are enabled, because we don't need those on the backend. This will need to be revisited on Fortress, in the context of #556.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/224