### PR TITLE
Place config files in a versioned directory

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -65,6 +65,9 @@ since pose information is being logged in the `changed_state` topic.
       + `TransformControl`: Translate and rotate
       + `ViewAndle`: Move camera to preset angles
 
+* The `gui.config` and `server.config` files are now located in a versioned
+  folder inside `$HOME/.ignition/gazebo`, i.e. `$HOME/.ignition/gazebo/6/gui.config`.
+
 ## Ignition Gazebo 4.x to 5.x
 
 * Use `cli` component of `ignition-utils1`.

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -877,7 +877,7 @@ ignition::gazebo::loadPluginInfo(bool _isPlayback)
   std::string defaultConfigDir;
   ignition::common::env(IGN_HOMEDIR, defaultConfigDir);
   defaultConfigDir = ignition::common::joinPaths(defaultConfigDir, ".ignition",
-    "gazebo");
+    "gazebo", IGNITION_GAZEBO_MAJOR_VERSION_STR);
 
   auto defaultConfig = ignition::common::joinPaths(defaultConfigDir,
       configFilename);

--- a/src/cmd/ign.cc
+++ b/src/cmd/ign.cc
@@ -231,7 +231,7 @@ extern "C" int runGui(const char *_guiConfig)
   std::string defaultConfig;
   ignition::common::env(IGN_HOMEDIR, defaultConfig);
   defaultConfig = ignition::common::joinPaths(defaultConfig, ".ignition",
-      "gazebo", "gui.config");
+      "gazebo", IGNITION_GAZEBO_MAJOR_VERSION_STR, "gui.config");
   app.SetDefaultConfigPath(defaultConfig);
 
   // Customize window
@@ -418,7 +418,7 @@ extern "C" int runGui(const char *_guiConfig)
       }
     }
 
-    // Also set ~/.ignition/gazebo/gui.config as the default path
+    // Also set ~/.ignition/gazebo/ver/gui.config as the default path
     if (!app.LoadConfig(defaultConfig))
     {
       ignerr << "Failed to load config file[" << _guiConfig << "]."

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -90,7 +90,7 @@ std::unique_ptr<ignition::gui::Application> createGui(
     }
     ignition::common::env(IGN_HOMEDIR, defaultConfig);
     defaultConfig = ignition::common::joinPaths(defaultConfig, ".ignition",
-        "gazebo", defaultGuiConfigName);
+        "gazebo", IGNITION_GAZEBO_MAJOR_VERSION_STR, defaultGuiConfigName);
   }
   else
   {
@@ -279,7 +279,7 @@ std::unique_ptr<ignition::gui::Application> createGui(
       }
     }
 
