### PR TITLE
Enable specific entities on buoyancy plugin

### DIFF
--- a/examples/worlds/graded_buoyancy.sdf
+++ b/examples/worlds/graded_buoyancy.sdf
@@ -34,16 +34,16 @@
         </density_change>
       </graded_buoyancy>
 
-      <!-- whitelist by link name -->
-      <white_list>lighter_than_water::ball::body</white_list>
+      <!-- enable by link name -->
+      <enable>lighter_than_water::ball::body</enable>
 
-      <!-- whitelist by nested model name -->
-      <white_list>lighter_than_water::box</white_list>
+      <!-- enable by nested model name -->
+      <enable>lighter_than_water::box</enable>
 
-      <!-- whitelist by top level model name -->
-      <white_list>balloon_lighter_than_air</white_list>
-      <white_list>box_neutral_buoyancy</white_list>
-      <white_list>box_negative_buoyancy</white_list>
+      <!-- enable by top level model name -->
+      <enable>balloon_lighter_than_air</enable>
+      <enable>box_neutral_buoyancy</enable>
+      <enable>box_negative_buoyancy</enable>
     </plugin>
 
     <light type="directional" name="sun">

--- a/examples/worlds/graded_buoyancy.sdf
+++ b/examples/worlds/graded_buoyancy.sdf
@@ -33,74 +33,12 @@
           <density>1</density>
         </density_change>
       </graded_buoyancy>
+      <white_list>ball_lighter_than_water</white_list>
+      <white_list>box_lighter_than_water</white_list>
+      <white_list>balloon_lighter_than_air</white_list>
+      <white_list>box_neutral_buoyancy</white_list>
+      <white_list>box_negative_buoyancy</white_list>
     </plugin>
-
-    <gui fullscreen="0">
-
-      <!-- 3D scene -->
-      <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
-          <title>3D View</title>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="string" key="state">docked</property>
-        </ignition-gui>
-
-        <engine>ogre2</engine>
-        <scene>scene</scene>
-        <ambient_light>0.4 0.4 0.4</ambient_light>
-        <background_color>0.8 0.8 0.8</background_color>
-        <camera_pose>-10 -2 5.6 0 0.5 0</camera_pose>
-      </plugin>
-
-      <!-- World control -->
-      <plugin filename="WorldControl" name="World control">
-        <ignition-gui>
-          <title>World control</title>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="bool" key="resizable">false</property>
-          <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
-          <property type="double" key="z">1</property>
-
-          <property type="string" key="state">floating</property>
-          <anchors target="3D View">
-            <line own="left" target="left"/>
-            <line own="bottom" target="bottom"/>
-          </anchors>
-        </ignition-gui>
-
-        <play_pause>true</play_pause>
-        <step>true</step>
-        <start_paused>true</start_paused>
-        <service>/world/buoyancy/control</service>
-        <stats_topic>/world/buoyancy/stats</stats_topic>
-      </plugin>
-
-      <!-- World statistics -->
-      <plugin filename="WorldStats" name="World stats">
-        <ignition-gui>
-          <title>World stats</title>
-          <property type="bool" key="showTitleBar">false</property>
-          <property type="bool" key="resizable">false</property>
-          <property type="double" key="height">110</property>
-          <property type="double" key="width">290</property>
-          <property type="double" key="z">1</property>
-
-          <property type="string" key="state">floating</property>
-          <anchors target="3D View">
-            <line own="right" target="right"/>
-            <line own="bottom" target="bottom"/>
-          </anchors>
-        </ignition-gui>
-
-        <sim_time>true</sim_time>
-        <real_time>true</real_time>
-        <real_time_factor>true</real_time_factor>
-        <iterations>true</iterations>
-        <topic>/world/buoyancy/stats</topic>
-      </plugin>
-
-    </gui>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -273,6 +211,40 @@
     <!-- This box is negatively buoyant and therefore should sink -->
     <model name='box_negative_buoyancy'>
       <pose>0 -8 0 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>1050</mass>
+          <pose>0 0 0.1 0 0 0</pose>
+          <inertia>
+            <ixx>86.28907821859966</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>86.28907821859966</iyy>
+            <iyz>0</iyz>
+            <izz>5.026548245743671</izz>
+          </inertia>
+        </inertial>
+
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+             <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Not affected by buoyancy -->
+    <model name='box_no_buoyancy'>
+      <pose>4 -6 0 0 0 0</pose>
       <link name='body'>
         <inertial>
           <mass>1050</mass>

