### PR TITLE
Disable user commands light test on macOS

### DIFF
--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -24,6 +24,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Light.hh"
 #include "ignition/gazebo/components/Link.hh"
@@ -690,7 +691,8 @@ TEST_F(UserCommandsTest, Pose)
 }
 
 /////////////////////////////////////////////////
-TEST_F(UserCommandsTest, Light)
+// https://github.com/ignitionrobotics/ign-gazebo/issues/634
+TEST_F(UserCommandsTest, IGN_UTILS_TEST_DISABLED_ON_MAC(Light))
 {
   // Start server
   ServerConfig serverConfig;


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/634

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The test fails consistently, see its history:

https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo4-homebrew-amd64/102/testReport/(root)/INTEGRATION_user_commands/test_ran/history/

Let's disable it until we have time to look for an actual fix.

## Checklist
- [x] Signed all commits for DCO
- [x] ~~Added~~ **Removed** tests
- [x] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
