### PR TITLE
Fix GUI crash when accessing bad rendering UserData

### DIFF
--- a/src/gui/plugins/align_tool/AlignTool.cc
+++ b/src/gui/plugins/align_tool/AlignTool.cc
@@ -365,7 +365,7 @@ void AlignTool::Align()
         continue;
 
       if (vis->HasUserData("gazebo-entity") &&
-          std::get<int>(vis->UserData("gazebo-entity")) == 
+          std::get<int>(vis->UserData("gazebo-entity")) ==
           static_cast<int>(entityId))
       {
         // Check here to see if visual is top level or not, continue if not

--- a/src/gui/plugins/align_tool/AlignTool.cc
+++ b/src/gui/plugins/align_tool/AlignTool.cc
@@ -364,7 +364,8 @@ void AlignTool::Align()
       if (!vis)
         continue;
 
-      if (std::get<int>(vis->UserData("gazebo-entity")) ==
+      if (vis->HasUserData("gazebo-entity") &&
+          std::get<int>(vis->UserData("gazebo-entity")) == 
           static_cast<int>(entityId))
       {
         // Check here to see if visual is top level or not, continue if not

--- a/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.cc
+++ b/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.cc
@@ -71,16 +71,14 @@ void EntityContextMenuPrivate::OnRender()
     {
       auto cam = std::dynamic_pointer_cast<rendering::Camera>(
         this->scene->NodeByIndex(i));
-      if (cam)
+      if (cam && cam->HasUserData("user-camera") &&
+          std::get<bool>(cam->UserData("user-camera")))
       {
-        if (std::get<bool>(cam->UserData("user-camera")))
-        {
-          this->camera = cam;
+        this->camera = cam;
 
-          igndbg << "Entity context menu plugin is using camera ["
-                 << this->camera->Name() << "]" << std::endl;
-          break;
-        }
+        igndbg << "Entity context menu plugin is using camera ["
+               << this->camera->Name() << "]" << std::endl;
+        break;
       }
     }
   }

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1026,7 +1026,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
           scene->NodeByName(this->dataPtr->viewTransparentTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -1052,7 +1052,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
           scene->NodeByName(this->dataPtr->viewCOMTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -1078,7 +1078,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
           scene->NodeByName(this->dataPtr->viewInertiaTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -1104,7 +1104,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
           scene->NodeByName(this->dataPtr->viewJointsTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -1130,7 +1130,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
           scene->NodeByName(this->dataPtr->viewWireframesTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -1156,7 +1156,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
           scene->NodeByName(this->dataPtr->viewCollisionsTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));

--- a/src/gui/plugins/select_entities/SelectEntities.cc
+++ b/src/gui/plugins/select_entities/SelectEntities.cc
@@ -441,15 +441,13 @@ void SelectEntitiesPrivate::Initialize()
     {
       auto cam = std::dynamic_pointer_cast<rendering::Camera>(
         scene->NodeByIndex(i));
-      if (cam)
+      if (cam && cam->HasUserData("user-camera") &&
+          std::get<bool>(cam->UserData("user-camera")))
       {
-        if (std::get<bool>(cam->UserData("user-camera")))
-        {
-          this->camera = cam;
-          igndbg << "TransformControl plugin is using camera ["
-                 << this->camera->Name() << "]" << std::endl;
-          break;
-        }
+        this->camera = cam;
+        igndbg << "SelectEntities plugin is using camera ["
+               << this->camera->Name() << "]" << std::endl;
+        break;
       }
     }
 
@@ -531,7 +529,8 @@ bool SelectEntities::eventFilter(QObject *_obj, QEvent *_event)
           auto visual = this->dataPtr->scene->VisualByIndex(i);
 
           unsigned int entityId = kNullEntity;
-          try{
+          try
+          {
             entityId = std::get<int>(visual->UserData("gazebo-entity"));
           }
           catch(std::bad_variant_access &)

--- a/src/gui/plugins/spawn/Spawn.cc
+++ b/src/gui/plugins/spawn/Spawn.cc
@@ -311,19 +311,17 @@ void SpawnPrivate::OnRender()
     {
       auto cam = std::dynamic_pointer_cast<rendering::Camera>(
         this->scene->NodeByIndex(i));
-      if (cam)
+      if (cam && cam->HasUserData("user-camera") &&
+          std::get<bool>(cam->UserData("user-camera")))
       {
-        if (std::get<bool>(cam->UserData("user-camera")))
-        {
-          this->camera = cam;
+        this->camera = cam;
 
-          // Ray Query
-          this->rayQuery = this->camera->Scene()->CreateRayQuery();
+        // Ray Query
+        this->rayQuery = this->camera->Scene()->CreateRayQuery();
 
-          igndbg << "Spawn plugin is using camera ["
-                 << this->camera->Name() << "]" << std::endl;
-          break;
-        }
+        igndbg << "Spawn plugin is using camera ["
+               << this->camera->Name() << "]" << std::endl;
+        break;
       }
     }
   }

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -507,15 +507,13 @@ void TransformControlPrivate::HandleTransform()
     {
       auto cam = std::dynamic_pointer_cast<rendering::Camera>(
         this->scene->NodeByIndex(i));
-      if (cam)
+      if (cam && cam->HasUserData("user-camera") &&
+          std::get<bool>(cam->UserData("user-camera")))
       {
-        if (std::get<bool>(cam->UserData("user-camera")))
-        {
-          this->camera = cam;
-          igndbg << "TransformControl plugin is using camera ["
-                 << this->camera->Name() << "]" << std::endl;
-          break;
-        }
+        this->camera = cam;
+        igndbg << "TransformControl plugin is using camera ["
+               << this->camera->Name() << "]" << std::endl;
+        break;
       }
     }
 
@@ -534,7 +532,8 @@ void TransformControlPrivate::HandleTransform()
   {
     if (this->transformControl.Node())
     {
-      try {
+      try
+      {
         this->transformControl.Node()->SetUserData(
           "pause-update", static_cast<int>(0));
       }
@@ -591,7 +590,8 @@ void TransformControlPrivate::HandleTransform()
           this->transformControl.SetActiveAxis(axis);
           this->transformControl.Start();
           if (this->transformControl.Node()){
-            try {
+            try
+            {
               this->transformControl.Node()->SetUserData(
                 "pause-update", static_cast<int>(1));
             }
@@ -623,7 +623,8 @@ void TransformControlPrivate::HandleTransform()
           {
             if (this->transformControl.Node())
             {
-              try {
+              try
+              {
                 this->transformControl.Node()->SetUserData(
                   "pause-update", static_cast<int>(0));
               }
@@ -712,7 +713,8 @@ void TransformControlPrivate::HandleTransform()
               if (topClickedNode == topClickedVisual)
               {
                 this->transformControl.Attach(topClickedVisual);
-                try {
+                try
+                {
                   topClickedVisual->SetUserData(
                     "pause-update", static_cast<int>(1));
                 }
@@ -724,7 +726,8 @@ void TransformControlPrivate::HandleTransform()
               else
               {
                 this->transformControl.Detach();
-                try {
+                try
+                {
                   topClickedVisual->SetUserData(
                     "pause-update", static_cast<int>(0));
                 }
@@ -746,7 +749,8 @@ void TransformControlPrivate::HandleTransform()
       && this->transformControl.Active())
   {
     if (this->transformControl.Node()){
-      try {
+      try
+      {
         this->transformControl.Node()->SetUserData(
           "pause-update", static_cast<int>(1));
       } catch (std::bad_variant_access &)
@@ -780,7 +784,8 @@ void TransformControlPrivate::HandleTransform()
       {
         auto visual = this->scene->VisualByIndex(i);
         auto entityId = kNullEntity;
-        try {
+        try
+        {
           entityId = static_cast<unsigned int>(
             std::get<int>(visual->UserData("gazebo-entity")));
         }

--- a/src/gui/plugins/video_recorder/VideoRecorder.cc
+++ b/src/gui/plugins/video_recorder/VideoRecorder.cc
@@ -144,15 +144,13 @@ void VideoRecorderPrivate::Initialize()
   {
     auto cam = std::dynamic_pointer_cast<rendering::Camera>(
       this->scene->NodeByIndex(i));
-    if (cam)
+    if (cam && cam->HasUserData("user-camera") &&
+        std::get<bool>(cam->UserData("user-camera")))
     {
-      if (std::get<bool>(cam->UserData("user-camera")))
-      {
-        this->camera = cam;
-        igndbg << "Video Recorder plugin is recoding camera ["
-               << this->camera->Name() << "]" << std::endl;
-        break;
-      }
+      this->camera = cam;
+      igndbg << "Video Recorder plugin is recoding camera ["
+             << this->camera->Name() << "]" << std::endl;
+      break;
     }
   }
 

--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
@@ -690,7 +690,7 @@ void VisualizationCapabilitiesPrivate::OnRender()
           scene->NodeByName(this->viewCOMTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -716,7 +716,7 @@ void VisualizationCapabilitiesPrivate::OnRender()
           scene->NodeByName(this->viewInertiaTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -742,7 +742,7 @@ void VisualizationCapabilitiesPrivate::OnRender()
           this->scene->VisualByName(this->viewTransparentTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -768,7 +768,7 @@ void VisualizationCapabilitiesPrivate::OnRender()
           scene->NodeByName(this->viewCollisionsTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -794,7 +794,7 @@ void VisualizationCapabilitiesPrivate::OnRender()
           scene->NodeByName(this->viewJointsTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));
@@ -820,7 +820,7 @@ void VisualizationCapabilitiesPrivate::OnRender()
           scene->NodeByName(this->viewWireframesTarget);
       auto targetVis = std::dynamic_pointer_cast<rendering::Visual>(targetNode);
 
-      if (targetVis)
+      if (targetVis && targetVis->HasUserData("gazebo-entity"))
       {
         Entity targetEntity =
             std::get<int>(targetVis->UserData("gazebo-entity"));


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Fix a bug that came up during the tutorial party. Without this fix, the `AlignTool` plugin crashes on use.

I went ahead and guarded all instances of `UserData` that weren't already protected by `try / catch` blocks.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
