### PR TITLE
Lock views during system PostUpdates

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -657,9 +657,11 @@ namespace ignition
       /// \brief Find a view based on the provided component type ids.
       /// \param[in] _types The component type ids that serve as a key into
       /// a map of views.
-      /// \return A pointer to the view. nullptr is returned if the view wasn't
-      /// found.
-      private: detail::BaseView *FindView(
+      /// \return A pair containing a the view itself and a mutex that can be
+      /// used for locking the view while entities are being added to it.
+      /// If a view defined by _types does not exist, the pair will contain
+      /// nullptrs.
+      private: std::pair<detail::BaseView *, std::mutex *> FindView(
                    const std::vector<ComponentTypeId> &_types) const;
 
       /// \brief Add a new view to the set of stored views.
@@ -696,6 +698,22 @@ namespace ignition
           Entity _entity,
           const std::unordered_set<ComponentTypeId> &_types = {},
           bool _full = false) const;
+
+      /// \brief Set whether views should be locked when entities are being
+      /// added to them. This can be used to prevent race conditions in
+      /// system PostUpdates, since these are run in parallel (entities are
+      /// added to views when the view is used, so if two systems try to access
+      /// the same view in PostUpdate, we run the risk of multiple threads
+      /// reading/writing from the same data).
+      /// \param[in] _lock Whether the views should lock while entities are
+      /// being added to them (true) or not (false).
+      private: void LockAddingEntitiesToViews(bool _lock);
+
+      /// \brief Get whether views should be locked when entities are being
+      /// added to them.
+      /// \return True if views should be locked during entitiy addition, false
+      /// otherwise.
+      private: bool LockAddingEntitiesToViews() const;
 
       // Make runners friends so that they can manage entity creation and
       // removal. This should be safe since runners are internal

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -133,8 +133,15 @@ class ignition::gazebo::EntityComponentManagerPrivate
   public: mutable std::mutex removedComponentsMutex;
 
   /// \brief The set of all views.
+  /// The value is a pair of the view itself and a mutex that can be used for
+  /// locking the view to ensure thread safety when adding entities to the view.
   public: mutable std::unordered_map<detail::ComponentTypeKey,
-          std::unique_ptr<detail::BaseView>, detail::ComponentTypeHasher> views;
+          std::pair<std::unique_ptr<detail::BaseView>,
+            std::unique_ptr<std::mutex>>, detail::ComponentTypeHasher> views;
+
+  /// \brief A flag that indicates whether views should be locked while adding
+  /// new entities to them or not.
+  public: bool lockAddEntitiesToViews{false};
 
   /// \brief Cache of previously queried descendants. The key is the parent
   /// entity for which descendants were queried, and the value are all its
@@ -271,7 +278,7 @@ void EntityComponentManager::ClearNewlyCreatedEntities()
 
   for (auto &view : this->dataPtr->views)
   {
-    view.second->ResetNewEntityState();
+    view.second.first->ResetNewEntityState();
   }
 }
 
@@ -319,7 +326,7 @@ void EntityComponentManager::RequestRemoveEntity(Entity _entity,
   {
     for (auto &view : this->dataPtr->views)
     {
-      view.second->MarkEntityToRemove(removedEntity);
+      view.second.first->MarkEntityToRemove(removedEntity);
     }
   }
 }
@@ -377,7 +384,7 @@ void EntityComponentManager::ProcessRemoveEntityRequests()
       // Remove the entity from views.
       for (auto &view : this->dataPtr->views)
       {
-        view.second->RemoveEntity(entity);
+        view.second.first->RemoveEntity(entity);
       }
     }
     // Clear the set of entities to remove.
@@ -420,7 +427,7 @@ bool EntityComponentManager::RemoveComponent(
 
     // update views to reflect the component removal
     for (auto &viewPair : this->dataPtr->views)
-      viewPair.second->NotifyComponentRemoval(_entity, _typeId);
+      viewPair.second.first->NotifyComponentRemoval(_entity, _typeId);
   }
 
   this->dataPtr->AddModifiedComponent(_entity);
