### PR TITLE
Wirebox deletion: Suggestion to #1053

### DIFF
--- a/src/gui/plugins/scene_manager/GzSceneManager.cc
+++ b/src/gui/plugins/scene_manager/GzSceneManager.cc
@@ -17,6 +17,8 @@
 
 #include "GzSceneManager.hh"
 
+#include <vector>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/GuiEvents.hh>

--- a/src/gui/plugins/scene_manager/GzSceneManager.cc
+++ b/src/gui/plugins/scene_manager/GzSceneManager.cc
@@ -28,6 +28,7 @@
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/gui/GuiEvents.hh"
 #include "ignition/gazebo/rendering/RenderUtil.hh"
 
 namespace ignition
@@ -81,12 +82,26 @@ void GzSceneManager::Update(const UpdateInfo &_info,
 
   this->dataPtr->renderUtil.UpdateECM(_info, _ecm);
   this->dataPtr->renderUtil.UpdateFromECM(_info, _ecm);
+
+  // Emit entities removed event
+  std::vector<Entity> removed;
+  _ecm.EachRemoved<components::Name>(
+      [&](const Entity &_entity, const components::Name *)->bool
+      {
+        removed.push_back(_entity);
+        return true;
+      });
+
+  ignition::gazebo::gui::events::RemovedEntities removedEvent(removed);
+  ignition::gui::App()->sendEvent(
+      ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
+      &removedEvent);
 }
 
 /////////////////////////////////////////////////
 bool GzSceneManager::eventFilter(QObject *_obj, QEvent *_event)
 {
-  if (_event->type() == gui::events::Render::kType)
+  if (_event->type() == ignition::gui::events::Render::kType)
   {
     this->dataPtr->OnRender();
   }

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -92,10 +92,6 @@
 #include "ignition/gazebo/rendering/SceneManager.hh"
 #include "ignition/gazebo/rendering/MarkerManager.hh"
 
-#include <ignition/gui/Application.hh>
-#include <ignition/gui/MainWindow.hh>
-#include "ignition/gazebo/gui/GuiEvents.hh"
-
 #include "ignition/gazebo/Util.hh"
 
 using namespace ignition;
@@ -1008,7 +1004,6 @@ void RenderUtil::Update()
   // remove existing entities
   {
     IGN_PROFILE("RenderUtil::Update Remove");
-    std::vector<Entity> removed;
     for (auto &entity : removeEntities)
     {
       auto node = this->dataPtr->sceneManager.NodeById(entity.first);
@@ -1020,15 +1015,6 @@ void RenderUtil::Update()
 
       this->dataPtr->RemoveSensor(entity.first);
       this->dataPtr->RemoveBoundingBox(entity.first);
-      removed.push_back(entity.first);
-    }
-
-    if (removed.size())
-    {
-      ignition::gazebo::gui::events::RemovedEntities removedEvent(removed);
-      ignition::gui::App()->sendEvent(
-          ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-          &removedEvent);
     }
   }
 


### PR DESCRIPTION
Suggestion to #1053 that avoids adding GUI as a dependency of rendering.

`RenderUtil` is part of `gazebo::rendering` and is used by both the backend scene (`systems::Sensors`) and the front-end. We shouldn't introduce a dependency on GUI to the backend. The suggestion here emits the event from `GzSceneMananger`, because that's the GUI plugin responsible for connecting the GUI scene to the ECM (most of it done leveraging `RenderUtil`).

For future reference, when I first looked at #1053 I thought we may not need an event because the wirebox should be deleted as a child of the visual. But it looks like that doesn't happen; not sure if it's kept alive because the shared pointer is kept in a map inside `SelectEntities`. In any case, we need to remove the item from that map, and I think that the event is a good way of doing that.