### PR TITLE
Make tests run as fast as possible

### DIFF
--- a/src/SdfEntityCreator_TEST.cc
+++ b/src/SdfEntityCreator_TEST.cc
@@ -124,7 +124,7 @@ TEST_F(SdfEntityCreatorTest, CreateEntities)
 
       EXPECT_EQ("default", _name->Data());
       EXPECT_DOUBLE_EQ(0.001, _physics->Data().MaxStepSize());
-      EXPECT_DOUBLE_EQ(1.0, _physics->Data().RealTimeFactor());
+      EXPECT_DOUBLE_EQ(0.0, _physics->Data().RealTimeFactor());
 
       worldCount++;
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -103,8 +103,15 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   // So to get a given RTF, our desired period is:
   //
   // period = step_size / RTF
-  this->updatePeriod = std::chrono::nanoseconds(
-      static_cast<int>(this->stepSize.count() / this->desiredRtf));
+  if (this->desiredRtf < 1e-9)
+  {
+    this->updatePeriod = 0ms;
+  }
+  else
+  {
+    this->updatePeriod = std::chrono::nanoseconds(
+        static_cast<int>(this->stepSize.count() / this->desiredRtf));
+  }
 
   this->pauseConn = this->eventMgr.Connect<events::Pause>(
       std::bind(&SimulationRunner::SetPaused, this, std::placeholders::_1));

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -953,7 +953,7 @@ TEST_P(SimulationRunnerTest, Time)
   EXPECT_EQ(0u, runner.CurrentInfo().iterations);
   EXPECT_EQ(0ms, runner.CurrentInfo().simTime);
   EXPECT_EQ(0ms, runner.CurrentInfo().dt);
-  EXPECT_EQ(1ms, runner.UpdatePeriod());
+  EXPECT_EQ(0ms, runner.UpdatePeriod());
   EXPECT_EQ(1ms, runner.StepSize());
 
   runner.SetPaused(false);
@@ -966,7 +966,7 @@ TEST_P(SimulationRunnerTest, Time)
   EXPECT_EQ(100u, runner.CurrentInfo().iterations);
   EXPECT_EQ(100ms, runner.CurrentInfo().simTime);
   EXPECT_EQ(1ms, runner.CurrentInfo().dt);
-  EXPECT_EQ(1ms, runner.UpdatePeriod());
+  EXPECT_EQ(0ms, runner.UpdatePeriod());
   EXPECT_EQ(1ms, runner.StepSize());
 
   int sleep = 0;
@@ -987,7 +987,7 @@ TEST_P(SimulationRunnerTest, Time)
   EXPECT_EQ(200u, runner.CurrentInfo().iterations);
   EXPECT_EQ(300ms, runner.CurrentInfo().simTime);
   EXPECT_EQ(2ms, runner.CurrentInfo().dt);
-  EXPECT_EQ(1ms, runner.UpdatePeriod());
+  EXPECT_EQ(0ms, runner.UpdatePeriod());
   EXPECT_EQ(2ms, runner.StepSize());
 
   sleep = 0;
@@ -1007,7 +1007,7 @@ TEST_P(SimulationRunnerTest, Time)
   EXPECT_EQ(200u, runner.CurrentInfo().iterations);
   EXPECT_EQ(300ms, runner.CurrentInfo().simTime);
   EXPECT_EQ(2ms, runner.CurrentInfo().dt);
-  EXPECT_EQ(1ms, runner.UpdatePeriod());
+  EXPECT_EQ(0ms, runner.UpdatePeriod());
   EXPECT_EQ(2ms, runner.StepSize());
 
   // Verify info published to /clock topic
@@ -1025,7 +1025,7 @@ TEST_P(SimulationRunnerTest, Time)
   EXPECT_EQ(500ms, runner.CurrentInfo().simTime)
     << runner.CurrentInfo().simTime.count();
   EXPECT_EQ(2ms, runner.CurrentInfo().dt);
