### PR TITLE
Fix rotating cubes when placed by GUI tool while using the buoyancy plugin

### DIFF
--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -420,7 +420,7 @@ void Buoyancy::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
     {
       auto newPose = enableComponent<components::Inertial>(_ecm, _entity);
       newPose |= enableComponent<components::WorldPose>(_ecm, _entity);
-      if(newPose)
+      if (newPose)
       {
         // Skip entity if WorldPose and inertial are not yet ready
         return true;

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -178,7 +178,6 @@ void BuoyancyPrivate::GradedFluidDensity(
     this->buoyancyForces.push_back(buoyancyAction);
 
     prevLayerVol = vol;
-
   }
   // For the rest of the layers.
   auto vol = _shape.Volume();
@@ -219,6 +218,7 @@ std::pair<math::Vector3d, math::Vector3d> BuoyancyPrivate::ResolveForces(
     auto offset = globalPoint.Pos() - _pose.Pos();
     torque += force.Cross(offset);
   }
+
   return {force, torque};
 }
 
@@ -464,6 +464,7 @@ void Buoyancy::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
         {
           const components::CollisionElement *coll =
             _ecm.Component<components::CollisionElement>(e);
+
           auto pose = worldPose(e, _ecm);
 
           if (!coll)
@@ -493,10 +494,8 @@ void Buoyancy::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
           }
         }
       }
-
       auto [force, torque] = this->dataPtr->ResolveForces(
         link.WorldInertialPose(_ecm).value());
-
       // Apply the wrench to the link. This wrench is applied in the
       // Physics System.
       link.AddWorldWrench(_ecm, force, torque);

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -308,7 +308,7 @@ void Buoyancy::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
            << std::endl;
     return;
   }
-  
+
   // Compute the volume and center of volume for each new link
   _ecm.EachNew<components::Link, components::Inertial>(
       [&](const Entity &_entity,

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -57,7 +57,7 @@ TEST_F(BuoyancyTest, UniformWorldMovement)
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  std::size_t iterations = 1000;
+  std::size_t iterations = 1001;
 
   bool finished = false;
   test::Relay testSystem;
@@ -183,7 +183,7 @@ TEST_F(BuoyancyTest, UniformWorldMovement)
 
     if (_info.iterations == iterations)
     {
-      EXPECT_NEAR(-1.63, submarineSinkingPose->Data().Pos().Z(), 1e-2);
+      EXPECT_NEAR(-1.64, submarineSinkingPose->Data().Pos().Z(), 1e-2);
       EXPECT_NEAR(4.90, submarineBuoyantPose->Data().Pos().Z(), 1e-2);
       EXPECT_NEAR(171.4, duckPose->Data().Pos().Z(), 1e-2);
       finished = true;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Previously @aaronchongth discovered that the following behaviour takes place when adding shapes using the GUI tool while running the simulation

https://user-images.githubusercontent.com/542272/135060560-58df4949-9437-4d4a-8aee-6c418d257878.mp4

While this makes for great VFX, it is certainly not intended behavior. The root cause was eventually traced to the fact that when the gui tool is used new objects don't have a pose. The buoyancy plugin creates a pose component but does not wait for an update cycle. This PR moves the point at which the pose is read. Thus in the first preupdate cycle, the plugin will do nothing but enable the pose component.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

## Note 

If you test this in the fortress demo world you may find the cubes sink _really_ slowly. This is fine, as the cubes are really light given their volume and the plugin is configured to simulate air.
