### PR TITLE
Performance: use std::unordered_map where possible in SceneManager

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -17,6 +17,7 @@
 
 
 #include <map>
+#include <unordered_map>
 
 #include <sdf/Box.hh>
 #include <sdf/Collision.hh>
@@ -58,23 +59,23 @@ class ignition::gazebo::SceneManagerPrivate
   public: rendering::ScenePtr scene;
 
   /// \brief Map of visual entity in Gazebo to visual pointers.
-  public: std::map<Entity, rendering::VisualPtr> visuals;
+  public: std::unordered_map<Entity, rendering::VisualPtr> visuals;
 
   /// \brief Map of actor entity in Gazebo to actor pointers.
-  public: std::map<Entity, rendering::MeshPtr> actors;
+  public: std::unordered_map<Entity, rendering::MeshPtr> actors;
 
   /// \brief Map of actor entity in Gazebo to actor animations.
-  public: std::map<Entity, common::SkeletonPtr> actorSkeletons;
+  public: std::unordered_map<Entity, common::SkeletonPtr> actorSkeletons;
 
   /// \brief Map of actor entity to the associated trajectories.
-  public: std::map<Entity, std::vector<common::TrajectoryInfo>>
+  public: std::unordered_map<Entity, std::vector<common::TrajectoryInfo>>
                     actorTrajectories;
 
   /// \brief Map of light entity in Gazebo to light pointers.
-  public: std::map<Entity, rendering::LightPtr> lights;
+  public: std::unordered_map<Entity, rendering::LightPtr> lights;
 
   /// \brief Map of sensor entity in Gazebo to sensor pointers.
-  public: std::map<Entity, rendering::SensorPtr> sensors;
+  public: std::unordered_map<Entity, rendering::SensorPtr> sensors;
 };
 
 
@@ -637,7 +638,7 @@ rendering::VisualPtr SceneManager::CreateActor(Entity _id,
   }
 
   unsigned int numAnims = 0;
-  std::map<std::string, unsigned int> mapAnimNameId;
+  std::unordered_map<std::string, unsigned int> mapAnimNameId;
   mapAnimNameId[descriptor.meshName] = numAnims++;
 
   rendering::VisualPtr actorVisual = this->dataPtr->scene->CreateVisual(name);


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

## Summary
When working on #1013, I noticed that the `SceneManager` keeps track of entity information via `std::map`. However, since order doesn't seem to matter in this context, it would be better to use `std::unordered_map` for faster lookup times.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**