-    // Also set ~/.ignition/gazebo/gui.config as the default path
+    // Also set ~/.ignition/gazebo/ver/gui.config as the default path
     if (!app->LoadConfig(defaultConfig))
     {
       ignerr << "Failed to load config file[" << defaultConfig << "]."

--- a/tutorials/gui_config.md
+++ b/tutorials/gui_config.md
@@ -13,7 +13,8 @@ There are a few places where the GUI configuration can come from:
 
 1. A file passed to the `--gui-config` command line argument
 2. A `<gui>` element inside an SDF file
-3. The default configuration file at `$HOME/.ignition/gazebo/gui.config` \*
+3. The default configuration file at `$HOME/.ignition/gazebo/<#>/gui.config` \*,
+   where `<#>` is Gazebo's major version.
 
 Each of the items above takes precedence over the ones below it. For example,
 if a user chooses a `--gui-config`, the SDF's `<gui>` element is ignored. And
@@ -21,7 +22,7 @@ the default configuration file is only loaded if no configuration is passed
 through the command line or the SDF file.
 
 > \* For log-playback, the default file is
-> `$HOME/.ignition/gazebo/playback_gui.config`
+> `$HOME/.ignition/gazebo/<#>/playback_gui.config`
 
 ## Try it out
 
@@ -39,7 +40,7 @@ You should see an empty world with several plugins loaded by default, such as th
 
 By default, you're loading this file:
 
-`$HOME/.ignition/gazebo/gui.config`
+`$HOME/.ignition/gazebo/<#>/gui.config`
 
 That file is created the first time you load Ignition Gazebo. Once it is
 created, Ignition will never write to it again unless you delete it. This
@@ -50,7 +51,7 @@ Let's try customizing it:
 
 1. Open this file with your favorite editor:
 
-    `$HOME/.ignition/gazebo/gui.config`
+    `$HOME/.ignition/gazebo/<#>/gui.config`
 
 2. Change `material_theme` from `Light` to `Dark`
 
@@ -67,7 +68,7 @@ provided by Ignition (when you update to a newer version for example). In
 that case, just delete that file, and the next time Gazebo is started a new file
 will be created with default values:
 
-`rm $HOME/.ignition/gazebo/gui.config`
+`rm $HOME/.ignition/gazebo/<#>/gui.config`
 
 ### SDF
 
@@ -168,7 +169,7 @@ hand, we'll create it from the UI.
 3. Gazebo should open with your custom layout.
 
 **Tip**: From the top-left menu, you can choose "Save client configuration" to
-save directly to `$HOME/.ignition/gazebo/gui.config`.
+save directly to `$HOME/.ignition/gazebo/<#>/gui.config`.
 
 @image html files/gui_config/cmd_line.png
 

--- a/tutorials/migration_sdf.md
+++ b/tutorials/migration_sdf.md
@@ -259,8 +259,8 @@ and [xacro](http://wiki.ros.org/xacro) to generate SDF files with the correct pl
 
 Ignition Gazebo is more modular than Gazebo classic, so most features are optional.
 For example, by default, Ignition will load all the system plugins defined on
-the `~/.ignition/gazebo/server.config` file and all GUI plugins defined on the
-`~/.ignition/gazebo/gui.config` file. But the user can always remove plugins from
+the `~/.ignition/gazebo/<#>/server.config` file and all GUI plugins defined on the
+`~/.ignition/gazebo/<#>/gui.config` file. But the user can always remove plugins from
 those files, or choose different ones by adding `<plugin>` tags to the SDF file.
 (For more details, see the [Server configuration tutorial](server_config.html)
 and the [GUI configuration tutorial](gui_config.html)).

--- a/tutorials/resources.md
+++ b/tutorials/resources.md
@@ -61,7 +61,7 @@ Ignition will look for GUI plugins on the following paths, in order:
 1. All paths set on the `IGN_GUI_PLUGIN_PATH` environment variable
 2. [GUI plugins that are installed with Ignition Gazebo](https://github.com/ignitionrobotics/ign-gazebo/tree/main/src/gui/plugins)
 3. Other paths added by calling `ignition::gui::App()->AddPluginPath`
-4. `~/.ignition/gui/plugins`
+4. `~/.ignition/gui/<#>/plugins`
 5. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/4.2/namespaceignition_1_1gui_1_1plugins.html)
 
 ### Physics engines
@@ -152,7 +152,7 @@ can come from the following, in order:
 
 1. The command line option `--gui-config <file path>`
 2. Plugins within SDF's `<world><gui>`
-3. `$HOME/.ignition/gazebo/gui.config` (if that file doesn't
+3. `$HOME/.ignition/gazebo/<#>/gui.config` (if that file doesn't
 exist, the default `gui.config` file that is installed with Ignition Gazebo
 will be copied to that location)
 

--- a/tutorials/resources.md
+++ b/tutorials/resources.md
@@ -61,7 +61,7 @@ Ignition will look for GUI plugins on the following paths, in order:
 1. All paths set on the `IGN_GUI_PLUGIN_PATH` environment variable
 2. [GUI plugins that are installed with Ignition Gazebo](https://github.com/ignitionrobotics/ign-gazebo/tree/main/src/gui/plugins)
 3. Other paths added by calling `ignition::gui::App()->AddPluginPath`
-4. `~/.ignition/gui/<#>/plugins`
+4. `~/.ignition/gui/plugins`
 5. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/4.2/namespaceignition_1_1gui_1_1plugins.html)
 
 ### Physics engines

--- a/tutorials/server_config.md
+++ b/tutorials/server_config.md
@@ -14,7 +14,8 @@ There are a few places where the plugins can be defined:
 
 1. `<plugin>` elements inside an SDF file.
 2. File path defined by the `IGN_GAZEBO_SERVER_CONFIG_PATH` environment variable.
-3. The default configuration file at `$HOME/.ignition/gazebo/server.config` \*
+3. The default configuration file at `$HOME/.ignition/gazebo/<#>/server.config` \*,
+   where `<#>` is Gazebo's major version.
 
 Each of the items above takes precedence over the ones below it. For example,
 if a the SDF file has any `<plugin>` elements, then the
@@ -23,7 +24,7 @@ file is only loaded if no plugins are passed through the SDF file or the
 environment variable.
 
 > \* For log-playback, the default file is
-> `$HOME/.ignition/gazebo/playback_gui.config`
+> `$HOME/.ignition/gazebo/<#>/playback_server.config`
 
 ## Try it out
 
@@ -48,7 +49,7 @@ broadcaster is loaded.
 
 By default, you're loading this file:
 
-`$HOME/.ignition/gazebo/server.config`
+`$HOME/.ignition/gazebo/<#>/server.config`
 
 That file is created the first time you load Ignition Gazebo. Once it is
 created, Ignition will never write to it again unless you delete it. This
@@ -59,7 +60,7 @@ Let's try customizing it:
 
 1. Open this file with your favorite editor:
 
-    `$HOME/.ignition/gazebo/server.config`
+    `$HOME/.ignition/gazebo/<#>/server.config`
 
 2. Remove the `<plugin>` block for the physics system
 
@@ -77,7 +78,7 @@ provided by Ignition (when you update to a newer version for example). In
 that case, just delete that file, and the next time Gazebo is started a new file
 will be created with default values:
 
-`rm $HOME/.ignition/gazebo/server.config`
+`rm $HOME/.ignition/gazebo/<#>/server.config`
 
 ### SDF
 

--- a/tutorials/video_recorder.md
+++ b/tutorials/video_recorder.md
@@ -42,7 +42,7 @@ in the world SDF file so you will need to download a copy of the
 and modify the GUI configuration in that file. On the other hand, if you
 launched Ignition Gazebo with a world file that does not have GUI
 configurations, you will need to specify the settings in
-`$HOME/.ignition/gazebo/gui.config`.
+`$HOME/.ignition/gazebo/<#>/gui.config`.
 
 Recall that videos are recorded from the 3D scene, we will to set the video
 configurations in the 3D scene plugin. Here is an example of the
@@ -105,7 +105,7 @@ going to the world SDF file, locate the
 
 * **bitrate**: Video encoding bitrate in bps. This affects the quality of the
 generated video. The default bitrate is 2Mbps.
-  
+
 ## Hardware-accelerated encoding
 
 Since Ignition Common 3.10.2, there is support for utilizing the power of GPUs


### PR DESCRIPTION
Signed-off-by: Louise Poubel <louise@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #765

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

From Fortress, place the config files in a versioned directory inside `~/.ignition/gazebo`. This will make sure that Fortress users don't reuse config files from older versions unless they explicitly ask to.

I targeted this at Fortress because I still haven't thought of a nice way to make this backwards compatible. The suggestion I put on the issue:

> For example, Gazebo could always look for ~/.ignition/gazebo/gui.config first, and use that if it exists.

Wouldn't be a good idea for existing users who are migrating to Fortress, for example.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests - existing tests should pass
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
