### PR TITLE
Use deserialize to remove CreateComponentImplementation's template dependency

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -705,7 +705,17 @@ namespace ignition
       /// \param[in] _componentTypeId Id of the component type.
       /// \param[in] _data Data used to construct the component.
       /// \return True if the component's data needs to be set externally; false
-      /// otherwise.
+      /// otherwise (this return type should be ignored - see todo note below)
+      /// TODO(adlarkin) update this method to return the actual component
+      /// (components::BaseComponent *) in ign-gazebo7. This method has
+      /// been updated in ign-gazebo6 to call BaseComponent::Deserialize in the
+      /// implementation, so the component data is now set correctly and does
+      /// not need to be set in the calling template method. Once this method
+      /// returns the actual component, the template method that calls this
+      /// (EntityComponentManager::CreateComponnt) can cast this returned
+      /// component to the derived component directly instead of having to do an
+      /// additional templated EntityComponentManager::Component lookup to get
+      /// the derived component
       private: bool CreateComponentImplementation(
                    const Entity _entity,
                    const ComponentTypeId _componentTypeId,

--- a/include/ignition/gazebo/detail/EntityComponentManager.hh
+++ b/include/ignition/gazebo/detail/EntityComponentManager.hh
@@ -87,21 +87,8 @@ template<typename ComponentTypeT>
 ComponentTypeT *EntityComponentManager::CreateComponent(const Entity _entity,
             const ComponentTypeT &_data)
 {
-  auto updateData = this->CreateComponentImplementation(_entity,
-      ComponentTypeT::typeId, &_data);
-  auto comp = this->Component<ComponentTypeT>(_entity);
-  if (updateData)
-  {
-    if (!comp)
-    {
-      ignerr << "Internal error. Failure to create a component of type "
-        << ComponentTypeT::typeId << " for entity " << _entity
-        << ". This should never happen!\n";
-      return comp;
-    }
-    *comp = _data;
-  }
-  return comp;
+  this->CreateComponentImplementation(_entity, ComponentTypeT::typeId, &_data);
+  return this->Component<ComponentTypeT>(_entity);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

## Summary
When I worked on #856, I came across an issue where I could not update derived component data when dealing with `BaseComponent` pointers in `EntityComponentManager::CreateComponentImplementation`: https://github.com/ignitionrobotics/ign-gazebo/pull/856#discussion_r684511937

The workaround at the time was to have `CreateComponentImplementation` return a flag that indicated whether the derived component data needed to be updated or not. If the data needed to be updated, it was taken care of in the template method that called `CreateComponentImplementation`, since the template method knew what the derived component type is.

However, after working on #1131, I realized that we can use component's `Serialize`/`Deserialize` methods in `EntityComponentManager::CreateComponentImplementation` to properly update the derived component data when working with `BaseComponent` pointers. The reason why this works is because these serialization methods are virtual methods that are implemented by both the `BaseComponent` and derived component classes. A regular assignment operator wouldn't work because the component classes don't have this operator implemented as a virtual override (see https://godbolt.org/z/hezKTbeEj for an example of what happens when a default assignment operator is used with polymorphism - spoiler alert: the derived class data is lost in the assignment).

As a result of this change, `CreateComponentImplementation` can return a pointer to the component instead of a update flag, and the template method that calls `CreateComponentImplementation` can then use this component directly. I can't change the signature of this method in `ign-gazebo6` since it will break ABI, but I left a `TODO` note about fixing it in `ign-gazebo7`. Since `CreateComponentImplementation` is a private method, we don't need to tick-tock it, right? We can change a private method without having to deprecate it, if I understand correctly.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**