--- a/examples/worlds/graded_buoyancy.sdf
+++ b/examples/worlds/graded_buoyancy.sdf
@@ -33,8 +33,14 @@
           <density>1</density>
         </density_change>
       </graded_buoyancy>
-      <white_list>ball_lighter_than_water</white_list>
-      <white_list>box_lighter_than_water</white_list>
+
+      <!-- whitelist by link name -->
+      <white_list>lighter_than_water::ball::body</white_list>
+
+      <!-- whitelist by nested model name -->
+      <white_list>lighter_than_water::box</white_list>
+
+      <!-- whitelist by top level model name -->
       <white_list>balloon_lighter_than_air</white_list>
       <white_list>box_neutral_buoyancy</white_list>
       <white_list>box_negative_buoyancy</white_list>
@@ -73,71 +79,73 @@
       </link>
     </model>
 
-    <!-- This sphere should bob up and down. -->
-    <model name='ball_lighter_than_water'>
+    <model name='lighter_than_water'>
       <pose>0 0 0 0 0 0</pose>
-      <link name='body'>
-        <pose>0 0 0 0 0 0</pose>
-        <inertial>
-          <mass>25</mass>
-          <inertia>
-            <ixx>86.28907821859966</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>86.28907821859966</iyy>
-            <iyz>0</iyz>
-            <izz>5.026548245743671</izz>
-          </inertia>
-        </inertial>
+      <!-- This sphere should bob up and down. -->
+      <model name="ball">
+        <link name='body'>
+          <pose>0 0 0 0 0 0</pose>
+          <inertial>
+            <mass>25</mass>
+            <inertia>
+              <ixx>86.28907821859966</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>86.28907821859966</iyy>
+              <iyz>0</iyz>
+              <izz>5.026548245743671</izz>
+            </inertia>
+          </inertial>
 
-        <visual name='body_visual'>
-          <geometry>
-            <sphere>
-              <radius>0.2</radius>
-            </sphere>
-          </geometry>
-        </visual>
-        <collision name='body_collision'>
-          <geometry>
-            <sphere>
-              <radius>0.2</radius>
-            </sphere>
-          </geometry>
-        </collision>
-      </link>
-    </model>
+          <visual name='body_visual'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+          </visual>
+          <collision name='body_collision'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+          </collision>
+        </link>
+      </model>
 
-    <!-- This box should float. -->
-    <model name='box_lighter_than_water'>
-      <pose>3 5 0 0.3 0.2 0.1</pose>
-      <link name='body'>
-        <inertial>
-          <mass>200</mass>
-          <inertia>
-            <ixx>33.33</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>33.33</iyy>
-            <iyz>0</iyz>
-            <izz>33.33</izz>
-          </inertia>
-        </inertial>
+      <!-- This box should float. -->
+      <model name='box'>
+        <pose>3 5 0 0.3 0.2 0.1</pose>
+        <link name='body'>
+          <inertial>
+            <mass>200</mass>
+            <inertia>
+              <ixx>33.33</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>33.33</iyy>
+              <iyz>0</iyz>
+              <izz>33.33</izz>
+            </inertia>
+          </inertial>
 
-        <visual name='body_visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-        </visual>
-        <collision name='body_collision'>
-          <geometry>
-             <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-        </collision>
-      </link>
+          <visual name='body_visual'>
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </visual>
+          <collision name='body_collision'>
+            <geometry>
+               <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+      </model>
     </model>
 
     <!-- This balloon should shoot up -->

--- a/src/gui/plugins/video_recorder/VideoRecorder.hh
+++ b/src/gui/plugins/video_recorder/VideoRecorder.hh
@@ -47,7 +47,7 @@ namespace gazebo
       override;
 
     // Documentation inherited
-    public: bool eventFilter(QObject *_obj, QEvent *_event);
+    public: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
     /// \brief Callback when video record start request is received
     /// \param[in] _format Video encoding format

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -122,7 +122,8 @@ class ignition::gazebo::systems::BuoyancyPrivate
   public: std::pair<math::Vector3d, math::Vector3d> ResolveForces(
     const math::Pose3d &_pose);
 
