### PR TITLE
Remove unused ignition gui header

### DIFF
--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -26,8 +26,6 @@
 
 #include <ignition/fuel_tools/Interface.hh>
 
-#include <ignition/gui/Application.hh>
-
 #include "ignition/gazebo/Util.hh"
 #include "SimulationRunner.hh"
 


### PR DESCRIPTION
Including `gui` headers requires inclusion/linking of ignition-gui as well as Qt, which is LGPL licensed.

This eliminates the dependency.

Signed-off-by: Michael Carroll <michael@openrobotics.org>