### PR TITLE
 Extend odom publisher to allow 3D

### DIFF
--- a/examples/worlds/multicopter_velocity_control.sdf
+++ b/examples/worlds/multicopter_velocity_control.sdf
@@ -12,6 +12,10 @@ You can use the velocity controller and command linear velocity and yaw angular 
 
     ign topic -t "/X3/gazebo/command/twist" -m ignition.msgs.Twist -p " "
 
+  Listen to odometry:
+
+    ign topic -e -t "/model/x3/odometry"
+
 
   Send commands to the hexacopter to go straight up:
 
@@ -20,6 +24,11 @@ You can use the velocity controller and command linear velocity and yaw angular 
   To hover
 
     ign topic -t "/X4/gazebo/command/twist" -m ignition.msgs.Twist -p " "
+
+  Listen to odometry:
+
+    ign topic -e -t "/model/X4/odometry"
+
 -->
 
 <sdf version="1.6">
@@ -210,6 +219,11 @@ You can use the velocity controller and command linear velocity and yaw angular 
           </rotor>
         </rotorConfiguration>
       </plugin>
+      <plugin
+        filename="ignition-gazebo-odometry-publisher-system"
+        name="ignition::gazebo::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
+      </plugin>
     </include>
     <include>
       <pose>0 3 1 0 0 0</pose>
@@ -399,6 +413,11 @@ You can use the velocity controller and command linear velocity and yaw angular 
             <direction>-1</direction>
           </rotor>
         </rotorConfiguration>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-odometry-publisher-system"
+        name="ignition::gazebo::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
       </plugin>
     </include>
   </world>

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -21,6 +21,7 @@
 
 #include <limits>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -63,6 +64,9 @@ class ignition::gazebo::systems::OdometryPublisherPrivate
   /// robot base.
   public: std::string robotBaseFrame;
 
+  /// \brief Number of dimensions to represent odometry.
+  public: int dimensions;
+
   /// \brief Update period calculated from <odom__publish_frequency>.
   public: std::chrono::steady_clock::duration odomPubPeriod{0};
 
@@ -73,10 +77,12 @@ class ignition::gazebo::systems::OdometryPublisherPrivate
   public: transport::Node::Publisher odomPub;
 
   /// \brief Rolling mean accumulators for the linear velocity
-  public: std::pair<math::RollingMean, math::RollingMean> linearMean;
+  public: std::tuple<math::RollingMean, math::RollingMean, math::RollingMean>
+    linearMean;
 
   /// \brief Rolling mean accumulators for the angular velocity
-  public: math::RollingMean angularMean;
+  public: std::tuple<math::RollingMean, math::RollingMean, math::RollingMean>
+    angularMean;
 
   /// \brief Initialized flag.
   public: bool initialized{false};
@@ -92,12 +98,22 @@ class ignition::gazebo::systems::OdometryPublisherPrivate
 OdometryPublisher::OdometryPublisher()
   : dataPtr(std::make_unique<OdometryPublisherPrivate>())
 {
-  this->dataPtr->linearMean.first.SetWindowSize(10);
-  this->dataPtr->linearMean.second.SetWindowSize(10);
-  this->dataPtr->angularMean.SetWindowSize(10);
-  this->dataPtr->linearMean.first.Clear();
-  this->dataPtr->linearMean.second.Clear();
-  this->dataPtr->angularMean.Clear();
+  std::get<0>(this->dataPtr->linearMean).SetWindowSize(10);
+  std::get<1>(this->dataPtr->linearMean).SetWindowSize(10);
+  std::get<2>(this->dataPtr->angularMean).SetWindowSize(10);
+  std::get<0>(this->dataPtr->linearMean).Clear();
+  std::get<1>(this->dataPtr->linearMean).Clear();
+  std::get<2>(this->dataPtr->angularMean).Clear();
+
+  if (this->dataPtr->dimensions == 3)
+  {
+    std::get<2>(this->dataPtr->linearMean).SetWindowSize(10);
+    std::get<0>(this->dataPtr->angularMean).SetWindowSize(10);
+    std::get<1>(this->dataPtr->angularMean).SetWindowSize(10);
+    std::get<2>(this->dataPtr->linearMean).Clear();
+    std::get<0>(this->dataPtr->angularMean).Clear();
+    std::get<1>(this->dataPtr->angularMean).Clear();
+  }
 }
 
 //////////////////////////////////////////////////
