### PR TITLE
Adjust pose decimals based on element width

### DIFF
--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -75,6 +75,15 @@ Rectangle {
     );
   }
 
+  // Get decimals based on a width
+  function getDecimals(width) {
+    if (width<= 80)
+      return 2;
+    else if (width <= 100)
+      return 4;
+    return 6;
+  }
+
   FontMetrics {
     id: fontMetrics
     font.family: "Roboto"
@@ -90,7 +99,7 @@ Rectangle {
       value: writableSpin.activeFocus ? writableSpin.value : numberValue
       minimumValue: -spinMax
       maximumValue: spinMax
-      decimals: 6
+      decimals: getDecimals(writableSpin.width)
       onEditingFinished: {
         sendPose()
       }
@@ -108,7 +117,7 @@ Rectangle {
       horizontalAlignment: Text.AlignRight
       verticalAlignment: Text.AlignVCenter
       text: {
-        var decimals = numberText.width < 100 ? 2 : 6
+        var decimals = getDecimals(numberText.width)
         return numberValue.toFixed(decimals)
       }
     }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

Pose values would be truncated because they didn't fit in the spin box. This PR adjusts the number of decimals based on the available width.

![pose_decimals](https://user-images.githubusercontent.com/1587438/136065756-87f84125-ad01-43ec-b4ab-e96fc47fe049.gif)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**