### PR TITLE
Fix generation of systems library symlinks in build directory

### DIFF
--- a/src/systems/CMakeLists.txt
+++ b/src/systems/CMakeLists.txt
@@ -66,7 +66,7 @@ function(gz_add_system system_name)
     # create_symlink requires cmake 3.13 on windows
     cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
   endif()
-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned} WORKING_DIRECTORY "lib")
   INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_GAZEBO_PLUGIN_INSTALL_DIR})
 endfunction()
 

--- a/src/systems/CMakeLists.txt
+++ b/src/systems/CMakeLists.txt
@@ -66,8 +66,8 @@ function(gz_add_system system_name)
     # create_symlink requires cmake 3.13 on windows
     cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
   endif()
-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned} WORKING_DIRECTORY "lib")
-  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_GAZEBO_PLUGIN_INSTALL_DIR})
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned} WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+  INSTALL(FILES ${PROJECT_BINARY_DIR}/lib/${unversioned} DESTINATION ${IGNITION_GAZEBO_PLUGIN_INSTALL_DIR})
 endfunction()
 
 add_subdirectory(air_pressure)

--- a/src/systems/CMakeLists.txt
+++ b/src/systems/CMakeLists.txt
@@ -66,6 +66,7 @@ function(gz_add_system system_name)
     # create_symlink requires cmake 3.13 on windows
     cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
   endif()
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
   EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned} WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
   INSTALL(FILES ${PROJECT_BINARY_DIR}/lib/${unversioned} DESTINATION ${IGNITION_GAZEBO_PLUGIN_INSTALL_DIR})
 endfunction()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1152

## Summary
As discussed in #1152, the unversioned library symlinks for systems are generated into the root of the build directory, but tests expect them in the `lib` subdirectory of the build directory. This PR fixes the location.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**