### PR TITLE
Fix the force-torque sensor update rate

### DIFF
--- a/examples/worlds/sensors.sdf
+++ b/examples/worlds/sensors.sdf
@@ -36,6 +36,10 @@
       name="ignition::gazebo::systems::Magnetometer">
     </plugin>
     <plugin
+      filename="ignition-gazebo-forcetorque-system"
+      name="ignition::gazebo::systems::ForceTorque">
+    </plugin>
+    <plugin
       filename="ignition-gazebo-user-commands-system"
       name="ignition::gazebo::systems::UserCommands">
     </plugin>
@@ -186,5 +190,71 @@
       </link>
     </model>
 
+    <model name="force_torque_demo">
+      <link name="base_plate">
+        <static>true</static>
+      </link>
+
+      <link name="link_1">
+        <pose> 0 0 2.0 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.100000</ixx>
+            <ixy>0.000000</ixy>
+            <ixz>0.000000</ixz>
+            <iyy>0.100000</iyy>
+            <iyz>0.000000</iyz>
+            <izz>0.100000</izz>
+          </inertia>
+          <mass>10.000000</mass>
+        </inertial>
+        <visual name="visual_sphere">
+          <geometry>
+            <sphere>
+              <radius>0.100000</radius>
+            </sphere>
+          </geometry>
+        </visual>
+        <visual name="visual_cylinder">
+          <pose>0 0 -0.75 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.0100000</radius>
+              <length>1.5</length>
+            </cylinder>
+          </geometry>
+        </visual>
+        <collision name="collision_sphere">
+          <geometry>
+            <sphere>
+              <radius>0.100000</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="joint_00" type="fixed">
+        <parent>world</parent>
+        <child>base_plate</child>
+      </joint>
+      <joint name="joint_01" type="revolute">
+        <parent>base_plate</parent>
+        <child>link_1</child>
+        <pose>0 0 -1.5 0 0 0</pose>
+        <axis>
+          <limit>
+            <lower>-1.57079</lower>
+            <upper>1.57079</upper>
+          </limit>
+          <dynamics>
+            <damping>0.000000</damping>
+            <friction>0.000000</friction>
+          </dynamics>
+          <xyz>1.000000 0.000000 0.000000</xyz>
+        </axis>
+        <sensor name="force_torque" type="force_torque">
+          <update_rate>10</update_rate>
+        </sensor>
+      </joint>
+    </model>
   </world>
 </sdf>

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -136,10 +136,7 @@ void ForceTorque::PostUpdate(const UpdateInfo &_info,
 
     for (auto &it : this->dataPtr->entitySensorMap)
     {
-      // Update measurement time
-      auto time = math::durationToSecNsec(_info.simTime);
-      static_cast<sensors::Sensor *>(it.second.get())->Update(
-          math::secNsecToDuration(time.first, time.second), false);
+      it.second.get()->sensors::Sensor::Update(_info.simTime, false);
     }
   }
 

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -137,7 +137,9 @@ void ForceTorque::PostUpdate(const UpdateInfo &_info,
     for (auto &it : this->dataPtr->entitySensorMap)
     {
       // Update measurement time
-      it.second->Update(_info.simTime);
+      auto time = math::durationToSecNsec(_info.simTime);
+      static_cast<sensors::Sensor *>(it.second.get())->Update(
+          math::secNsecToDuration(time.first, time.second), false);
     }
   }
 

--- a/test/worlds/force_torque.sdf
+++ b/test/worlds/force_torque.sdf
@@ -132,7 +132,7 @@
           <parent>base</parent>
           <child>sensor_plate</child>
           <sensor name="force_torque_sensor" type="force_torque">
-            <update_rate>30</update_rate>
+            <update_rate>100</update_rate>
             <always_on>true</always_on>
             <visualize>true</visualize>
             <topic>force_torque1</topic>
@@ -262,7 +262,7 @@
           <child>sensor_plate</child>
           <sensor name="force_torque_sensor" type="force_torque">
             <pose>0.1 0 0  0 0 0</pose>
-            <update_rate>30</update_rate>
+            <update_rate>100</update_rate>
             <always_on>true</always_on>
             <visualize>true</visualize>
             <topic>force_torque2</topic>
@@ -392,7 +392,7 @@
           <child>sensor_plate</child>
           <sensor name="force_torque_sensor" type="force_torque">
             <pose degrees="true">0 0 0.0   30 0 0</pose>
-            <update_rate>30</update_rate>
+            <update_rate>100</update_rate>
             <always_on>true</always_on>
             <visualize>true</visualize>
             <topic>force_torque3</topic>


### PR DESCRIPTION
# 🦟 Bug fix

Makes the force-torque sensor system properly respect the `update_time` parameter from the sensor's SDF.

## Summary

This bug is introduced by calling `ForceTorqueSensor::Update` rather that `Sensors::Update` from the base class.  This was causing all of the base class update logic to be skiped and the FT sensor would update every time.

To test, runt he example sensors world
```
ign gazebo ./src/ign-gazebo/examples/worlds/sensors.sdf    
```

And verify that the output rate of the f-t sensor is reasonable (10 hz, in this case):

```
ign topic -e -t /world/sensors/model/force_torque_demo/joint/joint_01/sensor/force_torque/forcetorque 
```

**Note to maintainers**: Remember to use **Squash-Merge**