### PR TITLE
Fix setting cast_shadows for visuals without material

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -315,7 +315,14 @@ rendering::VisualPtr SceneManager::CreateVisual(Entity _id,
           double productAlpha = (1.0-_visual.Transparency()) *
               (1.0 - submeshMat->Transparency());
           submeshMat->SetTransparency(1 - productAlpha);
+
+          // unlike setting transparency above, the parent submesh are not
+          // notified about the the cast shadows changes. So we need to set
+          // the material back to the submesh.
+          // \todo(anyone) find way to propate cast shadows changes tos submesh
+          // in ign-rendering
           submeshMat->SetCastShadows(_visual.CastShadows());
+          submesh->SetMaterial(submeshMat);
         }
       }
     }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

The `<cast_shadows>` SDF element has no effect for svisuals with no  `<material>` element. The  reason is that the cast shadows property change is not propagated to the parent submesh. This PR works around the issue by setting the material back to the submesh.

To test:

Download the [Electrical Box](https://app.ignitionrobotics.org/openrobotics/fuel/models/Electrical%20Box). Modify the model.sdf file in your fuel cache, i.e.:  `~/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/electrical box/3/model.sdf`, and add the following to the `<visual>` SDF element.

```
 <cast_shadows>0</cast_shadows>
```

Launch ign-gazebo with this world and insert the Electrical Box model to see that it no longer casts shadows. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
