### PR TITLE
Update DART deps to Focal

### DIFF
--- a/docker/scripts/install_ign_deps.sh
+++ b/docker/scripts/install_ign_deps.sh
@@ -67,10 +67,11 @@ sudo apt-get install --no-install-recommends -y \
 # ign-physics dependencies
 sudo apt-get install --no-install-recommends -y \
   libeigen3-dev \
-  dart6-data \
-  libdart6-collision-ode-dev \
-  libdart6-dev \
-  libdart6-utils-urdf-dev \
+  libdart-collision-ode-dev \
+  libdart-dev \
+  libdart-external-ikfast-dev \
+  libdart-external-odelcpsolver-dev \
+  libdart-utils-urdf-dev \
   libbenchmark-dev
 
 # ign-gazebo dependencies


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1004

## Summary
Within the Docker `install_ign_deps.sh` script, I updated DART dependencies from packages within the Bionic apt repositories to their Focal counterparts, at @chapulina 's suggestion from #1004 .

NOTE! : After making the changes, building `ign_gazebo:base` and `ign_gazebo:nightly` successfully completed. However, I have not been able to verify that the images function properly. I've been unsuccessfully debugging X forwarding to make `glxgears` or `ign gazebo shapes.sdf` work in the container with a GUI. 

I'm opening this PR because I don't think it is related to my X11 bug, but I'd appreciate it if someone could verify that the created containers are correct.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**