### PR TITLE
Fix finding heightmap blend textures

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -536,10 +536,10 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
       auto textureSdf = _geom.HeightmapShape()->TextureByIndex(i);
       rendering::HeightmapTexture textureDesc;
       textureDesc.SetSize(textureSdf->Size());
-      textureDesc.SetDiffuse(asFullPath(textureSdf->Diffuse(),
-          _geom.HeightmapShape()->FilePath()));
-      textureDesc.SetNormal(asFullPath(textureSdf->Normal(),
-          _geom.HeightmapShape()->FilePath()));
+      textureDesc.SetDiffuse(common::findFile(asFullPath(textureSdf->Diffuse(),
+          _geom.HeightmapShape()->FilePath())));
+      textureDesc.SetNormal(common::findFile(asFullPath(textureSdf->Normal(),
+          _geom.HeightmapShape()->FilePath())));
       descriptor.AddTexture(textureDesc);
     }
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -528,6 +528,7 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
     rendering::HeightmapDescriptor descriptor;
     descriptor.SetData(data);
     descriptor.SetSize(_geom.HeightmapShape()->Size());
+    descriptor.SetPosition(_geom.HeightmapShape()->Position());
     descriptor.SetSampling(_geom.HeightmapShape()->Sampling());
 
     for (uint64_t i = 0; i < _geom.HeightmapShape()->TextureCount(); ++i)


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

When heightmap models are placed in a custom  `IGN_GAZEBO_RESOURCE_PATH` but their textures are specified using relative paths, ign-rendering / ogre complains about these files not found. This is because they are not located in the standard ogre resource search directories so we need to use `common::findFile` to get their full paths.

## Summary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