-  /// \brief
+  /// \brief Scoped names of entities that buoyancy should apply to. If empty,
+  /// all links will receive buoyancy.
   public: std::unordered_set<std::string> whiteList;
 };
 

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -513,8 +513,8 @@ void Buoyancy::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
               static bool warned{false};
               if (!warned)
               {
-                ignwarn << "Only <box> and <sphere> collisions are supported by "
-                  << "the graded buoyancy option." << std::endl;
+                ignwarn << "Only <box> and <sphere> collisions are supported "
+                  << "by the graded buoyancy option." << std::endl;
                 warned = true;
               }
               break;

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -59,6 +59,9 @@ namespace systems
   /// * `<above_depth>` a child property of `<density_change>`. This determines
   /// the height at which the next fluid layer should start. [Units: m]
   /// * `<density>` the density of the fluid in this layer. [Units: kgm^-3]
+  /// * `<white_list>` used to indicate which models will receive buoyancy.
+  /// Add one white list element per model. If there are no white-listed models,
+  /// all models in simulation will be affected by buoyancy.
   ///
   /// ## Examples
   ///

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -127,6 +127,13 @@ namespace systems
                 const ignition::gazebo::UpdateInfo &_info,
                 ignition::gazebo::EntityComponentManager &_ecm) override;
 
+    /// \brief Check if an entity is whitelisted or not.
+    /// \param[in] _entity Target entity
+    /// \param[in] _ecm Entity component manager
+    /// \return True if buoyancy should be applied.
+    public: bool IsWhiteListed(Entity _entity,
+        const EntityComponentManager &_ecm) const;
+
     /// \brief Private data pointer
     private: std::unique_ptr<BuoyancyPrivate> dataPtr;
   };

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -59,10 +59,10 @@ namespace systems
   /// * `<above_depth>` a child property of `<density_change>`. This determines
   /// the height at which the next fluid layer should start. [Units: m]
   /// * `<density>` the density of the fluid in this layer. [Units: kgm^-3]
-  /// * `<white_list>` used to indicate which models will have buoyancy.
-  /// Add one white list element per model or link. This element accepts names
+  /// * `<enable>` used to indicate which models will have buoyancy.
+  /// Add one enable element per model or link. This element accepts names
   /// scoped from the top level model (i.e. `<model>::<nested_model>::<link>`).
-  /// If there are no white-listed entities, all models in simulation will be
+  /// If there are no enabled entities, all models in simulation will be
   /// affected by buoyancy.
   ///
   /// ## Examples
@@ -132,11 +132,11 @@ namespace systems
                 const ignition::gazebo::UpdateInfo &_info,
                 ignition::gazebo::EntityComponentManager &_ecm) override;
 
-    /// \brief Check if an entity is whitelisted or not.
+    /// \brief Check if an entity is enabled or not.
     /// \param[in] _entity Target entity
     /// \param[in] _ecm Entity component manager
     /// \return True if buoyancy should be applied.
-    public: bool IsWhiteListed(Entity _entity,
+    public: bool IsEnabled(Entity _entity,
         const EntityComponentManager &_ecm) const;
 
     /// \brief Private data pointer

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -59,9 +59,11 @@ namespace systems
   /// * `<above_depth>` a child property of `<density_change>`. This determines
   /// the height at which the next fluid layer should start. [Units: m]
   /// * `<density>` the density of the fluid in this layer. [Units: kgm^-3]
-  /// * `<white_list>` used to indicate which models will receive buoyancy.
-  /// Add one white list element per model. If there are no white-listed models,
-  /// all models in simulation will be affected by buoyancy.
+  /// * `<white_list>` used to indicate which models will have buoyancy.
+  /// Add one white list element per model or link. This element accepts names
+  /// scoped from the top level model (i.e. `<model>::<nested_model>::<link>`).
+  /// If there are no white-listed entities, all models in simulation will be
+  /// affected by buoyancy.
   ///
   /// ## Examples
   ///

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -200,8 +200,8 @@ TEST_F(BuoyancyTest, GradedBuoyancy)
 {
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/graded_buoyancy.sdf";
+  const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "worlds", "graded_buoyancy.sdf");
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);
@@ -228,20 +228,25 @@ TEST_F(BuoyancyTest, GradedBuoyancy)
     Entity heliumBalloon = _ecm.EntityByComponents(
         components::Model(), components::Name("balloon_lighter_than_air"));
 
+    Entity noBuoyancy = _ecm.EntityByComponents(
+        components::Model(), components::Name("box_no_buoyancy"));
+
     ASSERT_NE(neutralBox, kNullEntity);
     ASSERT_NE(bobbingBall, kNullEntity);
     ASSERT_NE(heliumBalloon, kNullEntity);