@@ -656,7 +663,7 @@ bool EntityComponentManager::CreateComponentImplementation(
     updateData = false;
     for (auto &viewPair : this->dataPtr->views)
     {
-      auto &view = viewPair.second;
+      auto &view = viewPair.second.first;
       if (this->EntityMatches(_entity, view->ComponentTypes()))
         view->MarkEntityToAdd(_entity, this->IsNewEntity(_entity));
     }
@@ -687,7 +694,7 @@ bool EntityComponentManager::CreateComponentImplementation(
 
       for (auto &viewPair : this->dataPtr->views)
       {
-        viewPair.second->NotifyComponentAddition(_entity,
+        viewPair.second.first->NotifyComponentAddition(_entity,
             this->IsNewEntity(_entity), _componentTypeId);
       }
     }
@@ -795,14 +802,18 @@ const EntityGraph &EntityComponentManager::Entities() const
 }
 
 //////////////////////////////////////////////////
-detail::BaseView *EntityComponentManager::FindView(
+std::pair<detail::BaseView *, std::mutex *> EntityComponentManager::FindView(
     const std::vector<ComponentTypeId> &_types) const
 {
   std::lock_guard<std::mutex> lockViews(this->dataPtr->viewsMutex);
+  std::pair<detail::BaseView *, std::mutex *> viewMutexPair(nullptr, nullptr);
   auto iter = this->dataPtr->views.find(_types);
   if (iter != this->dataPtr->views.end())
-    return iter->second.get();
-  return nullptr;
+  {
+    viewMutexPair.first = iter->second.first.get();
+    viewMutexPair.second = iter->second.second.get();
+  }
+  return viewMutexPair;
 }
 
 //////////////////////////////////////////////////
@@ -810,12 +821,13 @@ detail::BaseView *EntityComponentManager::AddView(
     const detail::ComponentTypeKey &_types,
     std::unique_ptr<detail::BaseView> _view) const
 {
-  // If the view already exists, then the map will return the iterator to
-  // the location that prevented the insertion.
   std::lock_guard<std::mutex> lockViews(this->dataPtr->viewsMutex);
-  auto iter = this->dataPtr->views.insert(
-      std::make_pair(_types, std::move(_view))).first;
-  return iter->second.get();
+  auto iter = this->dataPtr->views.find(_types);
+  if (iter != this->dataPtr->views.end())
+    return iter->second.first.get();
+  this->dataPtr->views[_types] =
+    std::make_pair(std::move(_view), std::make_unique<std::mutex>());
+  return this->dataPtr->views[_types].first.get();
 }
 
 //////////////////////////////////////////////////
@@ -824,7 +836,7 @@ void EntityComponentManager::RebuildViews()
   IGN_PROFILE("EntityComponentManager::RebuildViews");
   for (auto &viewPair : this->dataPtr->views)
   {
-    auto &view = viewPair.second;
+    auto &view = viewPair.second.first;
     view->Reset();
 
     // Add all the entities that match the component types to the
@@ -1552,6 +1564,18 @@ void EntityComponentManager::SetEntityCreateOffset(uint64_t _offset)
   }
 
   this->dataPtr->entityCount = _offset;
+}
+
+/////////////////////////////////////////////////
+void EntityComponentManager::LockAddingEntitiesToViews(bool _lock)
+{
+  this->dataPtr->lockAddEntitiesToViews = _lock;
+}
+
+/////////////////////////////////////////////////
+bool EntityComponentManager::LockAddingEntitiesToViews() const
+{
+  return this->dataPtr->lockAddEntitiesToViews;
 }
 
 /////////////////////////////////////////////////

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -821,13 +821,13 @@ detail::BaseView *EntityComponentManager::AddView(
     const detail::ComponentTypeKey &_types,
     std::unique_ptr<detail::BaseView> _view) const
 {
+  // If the view already exists, then the map will return the iterator to
+  // the location that prevented the insertion.
   std::lock_guard<std::mutex> lockViews(this->dataPtr->viewsMutex);
-  auto iter = this->dataPtr->views.find(_types);
-  if (iter != this->dataPtr->views.end())
-    return iter->second.first.get();
-  this->dataPtr->views[_types] =
-    std::make_pair(std::move(_view), std::make_unique<std::mutex>());
-  return this->dataPtr->views[_types].first.get();
+  auto iter = this->dataPtr->views.insert(std::make_pair(_types,
+        std::make_pair(std::move(_view),
+          std::make_unique<std::mutex>()))).first;
+  return iter->second.first.get();
 }
 
 //////////////////////////////////////////////////

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -572,6 +572,7 @@ void SimulationRunner::UpdateSystems()
 
   {
     IGN_PROFILE("PostUpdate");
+    this->entityCompMgr.LockAddingEntitiesToViews(true);
     // If no systems implementing PostUpdate have been added, then
     // the barriers will be uninitialized, so guard against that condition.
     if (this->postUpdateStartBarrier && this->postUpdateStopBarrier)
@@ -579,6 +580,7 @@ void SimulationRunner::UpdateSystems()
       this->postUpdateStartBarrier->Wait();
       this->postUpdateStopBarrier->Wait();
     }
+    this->entityCompMgr.LockAddingEntitiesToViews(false);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

Fixes a race condition discovered in https://github.com/ignitionrobotics/ign-gazebo/pull/959#issuecomment-906883962

## Summary
As a consequence of the changes in #856, new entities aren't added to a view until the view is used, because we need access to the template signature of the view when adding entities to it. This introduces a potential race condition when processing system `PostUpdate`s since system `PostUpdate`s are run in parallel (see https://github.com/ignitionrobotics/ign-gazebo/pull/959#issuecomment-906883962 for a more detailed explanation).

The fix proposed here is to assign a mutex to every view that exists. Then, when processing system `PostUpdate`s, we lock the view while entities are being added to it. Since every view has its own mutex, this means that different views can still be accessed in parallel during `PostUpdate` calls - the only time blocking may occur is when two system `PostUpdate`s are trying to read from the same view. So, there shouldn't be any major performance hits here.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**