### PR TITLE
Support setting heightmap position through sdf

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -528,6 +528,7 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
     rendering::HeightmapDescriptor descriptor;
     descriptor.SetData(data);
     descriptor.SetSize(_geom.HeightmapShape()->Size());
+    descriptor.SetPosition(_geom.HeightmapShape()->Position());
     descriptor.SetSampling(_geom.HeightmapShape()->Sampling());
 
     for (uint64_t i = 0; i < _geom.HeightmapShape()->TextureCount(); ++i)


### PR DESCRIPTION

# 🦟 Bug fix

Setting the heightmap [<pos> sdf element](http://sdformat.org/spec?ver=1.8&elem=geometry#heightmap_pos) has no effect. This PR reads the value from SDF DOM and passes it to ign-rendering so we can change the heightmap position offset.

Test by downloading a heightmap model from fuel, e.g. 
https://app.ignitionrobotics.org/chapulina/fuel/models/Heightmap%20Bowl

edit the model.sdf in the fuel cache and set the <pos> values to anything other than 0 0 0 to change its position

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
