### PR TITLE
Fix SDFormat generation of pose elements

### DIFF
--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -411,10 +411,13 @@ namespace sdf_generator
     auto poseElem = _elem->GetElement("pose");
 
     // Remove all attributes of poseElem
-    sdf::ParamPtr relativeTo = poseElem->GetAttribute("relative_to");
-    if (nullptr != relativeTo)
+    for (const auto *attrName : {"relative_to", "degrees", "rotation_format"})
     {
-      relativeTo->Reset();
+      sdf::ParamPtr attr = poseElem->GetAttribute(attrName);
+      if (nullptr != attr)
+      {
+        attr->Reset();
+      }
     }
     poseElem->Set(poseComp->Data());
 
@@ -505,10 +508,13 @@ namespace sdf_generator
     auto poseElem = _elem->GetElement("pose");
 
     // Remove all attributes of poseElem
-    sdf::ParamPtr relativeTo = poseElem->GetAttribute("relative_to");
-    if (nullptr != relativeTo)
+    for (const auto *attrName : {"relative_to", "degrees", "rotation_format"})
     {
-      relativeTo->Reset();
+      sdf::ParamPtr attr = poseElem->GetAttribute(attrName);
+      if (nullptr != attr)
+      {
+        attr->Reset();
+      }
     }
     poseElem->Set(poseComp->Data());
     return true;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes a bug when generating SDFormat strings for included models with poses that use one of the newly added attributes (`//pose[@degrees]` and `//pose[@rotation_format]`). The issues comes from assigning an updated pose form the ECM to a `<pose>` element without clearing its attributes. For example, here are a couple of `pose` tags from the original world:

```xml
  <pose degrees='true'>1 2 3    90 0 0</pose>
  <pose rotation_format='quat_xyzw'>1 2 3    0 0 0 1</pose>
```
The generated world will currently have, which are both incorrect.

```xml
  <pose degrees='true'>1 2 3 1.5708 -0 0</pose>
  <pose rotation_format='quat_xyzw'>1 2 3 0 -0 0</pose>
```
After this PR, the output will be

```xml
  <pose>1 2 3 1.5708 -0 0</pose>
  <pose>1 2 3 0 -0 0</pose>
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**