+    ASSERT_NE(noBuoyancy, kNullEntity);
 
     auto neutralBoxPose = _ecm.Component<components::Pose>(neutralBox);
     ASSERT_NE(neutralBoxPose, nullptr);
 
-    auto bobbingBallPose = _ecm.Component<components::Pose>(
-        bobbingBall);
+    auto bobbingBallPose = _ecm.Component<components::Pose>(bobbingBall);
     ASSERT_NE(bobbingBallPose , nullptr);
 
-    auto heliumBalloonPose = _ecm.Component<components::Pose>(
-        heliumBalloon);
+    auto heliumBalloonPose = _ecm.Component<components::Pose>(heliumBalloon);
     ASSERT_NE(heliumBalloonPose , nullptr);
+
+    auto noBuoyancyPose = _ecm.Component<components::Pose>(noBuoyancy);
+    ASSERT_NE(noBuoyancyPose , nullptr);
 
     // The "neutralBox" should stay in its starting location.
     EXPECT_NEAR(0, neutralBoxPose->Data().Pos().X(), 1e-1);
@@ -253,9 +258,14 @@ TEST_F(BuoyancyTest, GradedBuoyancy)
       // Helium balloon should float up
       EXPECT_GT(heliumBalloonPose->Data().Pos().Z(),
                 neutralBoxPose->Data().Pos().Z());
+
       // Bobbing ball should stay within a certain band.
       EXPECT_GT(bobbingBallPose->Data().Pos().Z(), -1.2);
       EXPECT_LT(bobbingBallPose->Data().Pos().Z(), 0.5);
+
+      // No buoyancy box should sink
+      EXPECT_LT(noBuoyancyPose->Data().Pos().Z(),
+                neutralBoxPose->Data().Pos().Z());
     }
 
     if (_info.iterations == iterations)

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -220,10 +220,10 @@ TEST_F(BuoyancyTest, GradedBuoyancy)
   {
     // Check pose
     Entity neutralBox = _ecm.EntityByComponents(
-        components::Model(), components::Name("box_neutral_buoyancy"));
+        components::Model(), components::Name("neutral_buoyancy"));
 
     Entity bobbingBall = _ecm.EntityByComponents(
-        components::Model(), components::Name("ball_lighter_than_water"));
+        components::Model(), components::Name("lighter_than_water"));
 
     Entity heliumBalloon = _ecm.EntityByComponents(
         components::Model(), components::Name("balloon_lighter_than_air"));

--- a/test/worlds/graded_buoyancy.sdf
+++ b/test/worlds/graded_buoyancy.sdf
@@ -34,14 +34,14 @@
         </density_change>
       </graded_buoyancy>
 
-      <!-- whitelist by link name -->
-      <white_list>lighter_than_water::ball::body</white_list>
+      <!-- enable by link name -->
+      <enable>lighter_than_water::ball::body</enable>
 
-      <!-- whitelist by top level model name -->
-      <white_list>balloon_lighter_than_air</white_list>
+      <!-- enable by top level model name -->
+      <enable>balloon_lighter_than_air</enable>
 
-      <!-- whitelist by nested model name -->
-      <white_list>neutral_buoyancy::box</white_list>
+      <!-- enable by nested model name -->
+      <enable>neutral_buoyancy::box</enable>
     </plugin>
 
     <light type="directional" name="sun">
@@ -170,7 +170,7 @@
       <pose>4 -6 -3 0 0 0</pose>
       <link name='body'>
         <inertial>
-          <mass>1050</mass>
+          <mass>1000</mass>
           <pose>0 0 0.1 0 0 0</pose>
           <inertia>
             <ixx>86.28907821859966</ixx>

--- a/test/worlds/graded_buoyancy.sdf
+++ b/test/worlds/graded_buoyancy.sdf
@@ -33,10 +33,15 @@
           <density>1</density>
         </density_change>
       </graded_buoyancy>
-      <white_list>ball_lighter_than_water</white_list>
+
+      <!-- whitelist by link name -->
+      <white_list>lighter_than_water::ball::body</white_list>
+
+      <!-- whitelist by top level model name -->
       <white_list>balloon_lighter_than_air</white_list>
-      <white_list>box_neutral_buoyancy</white_list>
-      <white_list>box_negative_buoyancy</white_list>
+
+      <!-- whitelist by nested model name -->
+      <white_list>neutral_buoyancy::box</white_list>
     </plugin>
 
     <light type="directional" name="sun">
