### PR TITLE
Add IMU component inspector

### DIFF
--- a/src/gui/plugins/component_inspector/CMakeLists.txt
+++ b/src/gui/plugins/component_inspector/CMakeLists.txt
@@ -3,6 +3,7 @@ gz_add_gui_plugin(ComponentInspector
     AirPressure.cc
     Altimeter.cc
     ComponentInspector.cc
+    Imu.cc
     Magnetometer.cc
     ModelEditor.cc
     Types.cc
@@ -10,6 +11,7 @@ gz_add_gui_plugin(ComponentInspector
     AirPressure.hh
     Altimeter.hh
     ComponentInspector.hh
+    Imu.hh
     Magnetometer.hh
     ModelEditor.hh
     Types.hh

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -72,6 +72,7 @@
 
 #include "Altimeter.hh"
 #include "AirPressure.hh"
+#include "Imu.hh"
 #include "Magnetometer.hh"
 #include "ComponentInspector.hh"
 #include "ModelEditor.hh"
@@ -121,6 +122,9 @@ namespace ignition::gazebo
 
     /// \brief Altimeter sensor inspector elements
     public: std::unique_ptr<ignition::gazebo::Altimeter> altimeter;
+
+    /// \brief Imu inspector elements
+    public: std::unique_ptr<ignition::gazebo::Imu> imu;
 
     /// \brief Magnetometer inspector elements
     public: std::unique_ptr<ignition::gazebo::Magnetometer> magnetometer;
@@ -443,6 +447,9 @@ void ComponentInspector::LoadConfig(const tinyxml2::XMLElement *)
 
   // Create altimeter
   this->dataPtr->altimeter = std::make_unique<Altimeter>(this);
+
+  // Create the imu
+  this->dataPtr->imu = std::make_unique<Imu>(this);
 
   // Create the magnetometer
   this->dataPtr->magnetometer = std::make_unique<Magnetometer>(this);

--- a/src/gui/plugins/component_inspector/ComponentInspector.qrc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qrc
@@ -5,6 +5,7 @@
   <file>Boolean.qml</file>
   <file>ComponentInspector.qml</file>
   <file>ExpandingTypeHeader.qml</file>
+  <file>Imu.qml</file>
   <file>Light.qml</file>
   <file>Magnetometer.qml</file>
   <file>NoData.qml</file>

--- a/src/gui/plugins/component_inspector/Imu.cc
+++ b/src/gui/plugins/component_inspector/Imu.cc
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <sdf/Imu.hh>
+
+#include <ignition/common/Console.hh>
+#include <ignition/gazebo/components/Imu.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+
+#include "Imu.hh"
+#include "ComponentInspector.hh"
+#include "Types.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+/////////////////////////////////////////////////
+Imu::Imu(ComponentInspector *_inspector)
+{
+  _inspector->Context()->setContextProperty("ImuImpl", this);
+  this->inspector = _inspector;
+
+  ComponentCreator creator =
+    [=](EntityComponentManager &_ecm, Entity _entity, QStandardItem *_item)
+  {
+    auto comp = _ecm.Component<components::Imu>(_entity);
+    if (nullptr == _item || nullptr == comp)
+      return;
+    const sdf::Imu *imu = comp->Data().ImuSensor();
+
+    _item->setData(QString("Imu"),
+        ComponentsModel::RoleNames().key("dataType"));
+    _item->setData(QList({
+      QVariant(imu->LinearAccelerationXNoise().Mean()),
+      QVariant(imu->LinearAccelerationXNoise().BiasMean()),
+      QVariant(imu->LinearAccelerationXNoise().StdDev()),
+      QVariant(imu->LinearAccelerationXNoise().BiasStdDev()),
+      QVariant(imu->LinearAccelerationXNoise().DynamicBiasStdDev()),
+      QVariant(imu->LinearAccelerationXNoise().DynamicBiasCorrelationTime()),
+
+      QVariant(imu->LinearAccelerationYNoise().Mean()),
+      QVariant(imu->LinearAccelerationYNoise().BiasMean()),
+      QVariant(imu->LinearAccelerationYNoise().StdDev()),
+      QVariant(imu->LinearAccelerationYNoise().BiasStdDev()),
+      QVariant(imu->LinearAccelerationYNoise().DynamicBiasStdDev()),
+      QVariant(imu->LinearAccelerationYNoise().DynamicBiasCorrelationTime()),
+
+      QVariant(imu->LinearAccelerationZNoise().Mean()),
+      QVariant(imu->LinearAccelerationZNoise().BiasMean()),
+      QVariant(imu->LinearAccelerationZNoise().StdDev()),
+      QVariant(imu->LinearAccelerationZNoise().BiasStdDev()),
+      QVariant(imu->LinearAccelerationZNoise().DynamicBiasStdDev()),
+      QVariant(imu->LinearAccelerationZNoise().DynamicBiasCorrelationTime()),
+
+      QVariant(imu->AngularVelocityXNoise().Mean()),
+      QVariant(imu->AngularVelocityXNoise().BiasMean()),
+      QVariant(imu->AngularVelocityXNoise().StdDev()),
+      QVariant(imu->AngularVelocityXNoise().BiasStdDev()),
+      QVariant(imu->AngularVelocityXNoise().DynamicBiasStdDev()),
+      QVariant(imu->AngularVelocityXNoise().DynamicBiasCorrelationTime()),
+
+      QVariant(imu->AngularVelocityYNoise().Mean()),
+      QVariant(imu->AngularVelocityYNoise().BiasMean()),
+      QVariant(imu->AngularVelocityYNoise().StdDev()),
+      QVariant(imu->AngularVelocityYNoise().BiasStdDev()),
+      QVariant(imu->AngularVelocityYNoise().DynamicBiasStdDev()),
+      QVariant(imu->AngularVelocityYNoise().DynamicBiasCorrelationTime()),
+
+      QVariant(imu->AngularVelocityZNoise().Mean()),
+      QVariant(imu->AngularVelocityZNoise().BiasMean()),
+      QVariant(imu->AngularVelocityZNoise().StdDev()),
+      QVariant(imu->AngularVelocityZNoise().BiasStdDev()),
+      QVariant(imu->AngularVelocityZNoise().DynamicBiasStdDev()),
+      QVariant(imu->AngularVelocityZNoise().DynamicBiasCorrelationTime()),
+
+    }), ComponentsModel::RoleNames().key("data"));
+  };
+
+  this->inspector->RegisterComponentCreator(
+      components::Imu::typeId, creator);
+}
+
+/////////////////////////////////////////////////
+Q_INVOKABLE void Imu::OnLinearAccelerationXNoise(
+    double _mean, double _meanBias, double _stdDev,
+    double _stdDevBias, double _dynamicBiasStdDev,
+    double _dynamicBiasCorrelationTime)
+{
+  ignition::gazebo::UpdateCallback cb =
+      [=](EntityComponentManager &_ecm)
+  {
+    auto comp = _ecm.Component<components::Imu>(
+        this->inspector->Entity());
+    if (comp)
+    {
+      sdf::Imu *imu = comp->Data().ImuSensor();
+      if (imu)
+      {
+        sdf::Noise noise = imu->LinearAccelerationXNoise();
+
+        setNoise(noise, _mean, _meanBias, _stdDev, _stdDevBias,
+            _dynamicBiasStdDev, _dynamicBiasCorrelationTime);
+
+        imu->SetLinearAccelerationXNoise(noise);
+      }
+      else
+        ignerr << "Unable to get the imu linear acceleration x noise data.\n";
+    }
+    else
+    {
+      ignerr << "Unable to get the imu component.\n";
+    }
+  };
+  this->inspector->AddUpdateCallback(cb);
+}
+
+/////////////////////////////////////////////////
+Q_INVOKABLE void Imu::OnLinearAccelerationYNoise(
+    double _mean, double _meanBias, double _stdDev,
+    double _stdDevBias, double _dynamicBiasStdDev,
+    double _dynamicBiasCorrelationTime)
+{
+  ignition::gazebo::UpdateCallback cb =
+      [=](EntityComponentManager &_ecm)
+  {
+    auto comp = _ecm.Component<components::Imu>(
+        this->inspector->Entity());
+    if (comp)
+    {
+      sdf::Imu *imu = comp->Data().ImuSensor();
+      if (imu)
+      {
+        sdf::Noise noise = imu->LinearAccelerationYNoise();
+
+        setNoise(noise, _mean, _meanBias, _stdDev, _stdDevBias,
+            _dynamicBiasStdDev, _dynamicBiasCorrelationTime);
+
+        imu->SetLinearAccelerationYNoise(noise);
+      }
+      else
+        ignerr << "Unable to get the imu linear acceleration y noise data.\n";
+    }
+    else
+    {
+      ignerr << "Unable to get the imu component.\n";
+    }
+  };
+  this->inspector->AddUpdateCallback(cb);
+}
+
+/////////////////////////////////////////////////
+Q_INVOKABLE void Imu::OnLinearAccelerationZNoise(
+    double _mean, double _meanBias, double _stdDev,
+    double _stdDevBias, double _dynamicBiasStdDev,
+    double _dynamicBiasCorrelationTime)
+{
+  ignition::gazebo::UpdateCallback cb =
+      [=](EntityComponentManager &_ecm)
+  {
+    auto comp = _ecm.Component<components::Imu>(
+        this->inspector->Entity());
+    if (comp)
+    {
+      sdf::Imu *imu = comp->Data().ImuSensor();
+      if (imu)
+      {
+        sdf::Noise noise = imu->LinearAccelerationZNoise();
+
+        setNoise(noise, _mean, _meanBias, _stdDev, _stdDevBias,
+            _dynamicBiasStdDev, _dynamicBiasCorrelationTime);
+
+        imu->SetLinearAccelerationZNoise(noise);
+      }
+      else
+        ignerr << "Unable to get the imu linear acceleration z noise data.\n";
+    }
+    else
+    {
+      ignerr << "Unable to get the imu component.\n";
+    }
+  };
+  this->inspector->AddUpdateCallback(cb);
+}
+
+/////////////////////////////////////////////////
+Q_INVOKABLE void Imu::OnAngularVelocityXNoise(
+    double _mean, double _meanBias, double _stdDev,
+    double _stdDevBias, double _dynamicBiasStdDev,
+    double _dynamicBiasCorrelationTime)
+{
+  ignition::gazebo::UpdateCallback cb =
+      [=](EntityComponentManager &_ecm)
+  {
+    auto comp = _ecm.Component<components::Imu>(
+        this->inspector->Entity());
+    if (comp)
+    {
+      sdf::Imu *imu = comp->Data().ImuSensor();
+      if (imu)
+      {
+        sdf::Noise noise = imu->AngularVelocityXNoise();
+
+        setNoise(noise, _mean, _meanBias, _stdDev, _stdDevBias,
+            _dynamicBiasStdDev, _dynamicBiasCorrelationTime);
+
+        imu->SetAngularVelocityXNoise(noise);
+      }
+      else
+        ignerr << "Unable to get the imu angular velocity x noise data.\n";
+    }
+    else
+    {
+      ignerr << "Unable to get the imu component.\n";
+    }
+  };
+  this->inspector->AddUpdateCallback(cb);
+}
+
+/////////////////////////////////////////////////
+Q_INVOKABLE void Imu::OnAngularVelocityYNoise(
+    double _mean, double _meanBias, double _stdDev,
+    double _stdDevBias, double _dynamicBiasStdDev,
+    double _dynamicBiasCorrelationTime)
+{
+  ignition::gazebo::UpdateCallback cb =
+      [=](EntityComponentManager &_ecm)
+  {
+    auto comp = _ecm.Component<components::Imu>(
+        this->inspector->Entity());
+    if (comp)
+    {
+      sdf::Imu *imu = comp->Data().ImuSensor();
+      if (imu)
+      {
+        sdf::Noise noise = imu->AngularVelocityYNoise();
+
+        setNoise(noise, _mean, _meanBias, _stdDev, _stdDevBias,
+            _dynamicBiasStdDev, _dynamicBiasCorrelationTime);
+
+        imu->SetAngularVelocityYNoise(noise);
+      }
+      else
+        ignerr << "Unable to get the imu angular velocity y noise data.\n";
+    }
+    else
+    {
+      ignerr << "Unable to get the imu component.\n";
+    }
+  };
+  this->inspector->AddUpdateCallback(cb);
+}
+
+/////////////////////////////////////////////////
+Q_INVOKABLE void Imu::OnAngularVelocityZNoise(
+    double _mean, double _meanBias, double _stdDev,
+    double _stdDevBias, double _dynamicBiasStdDev,
+    double _dynamicBiasCorrelationTime)
+{
+  ignition::gazebo::UpdateCallback cb =
+      [=](EntityComponentManager &_ecm)
+  {
+    auto comp = _ecm.Component<components::Imu>(
+        this->inspector->Entity());
+    if (comp)
+    {
+      sdf::Imu *imu = comp->Data().ImuSensor();
+      if (imu)
+      {
+        sdf::Noise noise = imu->AngularVelocityZNoise();
+
+        setNoise(noise, _mean, _meanBias, _stdDev, _stdDevBias,
+            _dynamicBiasStdDev, _dynamicBiasCorrelationTime);
+
+        imu->SetAngularVelocityZNoise(noise);
+      }
+      else
+        ignerr << "Unable to get the imu angular velocity z noise data.\n";
+    }
+    else
+    {
+      ignerr << "Unable to get the imu component.\n";
+    }
+  };
+  this->inspector->AddUpdateCallback(cb);
+}

--- a/src/gui/plugins/component_inspector/Imu.hh
+++ b/src/gui/plugins/component_inspector/Imu.hh
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_IMU_HH_
+#define IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_IMU_HH_
+
+#include <ignition/gazebo/gui/GuiSystem.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+  class ComponentInspector;
+
+  /// \brief A class that handles IMU sensor changes.
+  class Imu : public QObject
+  {
+    Q_OBJECT
+
+    /// \brief Constructor
+    /// \param[in] _inspector The component inspector.
+    public: explicit Imu(ComponentInspector *_inspector);
+
+    /// \brief This function is called when a user changes values in the
+    /// Imu sensor's linear acceleration X noise values.
+    /// \param[in] _mean Mean value
+    /// \param[in] _meanBias Bias mean value
+    /// \param[in] _stdDev Standard deviation value
+    /// \param[in] _stdDevBias Bias standard deviation value
+    /// \param[in] _dynamicBiasStdDev Dynamic bias standard deviation value
+    /// \param[in] _dynamicBiasCorrelationTime Dynamic bias correlation time
+    /// value
+    public: Q_INVOKABLE void OnLinearAccelerationXNoise(
+                double _mean, double _meanBias, double _stdDev,
+                double _stdDevBias, double _dynamicBiasStdDev,
+                double _dynamicBiasCorrelationTime);
+
+    /// \brief This function is called when a user changes values in the
+    /// Imu sensor's linear acceleration Y noise values.
+    /// \param[in] _mean Mean value
+    /// \param[in] _meanBias Bias mean value
+    /// \param[in] _stdDev Standard deviation value
+    /// \param[in] _stdDevBias Bias standard deviation value
+    /// \param[in] _dynamicBiasStdDev Dynamic bias standard deviation value
+    /// \param[in] _dynamicBiasCorrelationTime Dynamic bias correlation time
+    /// value
+    public: Q_INVOKABLE void OnLinearAccelerationYNoise(
+                double _mean, double _meanBias, double _stdDev,
+                double _stdDevBias, double _dynamicBiasStdDev,
+                double _dynamicBiasCorrelationTime);
+
+    /// \brief This function is called when a user changes values in the
+    /// Imu sensor's linear acceleration Z noise values.
+    /// \param[in] _mean Mean value
+    /// \param[in] _meanBias Bias mean value
+    /// \param[in] _stdDev Standard deviation value
+    /// \param[in] _stdDevBias Bias standard deviation value
+    /// \param[in] _dynamicBiasStdDev Dynamic bias standard deviation value
+    /// \param[in] _dynamicBiasCorrelationTime Dynamic bias correlation time
+    /// value
+    public: Q_INVOKABLE void OnLinearAccelerationZNoise(
+                double _mean, double _meanBias, double _stdDev,
+                double _stdDevBias, double _dynamicBiasStdDev,
+                double _dynamicBiasCorrelationTime);
+
+    /// \brief This function is called when a user changes values in the
+    /// Imu sensor's angular velocity X noise values.
+    /// \param[in] _mean Mean value
+    /// \param[in] _meanBias Bias mean value
+    /// \param[in] _stdDev Standard deviation value
+    /// \param[in] _stdDevBias Bias standard deviation value
+    /// \param[in] _dynamicBiasStdDev Dynamic bias standard deviation value
+    /// \param[in] _dynamicBiasCorrelationTime Dynamic bias correlation time
+    /// value
+    public: Q_INVOKABLE void OnAngularVelocityXNoise(
+                double _mean, double _meanBias, double _stdDev,
+                double _stdDevBias, double _dynamicBiasStdDev,
+                double _dynamicBiasCorrelationTime);
+
+    /// \brief This function is called when a user changes values in the
+    /// Imu sensor's angular velocity Y noise values.
+    /// \param[in] _mean Mean value
+    /// \param[in] _meanBias Bias mean value
+    /// \param[in] _stdDev Standard deviation value
+    /// \param[in] _stdDevBias Bias standard deviation value
+    /// \param[in] _dynamicBiasStdDev Dynamic bias standard deviation value
+    /// \param[in] _dynamicBiasCorrelationTime Dynamic bias correlation time
+    /// value
+    public: Q_INVOKABLE void OnAngularVelocityYNoise(
+                double _mean, double _meanBias, double _stdDev,
+                double _stdDevBias, double _dynamicBiasStdDev,
+                double _dynamicBiasCorrelationTime);
+
+    /// \brief This function is called when a user changes values in the
+    /// Imu sensor's angular velocity Z noise values.
+    /// \param[in] _mean Mean value
+    /// \param[in] _meanBias Bias mean value
+    /// \param[in] _stdDev Standard deviation value
+    /// \param[in] _stdDevBias Bias standard deviation value
+    /// \param[in] _dynamicBiasStdDev Dynamic bias standard deviation value
+    /// \param[in] _dynamicBiasCorrelationTime Dynamic bias correlation time
+    /// value
+    public: Q_INVOKABLE void OnAngularVelocityZNoise(
+                double _mean, double _meanBias, double _stdDev,
+                double _stdDevBias, double _dynamicBiasStdDev,
+                double _dynamicBiasCorrelationTime);
+
+
+    /// \brief Pointer to the component inspector. This is used to add
+    /// update callbacks that modify the ECM.
+    private: ComponentInspector *inspector{nullptr};
+  };
+}
+}
+#endif

