### PR TITLE
Fix crash on resize

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -641,8 +641,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
     // setting the size should cause the render texture to be rebuilt
     {
       IGN_PROFILE("IgnRenderer::Render Pre-render camera");
-      this->dataPtr->camera->PreRender();
-      this->dataPtr->camera->Render();
+      this->dataPtr->camera->Update();
     }
     // mark mouse dirty to force update view projection in HandleMouseEvent
     this->dataPtr->mouseDirty = true;


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-rendering/issues/408

## Summary

Fix crash when resizing ign-gazebo gui window

ign-rendering6 enforces a strict order of render calls (prerender -> render -> postrender) in order to achieve efficient use of resources. If we run into more issues / crashes like this in the future, we should probably just print a warning (and auto recover from a bad state) instead of exiting on an assert.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

