### PR TITLE
Prevent creation of spurious <plugin> elements when saving worlds

### DIFF
--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -155,7 +155,7 @@ void LevelManager::ReadLevelPerformerInfo()
 
   sdf::ElementPtr pluginElem;
   // Get the ignition::gazebo plugin element
-  for (auto plugin = worldElem->GetElement("plugin"); plugin;
+  for (auto plugin = worldElem->FindElement("plugin"); plugin;
        plugin = plugin->GetNextElement("plugin"))
   {
     if (plugin->Get<std::string>("name") == kPluginName)

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -959,7 +959,7 @@ void SimulationRunner::LoadLoggingPlugins(const ServerConfig &_config)
 void SimulationRunner::LoadPlugins(const Entity _entity,
     const sdf::ElementPtr &_sdf)
 {
-  sdf::ElementPtr pluginElem = _sdf->GetElement("plugin");
+  sdf::ElementPtr pluginElem = _sdf->FindElement("plugin");
   while (pluginElem)
   {
     auto filename = pluginElem->Get<std::string>("filename");
@@ -967,8 +967,7 @@ void SimulationRunner::LoadPlugins(const Entity _entity,
     // No error message for the 'else' case of the following 'if' statement
     // because SDF create a default <plugin> element even if it's not
     // specified. An error message would result in spamming
-    // the console. \todo(nkoenig) Fix SDF should so that elements are not
-    // automatically added.
+    // the console.
     if (filename != "__default__" && name != "__default__")
     {
       this->LoadPlugin(_entity, filename, name, pluginElem);

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1439,6 +1439,52 @@ TEST_P(SimulationRunnerTest, GenerateWorldSdf)
   EXPECT_EQ(3u, world->ModelCount());
 }
 
+/////////////////////////////////////////////////
+/// Helper function to recursively check for plugins with filename and name
+/// attributes set to "__default__"
+testing::AssertionResult checkForSpuriousPlugins(sdf::ElementPtr _elem)
+{
+  auto plugin = _elem->FindElement("plugin");
+  if (nullptr != plugin &&
+      plugin->Get<std::string>("filename") == "__default__" &&
+      plugin->Get<std::string>("name") == "__default__")
+  {
+    return testing::AssertionFailure() << _elem->ToString("");
+  }
+  for (auto child = _elem->GetFirstElement(); child;
+       child = child->GetNextElement())
+  {
+    auto result = checkForSpuriousPlugins(child);
+    if (!result)
+      return result;
+  }
+  return testing::AssertionSuccess();
+}
+
+/////////////////////////////////////////////////
+TEST_P(SimulationRunnerTest, GeneratedSdfHasNoSpuriousPlugins)
+{
+  // Load SDF file
+  sdf::Root root;
+  root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "shapes.sdf"));
+
+  ASSERT_EQ(1u, root.WorldCount());
+
+  // Create simulation runner
+  auto systemLoader = std::make_shared<SystemLoader>();
+  SimulationRunner runner(root.WorldByIndex(0), systemLoader);
+
+  msgs::SdfGeneratorConfig req;
+  msgs::StringMsg genWorldSdf;
+  EXPECT_TRUE(runner.GenerateWorldSdf(req, genWorldSdf));
+  EXPECT_FALSE(genWorldSdf.data().empty());
+
+  sdf::Root newRoot;
+  newRoot.LoadSdfString(genWorldSdf.data());
+  EXPECT_TRUE(checkForSpuriousPlugins(newRoot.Element()));
+}
+
 // Run multiple times. We want to make sure that static globals don't cause
 // problems.
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, SimulationRunnerTest,


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Spurious `<plugin>` elements were created when saving worlds because `sdf::Element::GetElement` was used to check if a `<plugin>` child element exists. However this function always creates a new element if the element does not exist instead of returning a `nullptr`. The solution is to use `sdf::Element::FindElement` instead. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- ~[ ] Updated documentation (as needed)~
- ~[ ] Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
