### PR TITLE
Publish 10 world stats msgs/sec instead of 5

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -661,7 +661,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   if (!this->statsPub.Valid())
   {
     transport::AdvertiseMessageOptions advertOpts;
-    advertOpts.SetMsgsPerSec(5);
+    advertOpts.SetMsgsPerSec(10);
     this->statsPub = this->node->Advertise<ignition::msgs::WorldStatistics>(
         "stats", advertOpts);
   }

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -661,6 +661,12 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   if (!this->statsPub.Valid())
   {
     transport::AdvertiseMessageOptions advertOpts;
+    // publish 10 world statistics msgs/second. A smaller number isn't used
+    // because the GUI listens to these msgs to receive confirmation that
+    // pause/play GUI requests have been processed by the server, so we want to
+    // make sure that GUI requests are acknowledged quickly (see
+    // https://github.com/ignitionrobotics/ign-gui/pull/306 and
+    // https://github.com/ignitionrobotics/ign-gazebo/pull/1163)
     advertOpts.SetMsgsPerSec(10);
     this->statsPub = this->node->Advertise<ignition::msgs::WorldStatistics>(
         "stats", advertOpts);


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

Addresses https://github.com/ignitionrobotics/ign-gazebo/pull/1109#issuecomment-961207086

## Summary
The changes made in #1109 and https://github.com/ignitionrobotics/ign-gui/pull/306 result in the GUI listening to the world stats topic to receive play/pause confirmations from the server. The publisher of this topic is currently publishing 5 msgs/second, but I think it would be good to publish at a higher rate to decrease response times between a GUI play/pause button press and server confirmation.

## Test it
Use these changes with #1109 and try pressing play/pause/step in the GUI. The GUI response times should be a little faster now.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**