### PR TITLE
Fixed IMU system plugin

### DIFF
--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -27,8 +27,6 @@
 
 #include <ignition/common/Profiler.hh>
 
-#include <ignition/transport/Node.hh>
-
 #include <ignition/sensors/SensorFactory.hh>
 #include <ignition/sensors/ImuSensor.hh>
 
@@ -58,7 +56,13 @@ class ignition::gazebo::systems::ImuPrivate
   /// \brief Ign-sensors sensor factory for creating sensors
   public: sensors::SensorFactory sensorFactory;
 
+  /// \brief Keep track of world ID, which is equivalent to the scene's
+  /// root visual.
+  /// Defaults to zero, which is considered invalid by Ignition Gazebo.
   public: Entity worldEntity = kNullEntity;
+
+  /// True if the rendering component is initialized
+  public: bool initialize = false;
 
   /// \brief Create IMU sensor
   /// \param[in] _ecm Mutable reference to ECM.
@@ -67,6 +71,17 @@ class ignition::gazebo::systems::ImuPrivate
   /// \brief Update IMU sensor data based on physics data
   /// \param[in] _ecm Immutable reference to ECM.
   public: void Update(const EntityComponentManager &_ecm);
+
+  /// create sensor
+  /// \param[in] _ecm Mmutable reference to ECM.
+  /// \param[in] _entity Entity of the IMU
+  /// \param[in] _imu IMU component.
+  /// \param[in] _parent Parent entity component.
+  public: void addIMU(
+    EntityComponentManager &_ecm,
+    const Entity _entity,
+    const components::Imu *_imu,
+    const components::ParentEntity *_parent);
 
   /// \brief Remove IMU sensors if their entities have been removed from
   /// simulation.
@@ -122,6 +137,63 @@ void Imu::PostUpdate(const UpdateInfo &_info,
 }
 
 //////////////////////////////////////////////////
+void ImuPrivate::addIMU(
+  EntityComponentManager &_ecm,
+  const Entity _entity,
+  const components::Imu *_imu,
+  const components::ParentEntity *_parent)
+{
+  // Get the world acceleration (defined in world frame)
+  auto gravity = _ecm.Component<components::Gravity>(worldEntity);
+  if (nullptr == gravity)
+  {
+    ignerr << "World missing gravity." << std::endl;
+    return;
+  }
+
+  // create sensor
+  std::string sensorScopedName =
+      removeParentScope(scopedName(_entity, _ecm, "::", false), "::");
+  sdf::Sensor data = _imu->Data();
+  data.SetName(sensorScopedName);
+  // check topic
+  if (data.Topic().empty())
+  {
+    std::string topic = scopedName(_entity, _ecm) + "/imu";
+    data.SetTopic(topic);
+  }
+  std::unique_ptr<sensors::ImuSensor> sensor =
+      this->sensorFactory.CreateSensor<
+      sensors::ImuSensor>(data);
+  if (nullptr == sensor)
+  {
+    ignerr << "Failed to create sensor [" << sensorScopedName << "]"
+           << std::endl;
+    return;
+  }
+
+  // set sensor parent
+  std::string parentName = _ecm.Component<components::Name>(
+      _parent->Data())->Data();
+  sensor->SetParent(parentName);
+
+  // set gravity - assume it remains fixed
+  sensor->SetGravity(gravity->Data());
+
+  // Get initial pose of sensor and set the reference z pos
+  // The WorldPose component was just created and so it's empty
+  // We'll compute the world pose manually here
+  math::Pose3d p = worldPose(_entity, _ecm);
+  sensor->SetOrientationReference(p.Rot());
+
+  // Set topic
+  _ecm.CreateComponent(_entity, components::SensorTopic(sensor->Topic()));
+
+  this->entitySensorMap.insert(
+      std::make_pair(_entity, std::move(sensor)));
+}
+
+//////////////////////////////////////////////////
 void ImuPrivate::CreateImuEntities(EntityComponentManager &_ecm)
 {
   IGN_PROFILE("ImuPrivate::CreateImuEntities");
@@ -134,63 +206,31 @@ void ImuPrivate::CreateImuEntities(EntityComponentManager &_ecm)
     return;
   }
 
-  // Get the world acceleration (defined in world frame)
-  auto gravity = _ecm.Component<components::Gravity>(worldEntity);
-  if (nullptr == gravity)
+  if (!this->initialize)
   {
-    ignerr << "World missing gravity." << std::endl;
-    return;
-  }
-
-  // Create IMUs
-  _ecm.EachNew<components::Imu, components::ParentEntity>(
-    [&](const Entity &_entity,
-        const components::Imu *_imu,
-        const components::ParentEntity *_parent)->bool
-      {
-        // create sensor
-        std::string sensorScopedName =
-            removeParentScope(scopedName(_entity, _ecm, "::", false), "::");
-        sdf::Sensor data = _imu->Data();
-        data.SetName(sensorScopedName);
-        // check topic
-        if (data.Topic().empty())
+    // Create IMUs
+    _ecm.Each<components::Imu, components::ParentEntity>(
+      [&](const Entity &_entity,
+          const components::Imu *_imu,
+          const components::ParentEntity *_parent)->bool
         {
-          std::string topic = scopedName(_entity, _ecm) + "/imu";
-          data.SetTopic(topic);
-        }
-        std::unique_ptr<sensors::ImuSensor> sensor =
-            this->sensorFactory.CreateSensor<
-            sensors::ImuSensor>(data);
-        if (nullptr == sensor)
-        {
-          ignerr << "Failed to create sensor [" << sensorScopedName << "]"
-                 << std::endl;
+          addIMU(_ecm, _entity, _imu, _parent);
           return true;
-        }
-
-        // set sensor parent
-        std::string parentName = _ecm.Component<components::Name>(
-            _parent->Data())->Data();
-        sensor->SetParent(parentName);
-
-        // set gravity - assume it remains fixed
-        sensor->SetGravity(gravity->Data());
-
-        // Get initial pose of sensor and set the reference z pos
-        // The WorldPose component was just created and so it's empty
-        // We'll compute the world pose manually here
-        math::Pose3d p = worldPose(_entity, _ecm);
-        sensor->SetOrientationReference(p.Rot());
-
-        // Set topic
-        _ecm.CreateComponent(_entity, components::SensorTopic(sensor->Topic()));
-
-        this->entitySensorMap.insert(
-            std::make_pair(_entity, std::move(sensor)));
-
-        return true;
-      });
+        });
+      this->initialize = true;
+  }
+  else
+  {
+    // Create IMUs
+    _ecm.EachNew<components::Imu, components::ParentEntity>(
+      [&](const Entity &_entity,
+          const components::Imu *_imu,
+          const components::ParentEntity *_parent)->bool
+        {
+          addIMU(_ecm, _entity, _imu, _parent);
+          return true;
+        });
+    }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

While I was developing `ign_ros2_control` I found an issue which is related with adding new model, for example, using `ign_ros` to add a URDF.

The IMU system plugin is added after the IMU is in the scene which means `_ecm.EachNew` is was called and IMU will be added to the plugin. To fix this I used a similar approach that you can find in `RenderUtils.cc`

For this reason I used `_ecm.Each` in the first iteration and then we should stick with the current behaviour.

I think this should be extended to the other sensor plugins.

## Summary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**