### PR TITLE
Fixes to GUI config and minimal scene example

### DIFF
--- a/examples/worlds/minimal_scene.sdf
+++ b/examples/worlds/minimal_scene.sdf
@@ -17,12 +17,8 @@ Features:
 * Spawn entities through GUI
 * View angles
 * View collisions, wireframe, transparent, CoM, etc
-
-Missing for parity with GzScene3D:
-
 * Context menu
 * Drag and drop from Fuel / meshes
-* ...
 
 -->
 <sdf version="1.6">
@@ -56,10 +52,6 @@ Missing for parity with GzScene3D:
       </plugin>
       <plugin filename="GzSceneManager" name="Scene Manager">
         <ignition-gui>
-          <anchors target="3D View">
-            <line own="right" target="right"/>
-            <line own="top" target="top"/>
-          </anchors>
           <property key="resizable" type="bool">false</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
@@ -69,10 +61,6 @@ Missing for parity with GzScene3D:
       </plugin>
       <plugin filename="InteractiveViewControl" name="Interactive view control">
         <ignition-gui>
-          <anchors target="3D View">
-            <line own="right" target="right"/>
-            <line own="top" target="top"/>
-          </anchors>
           <property key="resizable" type="bool">false</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
@@ -82,10 +70,6 @@ Missing for parity with GzScene3D:
       </plugin>
       <plugin filename="CameraTracking" name="Camera Tracking">
         <ignition-gui>
-          <anchors target="3D View">
-            <line own="right" target="right"/>
-            <line own="top" target="top"/>
-          </anchors>
           <property key="resizable" type="bool">false</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
@@ -95,7 +79,16 @@ Missing for parity with GzScene3D:
       </plugin>
       <plugin filename="MarkerManager" name="Marker manager">
         <ignition-gui>
-          <anchors target="3D View">
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="SelectEntities" name="Select Entities">
+        <ignition-gui>
+          <anchors target="Select entities">
             <line own="right" target="right"/>
             <line own="top" target="top"/>
           </anchors>
@@ -106,7 +99,17 @@ Missing for parity with GzScene3D:
           <property key="showTitleBar" type="bool">false</property>
         </ignition-gui>
       </plugin>
-      <plugin filename="SelectEntities" name="Select Entities">
+      <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
+        <ignition-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <plugin filename="Spawn" name="Spawn Entities">
         <ignition-gui>
           <anchors target="Select entities">
             <line own="right" target="right"/>
@@ -143,20 +146,6 @@ Missing for parity with GzScene3D:
 
       </plugin>
 
-      <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
-        <ignition-gui>
-          <anchors target="Select entities">
-            <line own="right" target="right"/>
-            <line own="top" target="top"/>
-          </anchors>
-          <property key="resizable" type="bool">false</property>
-          <property key="width" type="double">5</property>
-          <property key="height" type="double">5</property>
-          <property key="state" type="string">floating</property>
-          <property key="showTitleBar" type="bool">false</property>
-        </ignition-gui>
-      </plugin>
-
       <!-- World statistics -->
       <plugin filename="WorldStats" name="World stats">
         <ignition-gui>
@@ -178,20 +167,6 @@ Missing for parity with GzScene3D:
         <real_time>true</real_time>
         <real_time_factor>true</real_time_factor>
         <iterations>true</iterations>
-      </plugin>
-
-      <plugin filename="Spawn" name="Spawn Entities">
-        <ignition-gui>
-          <anchors target="Select entities">
-            <line own="right" target="right"/>
-            <line own="top" target="top"/>
-          </anchors>
-          <property key="resizable" type="bool">false</property>
-          <property key="width" type="double">5</property>
-          <property key="height" type="double">5</property>
-          <property key="state" type="string">floating</property>
-          <property key="showTitleBar" type="bool">false</property>
-        </ignition-gui>
       </plugin>
 
       <!-- Insert simple shapes -->

--- a/src/gui/gui.config
+++ b/src/gui/gui.config
@@ -52,10 +52,6 @@
 </plugin>
 <plugin filename="GzSceneManager" name="Scene Manager">
   <ignition-gui>
-    <anchors target="3D View">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -65,10 +61,6 @@
 </plugin>
 <plugin filename="InteractiveViewControl" name="Interactive view control">
   <ignition-gui>
-    <anchors target="3D View">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -78,10 +70,6 @@
 </plugin>
 <plugin filename="CameraTracking" name="Camera Tracking">
   <ignition-gui>
-    <anchors target="3D View">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -91,10 +79,6 @@
 </plugin>
 <plugin filename="MarkerManager" name="Marker manager">
   <ignition-gui>
-    <anchors target="3D View">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -104,10 +88,6 @@
 </plugin>
 <plugin filename="SelectEntities" name="Select Entities">
   <ignition-gui>
-    <anchors target="Select entities">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -118,10 +98,6 @@
 
 <plugin filename="Spawn" name="Spawn Entities">
   <ignition-gui>
-    <anchors target="Select entities">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -132,10 +108,6 @@
 
 <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
   <ignition-gui>
-    <anchors target="Select entities">
-      <line own="right" target="right"/>
-      <line own="top" target="top"/>
-    </anchors>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
@@ -263,14 +235,4 @@
     <property type="bool" key="showTitleBar">false</property>
     <property type="string" key="state">docked</property>
   </ignition-gui>
-</plugin>
-
-<!-- View angle -->
-<plugin filename="ViewAngle" name="View angle">
-  <ignition-gui>
-    <property type="string" key="state">docked</property>
-  </ignition-gui>
-
-  <!-- disable legacy features used to connect this plugin to GzScene3D -->
-  <legacy>false</legacy>
 </plugin>


### PR DESCRIPTION
# Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

* Fix feature list
* Remove View Angle from default config
* Remove anchors from invisible plugins, they should be on the top-left corner of the screen anyway
* Reorder plugins on the example

Another thing we need to do is to update all examples to use `MinimalScene` instead of `GzScene`. That can come in a separate PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