--- a/src/gui/plugins/component_inspector/Imu.qml
+++ b/src/gui/plugins/component_inspector/Imu.qml
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Controls 1.4
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.3
+import QtQuick.Controls.Styles 1.4
+import "qrc:/ComponentInspector"
+import "qrc:/qml"
+
+// Item displaying imu sensor information.
+Rectangle {
+  height: header.height + content.height
+  width: componentInspector.width
+  color: index % 2 == 0 ? lightGrey : darkGrey
+
+  Column {
+    anchors.fill: parent
+
+    // The expanding header. Make sure that the content to expand has an id set
+    // to the value "content".
+    ExpandingTypeHeader {
+      id: header
+
+      // Set the 'expandingHeaderText' value to override the default header
+      // values, which is based on the model.
+      expandingHeaderText: "IMU"
+      expandingHeaderToolTip: "Inertial measurement unit properties"
+    }
+
+    // This is the content that will be expanded/contracted using the
+    // ExpandingHeader above. Note the "id: content" attribute.
+    Rectangle {
+      id: content
+      property bool show: false
+      width: parent.width
+      height: show ? layout.height : 0
+      clip: true
+      color: "transparent"
+      Layout.leftMargin: 4
+
+      Behavior on height {
+        NumberAnimation {
+          duration: 200;
+          easing.type: Easing.InOutQuad
+        }
+      }
+
+      ColumnLayout {
+        id: layout
+        width: parent.width
+
+        // Space out the section header.
+        Rectangle {
+          id: linearAccelerationXNoiseTextRect
+          width: parent.width
+          height: childrenRect.height
+          Layout.leftMargin: 10
+          Layout.topMargin: 10
+          color: "transparent"
+
+          Text {
+            text: "Linear Acceleration X Noise"
+            color: "dimgrey"
+            font.pointSize: 12
+          }
+        }
+
+        // Show the linear acceleration X noise values.
+        Noise {
+          id: linearAccelerationXNoise
+          Layout.fillWidth: true
+          Layout.leftMargin: 20
+
+          meanValue: model.data[0]
+          meanBias: model.data[1]
+          stdDevValue: model.data[2]
+          stdDevBias: model.data[3]
+          dynamicBiasStdDev: model.data[4]
+          dynamicBiasCorrelationTime: model.data[5]
+
+          // Connect to the onNoiseUpdate signal in Noise.qml
+          Component.onCompleted: {
+            linearAccelerationXNoise.onNoiseUpdate.connect(
+                ImuImpl.OnLinearAccelerationXNoise)
+          }
+        }
+
+        // Space out the section header.
+        Rectangle {
+          id: linearAccelerationYNoiseTextRect
+          width: parent.width
+          height: childrenRect.height
+          Layout.leftMargin: 10
+          Layout.topMargin: 10
+          color: "transparent"
+
+          Text {
+            text: "Linear Acceleration Y Noise"
+            color: "dimgrey"
+            font.pointSize: 12
+          }
+        }
+
+        // Show the linear acceleration Y noise values.
+        Noise {
+          id: linearAccelerationYNoise
+          Layout.fillWidth: true
+          Layout.leftMargin: 20
+
+          meanValue: model.data[6]
+          meanBias: model.data[7]
+          stdDevValue: model.data[8]
+          stdDevBias: model.data[9]
+          dynamicBiasStdDev: model.data[10]
+          dynamicBiasCorrelationTime: model.data[11]
+
+          // Connect to the onNoiseUpdate signal in Noise.qml
+          Component.onCompleted: {
+            linearAccelerationYNoise.onNoiseUpdate.connect(
+                ImuImpl.OnLinearAccelerationYNoise)
+          }
+        }
+
+        // Space out the section header.
+        Rectangle {
+          id: linearAccelerationZNoiseTextRect
+          width: parent.width
+          height: childrenRect.height
+          Layout.leftMargin: 10
+          Layout.topMargin: 10
+          color: "transparent"
+
+          Text {
+            text: "Linear Acceleration Z Noise"
+            color: "dimgrey"
+            font.pointSize: 12
+          }
+        }
+
+        // Show the linear acceleration Z noise values.
+        Noise {
+          id: linearAccelerationZNoise
+          Layout.fillWidth: true
+          Layout.leftMargin: 20
+
+          meanValue: model.data[12]
+          meanBias: model.data[13]
+          stdDevValue: model.data[14]
+          stdDevBias: model.data[15]
+          dynamicBiasStdDev: model.data[16]
+          dynamicBiasCorrelationTime: model.data[17]
+
+          // Connect to the onNoiseUpdate signal in Noise.qml
+          Component.onCompleted: {
+            linearAccelerationZNoise.onNoiseUpdate.connect(
+                ImuImpl.OnLinearAccelerationZNoise)
+          }
+        }
+
+        // Space out the section header.
+        Rectangle {
+          id: angularVelocityXNoiseTextRect
+          width: parent.width
+          height: childrenRect.height
+          Layout.leftMargin: 10
+          Layout.topMargin: 10
+          color: "transparent"
+
+          Text {
+            text: "Angular Velocity X Noise"
+            color: "dimgrey"
+            font.pointSize: 12
+          }
+        }
+
+        // Show the angular velocity X noise values.
+        Noise {
+          id: angularVelocityXNoise
+          Layout.fillWidth: true
+          Layout.leftMargin: 20
+
+          meanValue: model.data[18]
+          meanBias: model.data[19]
+          stdDevValue: model.data[20]
+          stdDevBias: model.data[21]
+          dynamicBiasStdDev: model.data[22]
+          dynamicBiasCorrelationTime: model.data[23]
+
+          // Connect to the onNoiseUpdate signal in Noise.qml
+          Component.onCompleted: {
+            angularVelocityXNoise.onNoiseUpdate.connect(
+                ImuImpl.OnAngularVelocityXNoise)
+          }
+        }
+
+        // Space out the section header.
+        Rectangle {
+          id: angularVelocityYNoiseTextRect
+          width: parent.width
+          height: childrenRect.height
+          Layout.leftMargin: 10
+          Layout.topMargin: 10
+          color: "transparent"
+
+          Text {
+            text: "Angular Velocity Y Noise"
+            color: "dimgrey"
+            font.pointSize: 12
+          }
+        }
+
+        // Show the angular velocity Y noise values.
+        Noise {
+          id: angularVelocityYNoise
+          Layout.fillWidth: true
+          Layout.leftMargin: 20
+
+          meanValue: model.data[18]
+          meanBias: model.data[19]
+          stdDevValue: model.data[20]
+          stdDevBias: model.data[21]
+          dynamicBiasStdDev: model.data[22]
+          dynamicBiasCorrelationTime: model.data[23]
+
+          // Connect to the onNoiseUpdate signal in Noise.qml
+          Component.onCompleted: {
+            angularVelocityYNoise.onNoiseUpdate.connect(
+                ImuImpl.OnAngularVelocityYNoise)
+          }
+        }
+
+        // Space out the section header.
+        Rectangle {
+          id: angularVelocityZNoiseTextRect
+          width: parent.width
+          height: childrenRect.height
+          Layout.leftMargin: 10
+          Layout.topMargin: 10
+          color: "transparent"
+
+          Text {
+            text: "Angular Velocity Z Noise"
+            color: "dimgrey"
+            font.pointSize: 12
+          }
+        }
+
+        // Show the angular velocity Z noise values.
+        Noise {
+          id: angularVelocityZNoise
+          Layout.fillWidth: true
+          Layout.leftMargin: 20
+
+          meanValue: model.data[18]
+          meanBias: model.data[19]
+          stdDevValue: model.data[20]
+          stdDevBias: model.data[21]
+          dynamicBiasStdDev: model.data[22]
+          dynamicBiasCorrelationTime: model.data[23]
+
+          // Connect to the onNoiseUpdate signal in Noise.qml
+          Component.onCompleted: {
+            angularVelocityZNoise.onNoiseUpdate.connect(
+                ImuImpl.OnAngularVelocityZNoise)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Adds IMU noise component inspection to the GUI.

## Test it

1. `ign gazebo -v 4 sensors.sdf`
2. Take note of the output from `ign model -m sensors_box -l link -s imu`
3. Select the imu sensor in the entity tree.
4. Make some changes to the values in the component inspector. 
5. Rerun `ign model -m sensors_box -l link -s imu` and you should see the changes.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**