-  EXPECT_EQ(1ms, runner.UpdatePeriod());
+  EXPECT_EQ(0ms, runner.UpdatePeriod());
   EXPECT_EQ(2ms, runner.StepSize());
 
   sleep = 0;

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -515,7 +515,7 @@ TEST_P(SceneBroadcasterTest, StateStatic)
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
   serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/examples/worlds/empty.sdf");
+      "/test/worlds/empty.sdf");
 
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());

--- a/test/integration/sensors_system.cc
+++ b/test/integration/sensors_system.cc
@@ -87,6 +87,17 @@ void testDefaultTopics()
   std::vector<transport::MessagePublisher> publishers;
   transport::Node node;
 
+  // Sensors are created in a separate thread, so we sleep here to give them
+  // time
+  int sleep{0};
+  int maxSleep{30};
+  for (; sleep < maxSleep && !node.TopicInfo(topics.front(), publishers);
+      ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_LT(sleep, maxSleep);
+
   for (const std::string &topic : topics)
   {
     bool result = node.TopicInfo(topic, publishers);

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -296,7 +296,7 @@ TEST_F(TouchPluginTest, SpawnedEntities)
   auto testFunc = [&](const std::string &_box1, const std::string &_box2)
   {
     this->server.reset();
-    this->StartServer("/examples/worlds/empty.sdf");
+    this->StartServer("/test/worlds/empty.sdf");
 
     whiteTouched = false;
     req.set_sdf(_box1);

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -704,7 +704,7 @@ TEST_F(UserCommandsTest, Physics)
   auto physicsComp = ecm->Component<components::Physics>(worldEntity);
   ASSERT_NE(nullptr, physicsComp);
   EXPECT_DOUBLE_EQ(0.001, physicsComp->Data().MaxStepSize());
-  EXPECT_DOUBLE_EQ(1.0, physicsComp->Data().RealTimeFactor());
+  EXPECT_DOUBLE_EQ(0.0, physicsComp->Data().RealTimeFactor());
 
   // Set physics properties
   msgs::Physics req;

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -52,7 +52,7 @@ TEST_F(UserCommandsTest, Create)
   // Start server
   ServerConfig serverConfig;
   const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/examples/worlds/empty.sdf";
+    "/test/worlds/empty.sdf";
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);

--- a/test/worlds/air_pressure.sdf
+++ b/test/worlds/air_pressure.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="air_pressure_sensor">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-air-pressure-system"
       name="ignition::gazebo::systems::AirPressure">

--- a/test/worlds/altimeter.sdf
+++ b/test/worlds/altimeter.sdf
@@ -3,7 +3,7 @@
   <world name="altimeter_sensor">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/altimeter_with_pose.sdf
+++ b/test/worlds/altimeter_with_pose.sdf
@@ -3,7 +3,7 @@
   <world name="altimeter_sensor">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/apply_joint_force.sdf
+++ b/test/worlds/apply_joint_force.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/battery.sdf
+++ b/test/worlds/battery.sdf
@@ -3,7 +3,7 @@
   <world name="batteries">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/breadcrumbs.sdf
+++ b/test/worlds/breadcrumbs.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/breadcrumbs_levels.sdf
+++ b/test/worlds/breadcrumbs_levels.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="libignition-gazebo-physics-system.so"

--- a/test/worlds/buoyancy.sdf.in
+++ b/test/worlds/buoyancy.sdf.in
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="libignition-gazebo-physics-system.so"

--- a/test/worlds/camera_sensor_empty_scene.sdf
+++ b/test/worlds/camera_sensor_empty_scene.sdf
@@ -3,7 +3,7 @@
   <world name="sensors">
     <physics name="1ms" type="ignored">
       <max_step_size>.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/camera_video_record.sdf
+++ b/test/worlds/camera_video_record.sdf
@@ -5,7 +5,7 @@
 
     <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="libignition-gazebo-physics-system.so"

--- a/test/worlds/canonical.sdf
+++ b/test/worlds/canonical.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/collada_world_exporter.sdf
+++ b/test/worlds/collada_world_exporter.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="collada_world_exporter_box_test">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
 
     <plugin
       filename="ignition-gazebo-collada-world-exporter-system"

--- a/test/worlds/contact.sdf
+++ b/test/worlds/contact.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="contact_sensor">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/conveyor.sdf
+++ b/test/worlds/conveyor.sdf
@@ -6,7 +6,7 @@
         -->
         <physics name="1ms" type="ignored">
             <max_step_size>0.001</max_step_size>
-            <real_time_factor>10.0</real_time_factor>
+            <real_time_factor>0</real_time_factor>
         </physics>
         <plugin
                 filename="ignition-gazebo-physics-system"

--- a/test/worlds/demo_joint_types.sdf
+++ b/test/worlds/demo_joint_types.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/depth_camera_sensor.sdf
+++ b/test/worlds/depth_camera_sensor.sdf
@@ -7,7 +7,7 @@
   <world name="depth_camera_sensor">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/detachable_joint.sdf
+++ b/test/worlds/detachable_joint.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="detachable_joint">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics"/>
 

--- a/test/worlds/diff_drive.sdf
+++ b/test/worlds/diff_drive.sdf
@@ -2,9 +2,9 @@
 <sdf version="1.6">
   <world name="diff_drive">
 
-    <physics name="1ms" type="ode">
+    <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/diff_drive_custom_frame_id.sdf
+++ b/test/worlds/diff_drive_custom_frame_id.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/diff_drive_custom_tf_topic.sdf
+++ b/test/worlds/diff_drive_custom_tf_topic.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/diff_drive_custom_topics.sdf
+++ b/test/worlds/diff_drive_custom_topics.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/diff_drive_limited_joint_pub.sdf
+++ b/test/worlds/diff_drive_limited_joint_pub.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/diff_drive_skid.sdf
+++ b/test/worlds/diff_drive_skid.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/empty.sdf
+++ b/test/worlds/empty.sdf
@@ -1,42 +1,26 @@
 <?xml version="1.0" ?>
-<!--
-  Log record resources demo.
-
-  Running this world will record log files to /tmp/log. It will overwrite that
-  directory if it already exists.
-
-  You can playback running the log_playback.sdf file.
--->
 <sdf version="1.6">
-  <world name="default">
+  <world name="empty">
     <physics name="fast" type="ignored">
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>0</real_time_factor>
     </physics>
-
     <plugin
-     filename="ignition-gazebo-physics-system"
-     name="ignition::gazebo::systems::Physics">
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
     </plugin>
     <plugin
       filename="ignition-gazebo-scene-broadcaster-system"
       name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
     <plugin
-      filename="ignition-gazebo-log-system"
-      name="ignition::gazebo::systems::LogRecord">
-      <!-- Deprecated: directories to write recorded files.
-           Use --record-path instead. -->
-      <!-- path>/tmp/log</path -->
-      <record_resources>1</record_resources>
-      <compress>0</compress>
+      filename="ignition-gazebo-contact-system"
+      name="ignition::gazebo::systems::Contact">
     </plugin>
-
-    <scene>
-      <ambient>0.8 0.8 0.8 1.0</ambient>
-      <background>0.34 0.39 0.43 1.0</background>
-      <grid>false</grid>
-      <origin_visual>false</origin_visual>
-    </scene>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -52,16 +36,8 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
-    <include>
-      <static>false</static>
-      <name>staging_area</name>
-      <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1</uri>
-    </include>
-
     <model name="ground_plane">
       <static>true</static>
-      <pose>0 0 -0.5 0 0.52 0</pose>
       <link name="link">
         <collision name="collision">
           <geometry>

--- a/test/worlds/event_trigger.sdf
+++ b/test/worlds/event_trigger.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="EventTriggerSystem"
       name="ignition::gazebo::EventTriggerSystem">

--- a/test/worlds/falling.sdf
+++ b/test/worlds/falling.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/friction.sdf
+++ b/test/worlds/friction.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/gpu_lidar_sensor.sdf
+++ b/test/worlds/gpu_lidar_sensor.sdf
@@ -7,7 +7,7 @@
   <world name="gpu_lidar_sensor">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/imu.sdf
+++ b/test/worlds/imu.sdf
@@ -4,7 +4,7 @@
     <gravity>0 0 -5</gravity>
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/include.sdf
+++ b/test/worlds/include.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <include>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/ground plane/1</uri>
     </include>

--- a/test/worlds/joint_controller.sdf
+++ b/test/worlds/joint_controller.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/joint_position_controller.sdf
+++ b/test/worlds/joint_position_controller.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/level_performance.sdf
+++ b/test/worlds/level_performance.sdf
@@ -7,6 +7,10 @@
 -->
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
      filename="ignition-gazebo-physics-system"
      name="ignition::gazebo::systems::Physics">

--- a/test/worlds/levels.sdf
+++ b/test/worlds/levels.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="levels">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-scene-broadcaster-system"
       name="ignition::gazebo::systems::SceneBroadcaster">

--- a/test/worlds/levels_no_performers.sdf
+++ b/test/worlds/levels_no_performers.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="levels">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-scene-broadcaster-system"
       name="ignition::gazebo::systems::SceneBroadcaster">

--- a/test/worlds/lift_drag.sdf
+++ b/test/worlds/lift_drag.sdf
@@ -2,6 +2,10 @@
 <!-- Adapted from osrf/gazebo/test/worlds/lift_drag_plugin.world  -->
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
 
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/lights.sdf
+++ b/test/worlds/lights.sdf
@@ -3,7 +3,7 @@
   <world name="lights">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/log_playback.sdf
+++ b/test/worlds/log_playback.sdf
@@ -1,6 +1,10 @@
 <?xml version='1.0'?>
 <sdf version='1.6'>
   <world name='default'>
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin filename='ignition-gazebo-scene-broadcaster-system'
             name='ignition::gazebo::systems::SceneBroadcaster'>
     </plugin>

--- a/test/worlds/log_record_dbl_pendulum.sdf
+++ b/test/worlds/log_record_dbl_pendulum.sdf
@@ -10,7 +10,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/logical_audio_sensor_plugin.sdf
+++ b/test/worlds/logical_audio_sensor_plugin.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="logical_audio_sensor">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <model name="source_model">
       <pose>0 0 0 0 0 0</pose>
       <link name="source_link">

--- a/test/worlds/logical_audio_sensor_plugin_services.sdf
+++ b/test/worlds/logical_audio_sensor_plugin_services.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="logical_audio_sensor">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <model name="model_playing">
       <pose>0 0 0 0 0 0</pose>
       <link name="audio_link">

--- a/test/worlds/logical_camera_sensor.sdf
+++ b/test/worlds/logical_camera_sensor.sdf
@@ -4,7 +4,7 @@
   <world name="logical_camera_sensor">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/magnetometer.sdf
+++ b/test/worlds/magnetometer.sdf
@@ -4,7 +4,7 @@
     <magnetic_field>0.94 0.76 -0.12</magnetic_field>
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/mesh.sdf
+++ b/test/worlds/mesh.sdf
@@ -3,7 +3,7 @@
   <world name="shapes">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/multiple_worlds.sdf
+++ b/test/worlds/multiple_worlds.sdf
@@ -60,7 +60,7 @@
 
     <physics name="default" type="ode">
       <max_step_size>0.005</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
 
     <light type="directional" name="sun">

--- a/test/worlds/nested_model.sdf
+++ b/test/worlds/nested_model.sdf
@@ -3,7 +3,7 @@
   <world name="nested_model_world">
     <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="libignition-gazebo-physics-system.so"

--- a/test/worlds/nondefault_canonical.sdf
+++ b/test/worlds/nondefault_canonical.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/performer_detector.sdf
+++ b/test/worlds/performer_detector.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="performer_detector">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/performers.sdf
+++ b/test/worlds/performers.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>

--- a/test/worlds/plugins.sdf
+++ b/test/worlds/plugins.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="TestWorldSystem"
       name="ignition::gazebo::TestWorldSystem">

--- a/test/worlds/plugins_empty.sdf
+++ b/test/worlds/plugins_empty.sdf
@@ -2,6 +2,10 @@
 <!-- plugins.sdf without the plugins -->
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <model name="box">
       <link name="link_1">
         <sensor name="camera" type="camera">

--- a/test/worlds/pose_publisher.sdf
+++ b/test/worlds/pose_publisher.sdf
@@ -4,7 +4,7 @@
 
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/quadcopter.sdf
+++ b/test/worlds/quadcopter.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="quadcopter">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/quadcopter_velocity_control.sdf
+++ b/test/worlds/quadcopter_velocity_control.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="quadcopter">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/resource_paths.sdf
+++ b/test/worlds/resource_paths.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <!-- Physics plugin to load meshes -->
     <plugin
       filename="libignition-gazebo-physics-system.so"

--- a/test/worlds/revolute_joint.sdf
+++ b/test/worlds/revolute_joint.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/revolute_joint_equilibrium.sdf
+++ b/test/worlds/revolute_joint_equilibrium.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/rgbd_camera_sensor.sdf
+++ b/test/worlds/rgbd_camera_sensor.sdf
@@ -3,7 +3,7 @@
   <world name="rgbd_camera_sensor">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/save_world.sdf
+++ b/test/worlds/save_world.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="save_world">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/sensor.sdf
+++ b/test/worlds/sensor.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="camera_sensor">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-sensors-system"
       name="ignition::gazebo::systems::Sensors">

--- a/test/worlds/shapes.sdf
+++ b/test/worlds/shapes.sdf
@@ -3,7 +3,7 @@
   <world name="default">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
 
     <gui fullscreen="0">

--- a/test/worlds/static_diff_drive_vehicle.sdf
+++ b/test/worlds/static_diff_drive_vehicle.sdf
@@ -5,7 +5,7 @@
 
     <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/thermal.sdf
+++ b/test/worlds/thermal.sdf
@@ -8,7 +8,7 @@
   <world name="thermal_camera">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/tire_drum.sdf
+++ b/test/worlds/tire_drum.sdf
@@ -9,10 +9,9 @@
           <sor>1.0</sor>
         </solver>
       </ode>
+      <real_time_factor>0</real_time_factor>
     </physics>
 
-
-    
     <model name="tire">
       <pose>0 0 0.5  0 0 0</pose>
 
@@ -222,7 +221,7 @@
     </model>
 
 
-    
+
     <model name="drum">
       <pose>0 0 -4.0  1.5707963267948966 0 0</pose>
 

--- a/test/worlds/touch_plugin.sdf
+++ b/test/worlds/touch_plugin.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="touch">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">

--- a/test/worlds/tracked_vehicle_simple.sdf
+++ b/test/worlds/tracked_vehicle_simple.sdf
@@ -6,7 +6,7 @@
         -->
         <physics name='4ms' type='ignored'>
             <max_step_size>0.001</max_step_size>
-            <real_time_factor>1.0</real_time_factor>
+            <real_time_factor>0</real_time_factor>
             <real_time_update_rate>1000</real_time_update_rate>
         </physics>
         <plugin name='ignition::gazebo::systems::Physics' filename='ignition-gazebo-physics-system'/>

--- a/test/worlds/triggered_publisher.sdf
+++ b/test/worlds/triggered_publisher.sdf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="triggered_publisher">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/in_0"/>
       <output type="ignition.msgs.Empty" topic="/out_0"/>

--- a/test/worlds/velocity_control.sdf
+++ b/test/worlds/velocity_control.sdf
@@ -14,7 +14,7 @@
 
     <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
       filename="ignition-gazebo-physics-system"

--- a/test/worlds/wind_effects.sdf
+++ b/test/worlds/wind_effects.sdf
@@ -3,6 +3,10 @@
   <world name="wind_demo">
     <gravity>0 0 0</gravity>
 
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Set `real_time_factor` to zero so the test runs as fast as possible.

I tested this locally just with `diff_drive` and it took:

* Before: 19.5 s
* After: 11.6 s

I suspect this may have unintended consequences for some tests relying on timing. Let's see what CI says.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] ~~Updated documentation (as needed)~~
- [x] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