@@ -53,38 +58,40 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
-    <!-- This sphere should bob up and down. -->
-    <model name='ball_lighter_than_water'>
+    <model name='lighter_than_water'>
       <pose>0 0 0 0 0 0</pose>
-      <link name='body'>
-        <pose>0 0 0 0 0 0</pose>
-        <inertial>
-          <mass>25</mass>
-          <inertia>
-            <ixx>86.28907821859966</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>86.28907821859966</iyy>
-            <iyz>0</iyz>
-            <izz>5.026548245743671</izz>
-          </inertia>
-        </inertial>
+      <!-- This sphere should bob up and down. -->
+      <model name="ball">
+        <link name='body'>
+          <pose>0 0 0 0 0 0</pose>
+          <inertial>
+            <mass>25</mass>
+            <inertia>
+              <ixx>86.28907821859966</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>86.28907821859966</iyy>
+              <iyz>0</iyz>
+              <izz>5.026548245743671</izz>
+            </inertia>
+          </inertial>
 
-        <visual name='body_visual'>
-          <geometry>
-            <sphere>
-              <radius>0.2</radius>
-            </sphere>
-          </geometry>
-        </visual>
-        <collision name='body_collision'>
-          <geometry>
-            <sphere>
-              <radius>0.2</radius>
-            </sphere>
-          </geometry>
-        </collision>
-      </link>
+          <visual name='body_visual'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+          </visual>
+          <collision name='body_collision'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+          </collision>
+        </link>
+      </model>
     </model>
 
     <!-- This balloon should shoot up -->
@@ -122,37 +129,40 @@
     </model>
 
     <!-- This box is neutrally buoyant and therefore should stay still -->
-    <model name='box_neutral_buoyancy'>
+    <model name='neutral_buoyancy'>
       <pose>0 5 -3 0 0 0</pose>
-      <link name='body'>
-        <inertial>
-          <mass>1000</mass>
-          <pose>0 0 0.1 0 0 0</pose>
-          <inertia>
-            <ixx>86.28907821859966</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>86.28907821859966</iyy>
-            <iyz>0</iyz>
-            <izz>5.026548245743671</izz>
-          </inertia>
-        </inertial>
+      <model name='box'>
+          <pose>0 0 0 0 0 0</pose>
+        <link name='body'>
+          <inertial>
+            <mass>1000</mass>
+            <pose>0 0 0.1 0 0 0</pose>
+            <inertia>
+              <ixx>86.28907821859966</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>86.28907821859966</iyy>
+              <iyz>0</iyz>
+              <izz>5.026548245743671</izz>
+            </inertia>
+          </inertial>
 
-        <visual name='body_visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-        </visual>
-        <collision name='body_collision'>
-          <geometry>
-             <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-        </collision>
-      </link>
+          <visual name='body_visual'>
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </visual>
+          <collision name='body_collision'>
+            <geometry>
+               <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+      </model>
     </model>
 
     <!-- Not affected by buoyancy -->

--- a/test/worlds/graded_buoyancy.sdf
+++ b/test/worlds/graded_buoyancy.sdf
@@ -33,6 +33,10 @@
           <density>1</density>
         </density_change>
       </graded_buoyancy>
+      <white_list>ball_lighter_than_water</white_list>
+      <white_list>balloon_lighter_than_air</white_list>
+      <white_list>box_neutral_buoyancy</white_list>
+      <white_list>box_negative_buoyancy</white_list>
     </plugin>
 
     <light type="directional" name="sun">
@@ -123,6 +127,40 @@
       <link name='body'>
         <inertial>
           <mass>1000</mass>
+          <pose>0 0 0.1 0 0 0</pose>
+          <inertia>
+            <ixx>86.28907821859966</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>86.28907821859966</iyy>
+            <iyz>0</iyz>
+            <izz>5.026548245743671</izz>
+          </inertia>
+        </inertial>
+
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+             <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Not affected by buoyancy -->
+    <model name='box_no_buoyancy'>
+      <pose>4 -6 -3 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>1050</mass>
           <pose>0 0 0.1 0 0 0</pose>
           <inertia>
             <ixx>86.28907821859966</ixx>


### PR DESCRIPTION
# 🦟 Bug fix

This is technically a feature, but it fixes a usability bug that affects the Fortress demo.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Adds the ability of whitelisting just a few models in simulation which will be affected by buoyancy.

Also reduced console spam by printing a warning only once.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