@@ -110,8 +126,8 @@ void OdometryPublisher::Configure(const Entity &_entity,
 
   if (!this->dataPtr->model.Valid(_ecm))
   {
-    ignerr << "DiffDrive plugin should be attached to a model entity. "
-           << "Failed to initialize." << std::endl;
+    ignerr << "OdometryPublisher system plugin should be attached to a model"
+           << " entity. Failed to initialize." << std::endl;
     return;
   }
 
@@ -136,6 +152,24 @@ void OdometryPublisher::Configure(const Entity &_entity,
   else
   {
     this->dataPtr->robotBaseFrame = _sdf->Get<std::string>("robot_base_frame");
+  }
+
+  this->dataPtr->dimensions = 2;
+  if (!_sdf->HasElement("dimensions"))
+  {
+    igndbg << "OdometryPublisher system plugin missing <dimensions>, "
+      << "defaults to \"" << this->dataPtr->dimensions << "\"" << std::endl;
+  }
+  else
+  {
+    this->dataPtr->dimensions = _sdf->Get<int>("dimensions");
+    if (this->dataPtr->dimensions != 2 && this->dataPtr->dimensions != 3)
+    {
+      ignerr << "OdometryPublisher system plugin <dimensions> must be 2D or 3D "
+             << "not " << this->dataPtr->dimensions
+             << "D. Failed to initialize." << std::endl;
+      return;
+    }
   }
 
   double odomFreq = _sdf->Get<double>("odom_publish_frequency", 50).first;
@@ -203,7 +237,7 @@ void OdometryPublisherPrivate::UpdateOdometry(
     const ignition::gazebo::UpdateInfo &_info,
     const ignition::gazebo::EntityComponentManager &_ecm)
 {
-  IGN_PROFILE("DiffDrive::UpdateOdometry");
+  IGN_PROFILE("OdometryPublisher::UpdateOdometry");
   // Record start time.
   if (!this->initialized)
   {
@@ -227,6 +261,10 @@ void OdometryPublisherPrivate::UpdateOdometry(
   msg.mutable_pose()->mutable_position()->set_x(pose.Pos().X());
   msg.mutable_pose()->mutable_position()->set_y(pose.Pos().Y());
   msgs::Set(msg.mutable_pose()->mutable_orientation(), pose.Rot());
+  if (this->dimensions == 3)
+  {
+    msg.mutable_pose()->mutable_position()->set_z(pose.Pos().Z());
+  }
 
   // Get linear and angular displacements from last updated pose.
   double linearDisplacementX = pose.Pos().X() - this->lastUpdatePose.Pos().X();
@@ -236,19 +274,64 @@ void OdometryPublisherPrivate::UpdateOdometry(
   const double lastYaw = this->lastUpdatePose.Rot().Yaw();
   while (currentYaw < lastYaw - IGN_PI) currentYaw += 2 * IGN_PI;
   while (currentYaw > lastYaw + IGN_PI) currentYaw -= 2 * IGN_PI;
-  const float angularDiff = currentYaw - lastYaw;
+  const float yawDiff = currentYaw - lastYaw;
 
-  // Get velocities in robotBaseFrame and add to message.
-  double linearVelocityX = (cosf(currentYaw) * linearDisplacementX
-    + sinf(currentYaw) * linearDisplacementY) / dt.count();
-  double linearVelocityY = (cosf(currentYaw) * linearDisplacementY
-    - sinf(currentYaw) * linearDisplacementX) / dt.count();
-  this->linearMean.first.Push(linearVelocityX);
-  this->linearMean.second.Push(linearVelocityY);
-  this->angularMean.Push(angularDiff / dt.count());
-  msg.mutable_twist()->mutable_linear()->set_x(this->linearMean.first.Mean());
-  msg.mutable_twist()->mutable_linear()->set_y(this->linearMean.second.Mean());
-  msg.mutable_twist()->mutable_angular()->set_z(this->angularMean.Mean());
+  // Get velocities assuming 2D
+  if (this->dimensions == 2)
+  {
+    double linearVelocityX = (cosf(currentYaw) * linearDisplacementX
+      + sinf(currentYaw) * linearDisplacementY) / dt.count();
+    double linearVelocityY = (cosf(currentYaw) * linearDisplacementY
+      - sinf(currentYaw) * linearDisplacementX) / dt.count();
+    std::get<0>(this->linearMean).Push(linearVelocityX);
+    std::get<1>(this->linearMean).Push(linearVelocityY);
+    msg.mutable_twist()->mutable_linear()->set_x(
+      std::get<0>(this->linearMean).Mean());
+    msg.mutable_twist()->mutable_linear()->set_y(
+      std::get<1>(this->linearMean).Mean());
+  }
+  // Get velocities and roll/pitch rates assuming 3D
+  else if (this->dimensions == 3)
+  {
+    double currentRoll = pose.Rot().Roll();
+    const double lastRoll = this->lastUpdatePose.Rot().Roll();
+    while (currentRoll < lastRoll - IGN_PI) currentRoll += 2 * IGN_PI;
+    while (currentRoll > lastRoll + IGN_PI) currentRoll -= 2 * IGN_PI;
+    const float rollDiff = currentRoll - lastRoll;
+
+    double currentPitch = pose.Rot().Pitch();
+    const double lastPitch = this->lastUpdatePose.Rot().Pitch();
+    while (currentPitch < lastPitch - IGN_PI) currentPitch += 2 * IGN_PI;
+    while (currentPitch > lastPitch + IGN_PI) currentPitch -= 2 * IGN_PI;
+    const float pitchDiff = currentPitch - lastPitch;
+
+    double linearDisplacementZ =
+      pose.Pos().Z() - this->lastUpdatePose.Pos().Z();
+    math::Vector3 linearDisplacement(linearDisplacementX, linearDisplacementY,
+      linearDisplacementZ);
+    math::Vector3 linearVelocity =
+      pose.Rot().RotateVectorReverse(linearDisplacement) / dt.count();
+    std::get<0>(this->linearMean).Push(linearVelocity.X());
+    std::get<1>(this->linearMean).Push(linearVelocity.Y());
+    std::get<2>(this->linearMean).Push(linearVelocity.Z());
+    std::get<0>(this->angularMean).Push(rollDiff / dt.count());
+    std::get<1>(this->angularMean).Push(pitchDiff / dt.count());
+    msg.mutable_twist()->mutable_linear()->set_x(
+      std::get<0>(this->linearMean).Mean());
+    msg.mutable_twist()->mutable_linear()->set_y(
+      std::get<1>(this->linearMean).Mean());
+    msg.mutable_twist()->mutable_linear()->set_z(
+      std::get<2>(this->linearMean).Mean());
+    msg.mutable_twist()->mutable_angular()->set_x(
+      std::get<0>(this->angularMean).Mean());
+    msg.mutable_twist()->mutable_angular()->set_y(
+      std::get<1>(this->angularMean).Mean());
+  }
+
+  // Set yaw rate
+  std::get<2>(this->angularMean).Push(yawDiff / dt.count());
+  msg.mutable_twist()->mutable_angular()->set_z(
+    std::get<2>(this->angularMean).Mean());
 
   // Set the time stamp in the header.
   msg.mutable_header()->mutable_stamp()->CopyFrom(

--- a/src/systems/odometry_publisher/OdometryPublisher.hh
+++ b/src/systems/odometry_publisher/OdometryPublisher.hh
@@ -33,7 +33,7 @@ namespace systems
   class OdometryPublisherPrivate;
 
   /// \brief Odometry Publisher which can be attached to any entity in
-  /// order to periodically publish 2D odometry data in the form of
+  /// order to periodically publish 2D or 3D odometry data in the form of
   /// ignition::msgs::Odometry messages.
   ///
   /// # System Parameters
@@ -52,6 +52,10 @@ namespace systems
   /// `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element is optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
+  ///
+  /// `<dimensions>`: Number of dimensions to represent odometry. Only 2 and 3
+  /// dimensional spaces are supported. This element is optional, and the
+  /// default value is 2.
   class OdometryPublisher
       : public System,
         public ISystemConfigure,

--- a/test/integration/odometry_publisher.cc
+++ b/test/integration/odometry_publisher.cc
@@ -207,6 +207,135 @@ class OdometryPublisherTest
 
   /// \param[in] _sdfFile SDF file to load.
   /// \param[in] _odomTopic Odometry topic.
+  protected: void TestMovement3d(const std::string &_sdfFile,
+                                 const std::string &_odomTopic)
+  {
+    // Start server
+    ServerConfig serverConfig;
+    serverConfig.SetSdfFile(_sdfFile);
+
+    Server server(serverConfig);
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+
+    // Create a system that records the vehicle poses and velocities
+    test::Relay testSystem;
+
+    std::vector<math::Pose3d> poses;
+    testSystem.OnPostUpdate([&poses](const gazebo::UpdateInfo &,
+      const gazebo::EntityComponentManager &_ecm)
+      {
+        auto id = _ecm.EntityByComponents(
+          components::Model(),
+          components::Name("X3"));
+        EXPECT_NE(kNullEntity, id);
+
+        auto poseComp = _ecm.Component<components::Pose>(id);
+        ASSERT_NE(nullptr, poseComp);
+        poses.push_back(poseComp->Data());
+      });
+    server.AddSystem(testSystem.systemPtr);
+
+    // Run server while model is stationary
+    server.Run(true, 1000, false);
+
+    EXPECT_EQ(1000u, poses.size());
+
+    for (const auto &pose : poses)
+    {
+      EXPECT_EQ(poses[0], pose);
+    }
+
+    // 50 Hz is the default publishing freq
+    double period{1.0 / 50.0};
+    double lastMsgTime{1.0};
+    std::vector<math::Pose3d> odomPoses;
+    std::vector<math::Vector3d> odomLinVels;
+    std::vector<math::Vector3d> odomAngVels;
+    // Create function to store data from odometry messages
+    std::function<void(const msgs::Odometry &)> odomCb =
+      [&](const msgs::Odometry &_msg)
+      {
+        ASSERT_TRUE(_msg.has_header());
+        ASSERT_TRUE(_msg.header().has_stamp());
+
+        double msgTime =
+            static_cast<double>(_msg.header().stamp().sec()) +
+            static_cast<double>(_msg.header().stamp().nsec()) * 1e-9;
+
+        EXPECT_DOUBLE_EQ(msgTime, lastMsgTime + period);
+        lastMsgTime = msgTime;
+
+        odomPoses.push_back(msgs::Convert(_msg.pose()));
+        odomLinVels.push_back(msgs::Convert(_msg.twist().linear()));
+        odomAngVels.push_back(msgs::Convert(_msg.twist().angular()));
+      };
+    // Create node for publishing twist messages
+    transport::Node node;
+    auto cmdVel = node.Advertise<msgs::Twist>("/X3/gazebo/command/twist");
+    node.Subscribe(_odomTopic, odomCb);
+
+    test::Relay velocityRamp;
+    math::Vector3d linVelCmd(0.5, 0.3, 1.5);
+    math::Vector3d angVelCmd(0.0, 0.0, 0.2);
+    velocityRamp.OnPreUpdate(
+        [&](const gazebo::UpdateInfo &/*_info*/,
+            gazebo::EntityComponentManager &/*_ecm*/)
+        {
+          msgs::Twist msg;
+          msgs::Set(msg.mutable_linear(), linVelCmd);
+          msgs::Set(msg.mutable_angular(), angVelCmd);
+          cmdVel.Publish(msg);
+        });
+
+    server.AddSystem(velocityRamp.systemPtr);
+
+    // Run server while the model moves with the velocities set earlier
+    server.Run(true, 3000, false);
+
+    // Poses for 4s
+    ASSERT_EQ(4000u, poses.size());
+
+    int sleep = 0;
+    int maxSleep = 30;
+    for (; odomPoses.size() < 150 && sleep < maxSleep; ++sleep)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_NE(maxSleep, sleep);
+
+    // Odom for 3s
+    ASSERT_FALSE(odomPoses.empty());
+    EXPECT_EQ(150u, odomPoses.size());
+    EXPECT_EQ(150u, odomLinVels.size());
+    EXPECT_EQ(150u, odomAngVels.size());
+
+    // Check accuracy of poses published in the odometry message
+    auto finalModelFramePose = odomPoses.back();
+    EXPECT_NEAR(poses[1020].Pos().X(), odomPoses[0].Pos().X(), 1e-2);
+    EXPECT_NEAR(poses[1020].Pos().Y(), odomPoses[0].Pos().Y(), 1e-2);
+    EXPECT_NEAR(poses[1020].Pos().Z(), odomPoses[0].Pos().Z(), 1e-2);
+    EXPECT_NEAR(poses[1020].Rot().X(), odomPoses[0].Rot().X(), 1e-2);
+    EXPECT_NEAR(poses[1020].Rot().Y(), odomPoses[0].Rot().Y(), 1e-2);
+    EXPECT_NEAR(poses[1020].Rot().Z(), odomPoses[0].Rot().Z(), 1e-2);
+    EXPECT_NEAR(poses.back().Pos().X(), finalModelFramePose.Pos().X(), 1e-2);
+    EXPECT_NEAR(poses.back().Pos().Y(), finalModelFramePose.Pos().Y(), 1e-2);
+    EXPECT_NEAR(poses.back().Pos().Z(), finalModelFramePose.Pos().Z(), 1e-2);
+    EXPECT_NEAR(poses.back().Rot().X(), finalModelFramePose.Rot().X(), 1e-2);
+    EXPECT_NEAR(poses.back().Rot().Y(), finalModelFramePose.Rot().Y(), 1e-2);
+    EXPECT_NEAR(poses.back().Rot().Z(), finalModelFramePose.Rot().Z(), 1e-2);
+
+    // Check accuracy of velocities published in the odometry message
+    EXPECT_NEAR(odomLinVels.back().X(), linVelCmd[0], 1e-1);
+    EXPECT_NEAR(odomLinVels.back().Y(), linVelCmd[1], 1e-1);
+    EXPECT_NEAR(odomLinVels.back().Z(), linVelCmd[2], 1e-1);
+    EXPECT_NEAR(odomAngVels.back().X(), 0.0, 1e-1);
+    EXPECT_NEAR(odomAngVels.back().Y(), 0.0, 1e-1);
+    EXPECT_NEAR(odomAngVels.back().Z(), angVelCmd[2], 1e-1);
+  }
+
+  /// \param[in] _sdfFile SDF file to load.
+  /// \param[in] _odomTopic Odometry topic.
   /// \param[in] _frameId Name of the world-fixed coordinate frame
   /// for the odometry message.
   /// \param[in] _childFrameId Name of the coordinate frame rigidly
@@ -281,6 +410,15 @@ TEST_P(OdometryPublisherTest, MovementCustomTopic)
       std::string(PROJECT_SOURCE_PATH) +
       "/test/worlds/odometry_publisher_custom.sdf",
       "/model/bar/odom");
+}
+
+/////////////////////////////////////////////////
+TEST_P(OdometryPublisherTest, Movement3d)
+{
+  TestMovement3d(
+      ignition::common::joinPaths(PROJECT_SOURCE_PATH,
+      "/test/worlds/odometry_publisher_3d.sdf"),
+      "/model/X3/odometry");
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/odometry_publisher.cc
+++ b/test/integration/odometry_publisher.cc
@@ -417,7 +417,7 @@ TEST_P(OdometryPublisherTest, Movement3d)
 {
   TestMovement3d(
       ignition::common::joinPaths(PROJECT_SOURCE_PATH,
-      "/test/worlds/odometry_publisher_3d.sdf"),
+      "test", "worlds", "odometry_publisher_3d.sdf"),
       "/model/X3/odometry");
 }
 

--- a/test/worlds/odometry_publisher_3d.sdf
+++ b/test/worlds/odometry_publisher_3d.sdf
@@ -1,0 +1,390 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="quadrotor">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="X3">
+      <pose>0 0 0.053302 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1.5</mass>
+          <inertia>
+            <ixx>0.0347563</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.07</iyy>
+            <iyz>0</iyz>
+            <izz>0.0977</izz>
+          </inertia>
+        </inertial>
+        <collision name="base_link_inertia_collision">
+          <geometry>
+            <box>
+              <size>0.30 0.42 0.11</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="base_link_inertia_visual">
+          <geometry>
+            <box>
+              <size>0.15 0.21 0.11</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+      <link name="rotor_0">
+        <pose frame="">0.13 -0.22 0.023 0 -0 0</pose>
+        <inertial>
+          <mass>0.005</mass>
+          <inertia>
+            <ixx>9.75e-07</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>4.17041e-05</iyy>
+            <iyz>0</iyz>
+            <izz>4.26041e-05</izz>
+          </inertia>
+        </inertial>
+        <collision name="rotor_0_collision">
+          <geometry>
+            <cylinder>
+              <length>0.005</length>
+              <radius>0.1</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="rotor_0_visual">
+          <pose>0 0 0 1.57 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.01</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <diffuse>0 0 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="rotor_0_joint" type="revolute">
+        <child>rotor_0</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+        </axis>
+      </joint>
+      <link name="rotor_1">
+        <pose>-0.13 0.2 0.023 0 -0 0</pose>
+        <inertial>
+          <mass>0.005</mass>
+          <inertia>
+            <ixx>9.75e-07</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>4.17041e-05</iyy>
+            <iyz>0</iyz>
+            <izz>4.26041e-05</izz>
+          </inertia>
+        </inertial>
+        <collision name="rotor_1_collision">
+          <geometry>
+            <cylinder>
+              <length>0.005</length>
+              <radius>0.1</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="rotor_1_visual">
+          <pose>0 0 0 1.57 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.01</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <diffuse>1 0 0 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="rotor_1_joint" type="revolute">
+        <child>rotor_1</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+        </axis>
+      </joint>
+      <link name="rotor_2">
+        <pose>0.13 0.22 0.023 0 -0 0</pose>
+        <inertial>
+          <mass>0.005</mass>
+          <inertia>
+            <ixx>9.75e-07</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>4.17041e-05</iyy>
+            <iyz>0</iyz>
+            <izz>4.26041e-05</izz>
+          </inertia>
+        </inertial>
+        <collision name="rotor_2_collision">
+          <geometry>
+            <cylinder>
+              <length>0.005</length>
+              <radius>0.1</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="rotor_2_visual">
+          <pose>0 0 0 1.57 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.01</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <diffuse>0 0 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="rotor_2_joint" type="revolute">
+        <child>rotor_2</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+        </axis>
+      </joint>
+      <link name="rotor_3">
+        <pose>-0.13 -0.2 0.023 0 -0 0</pose>
+        <inertial>
+          <mass>0.005</mass>
+          <inertia>
+            <ixx>9.75e-07</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>4.17041e-05</iyy>
+            <iyz>0</iyz>
+            <izz>4.26041e-05</izz>
+          </inertia>
+        </inertial>
+        <collision name="rotor_3_collision">
+          <geometry>
+            <cylinder>
+              <length>0.005</length>
+              <radius>0.1</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="rotor_3_visual">
+          <pose>0 0 0 1.57 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.01</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <diffuse>1 0 0 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="rotor_3_joint" type="revolute">
+        <child>rotor_3</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+        </axis>
+      </joint>
+      <plugin
+        filename="ignition-gazebo-multicopter-motor-model-system"
+        name="ignition::gazebo::systems::MulticopterMotorModel">
+        <robotNamespace>X3</robotNamespace>
+        <jointName>rotor_0_joint</jointName>
+        <linkName>rotor_0</linkName>
+        <turningDirection>ccw</turningDirection>
+        <timeConstantUp>0.0125</timeConstantUp>
+        <timeConstantDown>0.025</timeConstantDown>
+        <maxRotVelocity>8000.0</maxRotVelocity>
+        <motorConstant>8.54858e-06</motorConstant>
+        <momentConstant>0.016</momentConstant>
+        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <motorNumber>0</motorNumber>
+        <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+        <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+        <motorSpeedPubTopic>motor_speed/0</motorSpeedPubTopic>
+        <rotorVelocitySlowdownSim>1</rotorVelocitySlowdownSim>
+        <motorType>velocity</motorType>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-multicopter-motor-model-system"
+        name="ignition::gazebo::systems::MulticopterMotorModel">
+        <robotNamespace>X3</robotNamespace>
+        <jointName>rotor_1_joint</jointName>
+        <linkName>rotor_1</linkName>
+        <turningDirection>ccw</turningDirection>
+        <timeConstantUp>0.0125</timeConstantUp>
+        <timeConstantDown>0.025</timeConstantDown>
+        <maxRotVelocity>8000.0</maxRotVelocity>
+        <motorConstant>8.54858e-06</motorConstant>
+        <momentConstant>0.016</momentConstant>
+        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <motorNumber>1</motorNumber>
+        <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+        <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+        <motorSpeedPubTopic>motor_speed/1</motorSpeedPubTopic>
+        <rotorVelocitySlowdownSim>1</rotorVelocitySlowdownSim>
+        <motorType>velocity</motorType>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-multicopter-motor-model-system"
+        name="ignition::gazebo::systems::MulticopterMotorModel">
+        <robotNamespace>X3</robotNamespace>
+        <jointName>rotor_2_joint</jointName>
+        <linkName>rotor_2</linkName>
+        <turningDirection>cw</turningDirection>
+        <timeConstantUp>0.0125</timeConstantUp>
+        <timeConstantDown>0.025</timeConstantDown>
+        <maxRotVelocity>8000.0</maxRotVelocity>
+        <motorConstant>8.54858e-06</motorConstant>
+        <momentConstant>0.016</momentConstant>
+        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <motorNumber>2</motorNumber>
+        <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+        <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+        <motorSpeedPubTopic>motor_speed/2</motorSpeedPubTopic>
+        <rotorVelocitySlowdownSim>1</rotorVelocitySlowdownSim>
+        <motorType>velocity</motorType>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-multicopter-motor-model-system"
+        name="ignition::gazebo::systems::MulticopterMotorModel">
+        <robotNamespace>X3</robotNamespace>
+        <jointName>rotor_3_joint</jointName>
+        <linkName>rotor_3</linkName>
+        <turningDirection>cw</turningDirection>
+        <timeConstantUp>0.0125</timeConstantUp>
+        <timeConstantDown>0.025</timeConstantDown>
+        <maxRotVelocity>8000.0</maxRotVelocity>
+        <motorConstant>8.54858e-06</motorConstant>
+        <momentConstant>0.016</momentConstant>
+        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <motorNumber>3</motorNumber>
+        <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+        <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+        <motorSpeedPubTopic>motor_speed/3</motorSpeedPubTopic>
+        <rotorVelocitySlowdownSim>1</rotorVelocitySlowdownSim>
+        <motorType>velocity</motorType>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-multicopter-control-system"
+        name="ignition::gazebo::systems::MulticopterVelocityControl">
+        <robotNamespace>X3</robotNamespace>
+        <commandSubTopic>gazebo/command/twist</commandSubTopic>
+        <enableSubTopic>enable</enableSubTopic>
+        <comLinkName>base_link</comLinkName>
+        <velocityGain>2.7 2.7 2.7</velocityGain>
+        <attitudeGain>2 3 0.15</attitudeGain>
+        <angularRateGain>0.4 0.52 0.18</angularRateGain>
+        <maximumLinearAcceleration>2 2 2</maximumLinearAcceleration>
+
+        <rotorConfiguration>
+          <rotor>
+            <jointName>rotor_0_joint</jointName>
+            <forceConstant>8.54858e-06</forceConstant>
+            <momentConstant>0.016</momentConstant>
+            <direction>1</direction>
+          </rotor>
+          <rotor>
+            <jointName>rotor_1_joint</jointName>
+            <forceConstant>8.54858e-06</forceConstant>
+            <momentConstant>0.016</momentConstant>
+            <direction>1</direction>
+          </rotor>
+          <rotor>
+            <jointName>rotor_2_joint</jointName>
+            <forceConstant>8.54858e-06</forceConstant>
+            <momentConstant>0.016</momentConstant>
+            <direction>-1</direction>
+          </rotor>
+          <rotor>
+            <jointName>rotor_3_joint</jointName>
+            <forceConstant>8.54858e-06</forceConstant>
+            <momentConstant>0.016</momentConstant>
+            <direction>-1</direction>
+          </rotor>
+        </rotorConfiguration>
+      </plugin>
+      <plugin
+        filename="ignition-gazebo-odometry-publisher-system"
+        name="ignition::gazebo::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Blake McHale <mchale.blake@gmail.com>

# 🎉 New feature

Closes #934 and replaces #941.

## Summary
This adds in a new tag `<dimensions>` to the odometry publisher plugin that accepts either 2 or 3 (defaults to 2). When the value is 3 it assumes a 3D assumption instead of planar. This is useful for people who want to know the z location and angular rates. In my use case, I was using the multicopter plugin with the X3 model.

## Test it
This feature can be tested by running the `INTEGRATION_odometry_publisher` test or adding the tag to the plugin in an SDF file. I tested this manually and echoed the odometry topic while commanding the multicopter with velocities.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
