### PR TITLE
Set camera clipping plane distance

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -66,6 +66,18 @@ namespace ignition::gazebo
     /// \brief gui camera pose
     public: math::Pose3d camPose;
 
+    /// \brief GUI camera near/far clipping distance (QList order is near, far)
+    public: QList<double> camClipDist{0.0, 0.0};
+
+    /// \brief Flag indicating if there is a new camera clipping distance
+    /// coming from qml side
+    public: bool newCamClipDist = false;
+
+    /// \brief Checks if there is new camera clipping distance from gui camera,
+    /// used to update qml side
+    /// \return True if there is a new clipping distance from gui camera
+    public: bool UpdateQtCamClipDist();
+
     /// \brief User camera
     public: rendering::CameraPtr camera{nullptr};
 
@@ -146,6 +158,12 @@ bool ViewAngle::eventFilter(QObject *_obj, QEvent *_event)
   if (_event->type() == ignition::gui::events::Render::kType)
   {
     this->dataPtr->OnRender();
+
+    // updates qml cam clip distance spin boxes if changed
+    if (this->dataPtr->UpdateQtCamClipDist())
+    {
+      this->CamClipDistChanged();
+    }
   }
   else if (_event->type() ==
            ignition::gazebo::gui::events::EntitiesSelected::kType)
@@ -284,6 +302,20 @@ void ViewAngle::CamPoseCb(const msgs::Pose &_msg)
 }
 
 /////////////////////////////////////////////////
+QList<double> ViewAngle::CamClipDist() const
+{
+  return this->dataPtr->camClipDist;
+}
+
+/////////////////////////////////////////////////
+void ViewAngle::SetCamClipDist(double _near, double _far)
+{
+  this->dataPtr->camClipDist[0] = _near;
+  this->dataPtr->camClipDist[1] = _far;
+  this->dataPtr->newCamClipDist = true;
+}
+
+/////////////////////////////////////////////////
 void ViewAnglePrivate::OnRender()
 {
   if (!this->camera)
@@ -395,6 +427,14 @@ void ViewAnglePrivate::OnRender()
       this->prevMoveToTime = now;
     }
   }
+
+  // Camera clipping plane distance
+  if (this->newCamClipDist)
+  {
+    this->camera->SetNearClipPlane(this->camClipDist[0]);
+    this->camera->SetFarClipPlane(this->camClipDist[1]);
+    this->newCamClipDist = false;
+  }
 }
 
 /////////////////////////////////////////////////
@@ -402,6 +442,24 @@ void ViewAnglePrivate::OnComplete()
 {
   this->viewingAngle = false;
   this->moveToPoseValue.reset();
+}
+
+/////////////////////////////////////////////////
+bool ViewAnglePrivate::UpdateQtCamClipDist()
+{
+  bool updated = false;
+  if (std::abs(this->camera->NearClipPlane() - this->camClipDist[0]) > 0.0001)
+  {
+    this->camClipDist[0] = this->camera->NearClipPlane();
+    updated = true;
+  }
+
+  if (std::abs(this->camera->FarClipPlane() - this->camClipDist[1]) > 0.0001)
+  {
+    this->camClipDist[1] = this->camera->FarClipPlane();
+    updated = true;
+  }
+  return updated;
 }
 
 // Register this plugin

--- a/src/gui/plugins/view_angle/ViewAngle.hh
+++ b/src/gui/plugins/view_angle/ViewAngle.hh
@@ -47,6 +47,13 @@ namespace gazebo
       NOTIFY CamPoseChanged
     )
 
+    /// \brief gui camera near/far clipping distance (QList order is near, far)
+    Q_PROPERTY(
+      QList<double> camClipDist
+      READ CamClipDist
+      NOTIFY CamClipDistChanged
+    )
+
     /// \brief Constructor
     public: ViewAngle();
 
@@ -87,6 +94,17 @@ namespace gazebo
     /// \brief Callback for retrieving gui camera pose
     /// \param[in] _msg Pose message
     public: void CamPoseCb(const msgs::Pose &_msg);
+
+    /// \brief Get the current gui camera's near and far clipping distances
+    public: Q_INVOKABLE QList<double> CamClipDist() const;
+
+    /// \brief Notify that the gui camera's near/far clipping distances changed
+    signals: void CamClipDistChanged();
+
+    /// \brief Updates gui camera's near/far clipping distances
+    /// \param[in] _near Near clipping plane distance
+    /// \param[in] _far Far clipping plane distance
+    public slots: void SetCamClipDist(double _near, double _far);
 
     /// \internal
     /// \brief Pointer to private data.

--- a/src/gui/plugins/view_angle/ViewAngle.qml
+++ b/src/gui/plugins/view_angle/ViewAngle.qml
@@ -213,6 +213,7 @@ ColumnLayout {
     Layout.fillWidth: true
     color: Material.Grey
     leftPadding: 5
+    font.bold: true
   }
 
   GridLayout {
@@ -333,6 +334,60 @@ ColumnLayout {
       decimals: 6
       stepSize: 0.01
       onEditingFinished: ViewAngle.SetCamPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+    }
+  }
+
+  // Set camera's near/far clipping distance
+  Text {
+    text: "Camera's clipping plane distance"
+    Layout.fillWidth: true
+    color: Material.Grey
+    leftPadding: 5
+    topPadding: 10
+    font.bold: true
+  }
+
+  GridLayout {
+    width: parent.width
+    columns: 4
+
+    Text {
+      text: "Near (m)"
+      color: "dimgrey"
+      Layout.row: 0
+      Layout.column: 0
+      leftPadding: 5
+    }
+    IgnSpinBox {
+      id: nearClip
+      Layout.fillWidth: true
+      Layout.row: 0
+      Layout.column: 1
+      value: ViewAngle.camClipDist[0]
+      maximumValue: farClip.value
+      minimumValue: 0.000001
+      decimals: 6
+      stepSize: 0.01
+      onEditingFinished: ViewAngle.SetCamClipDist(nearClip.value, farClip.value)
+    }
+    Text {
+      text: "Far (m)"
+      color: "dimgrey"
+      Layout.row: 0
+      Layout.column: 2
+      leftPadding: 5
+    }
+    IgnSpinBox {
+      id: farClip
+      Layout.fillWidth: true
+      Layout.row: 0
+      Layout.column: 3
+      value: ViewAngle.camClipDist[1]
+      maximumValue: 1000000
+      minimumValue: nearClip.value
+      decimals: 6
+      stepSize: 0.01
+      onEditingFinished: ViewAngle.SetCamClipDist(nearClip.value, farClip.value)
     }
   }
 


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/ignitionrobotics/ign-gui/issues/308
Closes #1154 

## Summary
Set the user camera's near/far clipping plane distance through the `View Angle` plugin. 

## Test it
1. `ign gazebo minimal_shapes.sdf`
2. Expand `View Angle` plugin
3. Enter near/far values in spin boxes

![Peek 2021-11-03 14-48](https://user-images.githubusercontent.com/8602001/140197795-f6610c94-4b54-450b-93f2-f0a36d01e94e.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**