### PR TITLE
Prevent a segfault when updating ComponentInspector

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -769,17 +769,24 @@ void ComponentInspector::Update(const UpdateInfo &,
     }
   }
 
-  // Remove components no longer present
+  // Remove components no longer present - list items to remove
+  std::list<ignition::gazebo::ComponentTypeId> itemsToRemove;
   for (auto itemIt : this->dataPtr->componentsModel.items)
   {
     auto typeId = itemIt.first;
     if (componentTypes.find(typeId) == componentTypes.end())
     {
-      QMetaObject::invokeMethod(&this->dataPtr->componentsModel,
-          "RemoveComponentType",
-          Qt::QueuedConnection,
-          Q_ARG(ignition::gazebo::ComponentTypeId, typeId));
+      itemsToRemove.push_back(typeId);
     }
+  }
+
+  // Remove components in list
+  for (auto typeId : itemsToRemove)
+  {
+    QMetaObject::invokeMethod(&this->dataPtr->componentsModel,
+        "RemoveComponentType",
+        Qt::QueuedConnection,
+        Q_ARG(ignition::gazebo::ComponentTypeId, typeId));
   }
 }
 

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -16,6 +16,7 @@
 */
 
 #include <iostream>
+#include <list>
 #include <regex>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR fixes a segfault observed on macOS that occurs when selecting different object types in the EntityTree.

The issue arises in the method `ComponentInspector::Update` in the loop that removes unused components from the component list.  The loop iterator may be invalidated by the erase operation in the loop body - this can cause a segfault (the b-tree rebalance fails inside `std::map`). The error was observed on macOS, it may be dependent on the implementation of the `std` libraries.

### Reproduce the error

1. Open an ignition gazebo session: 

   ```bash
   $ ign gazebo -v4 shapes.sdf
   ```

   *(NB: on macOS the server and gui must be started in different terminals because the approach to forking used in the ignition ruby script is not supported).*

2. Load the component inspector and entity tree (if not already configured)

3. Select a different component type in the entry tree (eg. select a light if a shape is already selected)

4. At this point the application may segfault.

### Fix

The approach taken is to first build a list of items to remove, then remove them in a second step. This ensures that at no point can a loop iterator be invalidated. There are other approaches that involve using a second iterator in the loop over the component items, however it was found that these may also fail because the erase step is called using a `QMetaObject::invokeMethod` (so the problem may be a threading / mutex issue rather than a invalid iterator). Either way, ensuring that the object being iterated over at the removal step is not the container having items removed prevents this problem.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

Not all tests pass on macOS (the environment is still experimental). However the failures do not appear to be connected to this change:

```bash
97% tests passed, 5 tests failed out of 196

Total Test time (real) = 499.63 sec

The following tests FAILED:
	 47 - UNIT_ModelCommandAPI_TEST (SEGFAULT)
	 91 - INTEGRATION_examples_build (Failed)
	117 - INTEGRATION_level_manager_runtime_performers (Subprocess aborted)
	131 - INTEGRATION_multiple_servers (Subprocess aborted)
	165 - INTEGRATION_user_commands (SEGFAULT)
```

**Note to maintainers**: Remember to use **Squash-Merge**