### PR TITLE
Skip failing Windows tests

### DIFF
--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -61,7 +61,8 @@ TEST_F(ComponentTest, ComponentCanBeCopiedAfterDefaultCtor)
 }
 
 //////////////////////////////////////////////////
-TEST_F(ComponentTest, DataByMove)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ComponentTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DataByMove))
 {
   auto factory = components::Factory::Instance();
 

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <ignition/msgs/int32.pb.h>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include <memory>
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -254,7 +254,8 @@ TEST_P(EntityComponentManagerFixture, InvalidComponentType)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, RemoveComponent)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(RemoveComponent))
 {
   // Create some entities
   auto eInt = manager.CreateEntity();
@@ -421,7 +422,8 @@ TEST_P(EntityComponentManagerFixture, RemoveAddAdjacent)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EntitiesAndComponents)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EntitiesAndComponents))
 {
   EXPECT_EQ(0u, manager.EntityCount());
 
@@ -493,7 +495,8 @@ TEST_P(EntityComponentManagerFixture, EntitiesAndComponents)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ComponentValues)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ComponentValues))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -659,7 +662,8 @@ TEST_P(EntityComponentManagerFixture, ComponentValues)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, RebuildViews)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(RebuildViews))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -721,7 +725,8 @@ TEST_P(EntityComponentManagerFixture, RebuildViews)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ViewsAddComponents)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ViewsAddComponents))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -785,7 +790,8 @@ TEST_P(EntityComponentManagerFixture, ViewsAddComponents)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ViewsRemoveComponents)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ViewsRemoveComponents))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -853,7 +859,8 @@ TEST_P(EntityComponentManagerFixture, ViewsRemoveComponents)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ViewsAddEntity)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ViewsAddEntity))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -932,7 +939,8 @@ TEST_P(EntityComponentManagerFixture, ViewsAddEntity)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ViewsRemoveEntities)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ViewsRemoveEntities))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -1061,7 +1069,8 @@ TEST_P(EntityComponentManagerFixture, RemoveEntity)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ViewsRemoveEntity)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ViewsRemoveEntity))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -1186,7 +1195,8 @@ int eachCount(EntityCompMgrTest &_manager)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachNewBasic)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachNewBasic))
 {
   // Create entities
   Entity e1 = manager.CreateEntity();
@@ -1208,7 +1218,8 @@ TEST_P(EntityComponentManagerFixture, EachNewBasic)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachNewAfterRemoveComponent)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachNewAfterRemoveComponent))
 {
   // Create entities
   Entity e1 = manager.CreateEntity();
@@ -1225,7 +1236,8 @@ TEST_P(EntityComponentManagerFixture, EachNewAfterRemoveComponent)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachNewRemoveComponentFromRemoveEntity)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachNewRemoveComponentFromRemoveEntity))
 {
   // Create entities
   Entity e1 = manager.CreateEntity();
@@ -1243,7 +1255,8 @@ TEST_P(EntityComponentManagerFixture, EachNewRemoveComponentFromRemoveEntity)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachNewAddComponentToExistingEntity)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachNewAddComponentToExistingEntity))
 {
   // Create entities
   Entity e1 = manager.CreateEntity();
@@ -1269,7 +1282,8 @@ TEST_P(EntityComponentManagerFixture, EachNewAddComponentToExistingEntity)
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachRemoveBasic)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachRemoveBasic))
 {
   // Create an entities
   Entity e1 = manager.CreateEntity();
@@ -1319,7 +1333,8 @@ TEST_P(EntityComponentManagerFixture, EachRemoveAlreadyRemove)
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachRemoveAfterRebuild)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachRemoveAfterRebuild))
 {
   // Test after rebuild
   Entity e1 = manager.CreateEntity();
@@ -1337,7 +1352,8 @@ TEST_P(EntityComponentManagerFixture, EachRemoveAfterRebuild)
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachRemoveAddComponentToRemoveEntity)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachRemoveAddComponentToRemoveEntity))
 {
   Entity e1 = manager.CreateEntity();
   manager.CreateComponent<IntComponent>(e1, IntComponent(123));
@@ -1352,7 +1368,8 @@ TEST_P(EntityComponentManagerFixture, EachRemoveAddComponentToRemoveEntity)
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachRemoveAllRemove)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachRemoveAllRemove))
 {
   // Test when all entities are removed
   Entity e1 = manager.CreateEntity();
@@ -1369,7 +1386,8 @@ TEST_P(EntityComponentManagerFixture, EachRemoveAllRemove)
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachNewEachRemove)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachNewEachRemove))
 {
   // Test EachNew and EachRemove together
   Entity e1 = manager.CreateEntity();
@@ -1397,7 +1415,8 @@ TEST_P(EntityComponentManagerFixture, EachNewEachRemove)
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachGetsNewOldRemove)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachGetsNewOldRemove))
 {
   // Test that an Each call gets new, old, and removed entities
   Entity e1 = manager.CreateEntity();
@@ -1430,7 +1449,8 @@ TEST_P(EntityComponentManagerFixture, EachGetsNewOldRemove)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EntityByComponents)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EntityByComponents))
 {
   // Create some entities
   Entity eInt = manager.CreateEntity();
@@ -1495,7 +1515,8 @@ TEST_P(EntityComponentManagerFixture, EntityByComponents)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EntityGraph)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EntityGraph))
 {
   EXPECT_EQ(0u, manager.EntityCount());
 
@@ -1627,7 +1648,7 @@ TEST_P(EntityComponentManagerFixture, EntityGraph)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, State)
+TEST_P(EntityComponentManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(State))
 {
   // Entities and components
   Entity e1{1};
@@ -1902,7 +1923,8 @@ TEST_P(EntityComponentManagerFixture, State)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, ChangedStateComponents)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ChangedStateComponents))
 {
   // Entity and component
   Entity e1{1};
@@ -2181,7 +2203,8 @@ TEST_P(EntityComponentManagerFixture, Descendants)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, SetChanged)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SetChanged))
 {
   // Create entities
   Entity e1 = manager.CreateEntity();
@@ -2277,7 +2300,9 @@ TEST_P(EntityComponentManagerFixture, SetEntityCreateOffset)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, SerializedStateMapMsgAfterRemoveComponent)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(
+           SerializedStateMapMsgAfterRemoveComponent)
 {
   // Create entity
   Entity e1 = manager.CreateEntity();
@@ -2342,7 +2367,8 @@ TEST_P(EntityComponentManagerFixture, SerializedStateMapMsgAfterRemoveComponent)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, SerializedStateMsgAfterRemoveComponent)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SerializedStateMsgAfterRemoveComponent))
 {
   // Create entity
   Entity e1 = manager.CreateEntity();
@@ -2403,7 +2429,8 @@ TEST_P(EntityComponentManagerFixture, SerializedStateMsgAfterRemoveComponent)
 //////////////////////////////////////////////////
 // Verify SerializedStateMap message with no changed components,
 // but some removed components
-TEST_P(EntityComponentManagerFixture, SerializedStateMapMsgCompsRemovedOnly)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SerializedStateMapMsgCompsRemovedOnly))
 {
   // Create entity
   Entity e1 = manager.CreateEntity();
@@ -2443,7 +2470,8 @@ TEST_P(EntityComponentManagerFixture, SerializedStateMapMsgCompsRemovedOnly)
 //////////////////////////////////////////////////
 // Verify that removed components are correctly filtered when creating a
 // SerializedStateMap message
-TEST_P(EntityComponentManagerFixture, SetRemovedComponentsMsgTypesFilter)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SetRemovedComponentsMsgTypesFilter))
 {
   // Create entity
   Entity e1 = manager.CreateEntity();
@@ -2481,7 +2509,9 @@ TEST_P(EntityComponentManagerFixture, SetRemovedComponentsMsgTypesFilter)
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, RemovedComponentsSyncBetweenServerAndGUI)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(
+           RemovedComponentsSyncBetweenServerAndGUI))
 {
   // Simulate the GUI's ECM
   EntityCompMgrTest guiManager;
@@ -2638,7 +2668,8 @@ TEST_P(EntityComponentManagerFixture, PinnedEntity)
 //////////////////////////////////////////////////
 /// \brief Test using msgs::SerializedStateMap and msgs::SerializedState
 /// to update existing component data between multiple ECMs
-TEST_P(EntityComponentManagerFixture, StateMsgUpdateComponent)
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(StateMsgUpdateComponent))
 {
   // create 2 ECMs: one will be modified directly, and the other should be
   // updated to match the first via msgs::SerializedStateMap

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -21,6 +21,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Rand.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Factory.hh"
 #include "ignition/gazebo/components/Pose.hh"

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -172,7 +172,9 @@ TEST_P(EntityComponentManagerFixture, AdjacentMemorySingleComponentType)
 }
 
 /////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, AdjacentMemoryTwoComponentTypes)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(EntityComponentManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(AdjacentMemoryTwoComponentTypes))
 {
   common::setenv("IGN_DEBUG_COMPONENT_FACTORY", "true");
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2302,7 +2302,7 @@ TEST_P(EntityComponentManagerFixture, SetEntityCreateOffset)
 //////////////////////////////////////////////////
 TEST_P(EntityComponentManagerFixture,
        IGN_UTILS_TEST_DISABLED_ON_WIN32(
-           SerializedStateMapMsgAfterRemoveComponent)
+           SerializedStateMapMsgAfterRemoveComponent))
 {
   // Create entity
   Entity e1 = manager.CreateEntity();

--- a/src/ModelCommandAPI_TEST.cc
+++ b/src/ModelCommandAPI_TEST.cc
@@ -72,7 +72,8 @@ std::string customExecStr(std::string _cmd)
 
 /////////////////////////////////////////////////
 // Test `ign model` command when no Gazebo server is running.
-TEST(ModelCommandAPI, NoServerRunning)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST(ModelCommandAPI, IGN_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
 {
   const std::string cmd = kIgnModelCommand + "--list ";
   const std::string output = customExecStr(cmd);
@@ -85,7 +86,7 @@ TEST(ModelCommandAPI, NoServerRunning)
 
 /////////////////////////////////////////////////
 // Tests `ign model` command.
-TEST(ModelCommandAPI, Commands)
+TEST(ModelCommandAPI, IGN_UTILS_TEST_DISABLED_ON_WIN32(Commands))
 {
   ignition::gazebo::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.

--- a/src/ModelCommandAPI_TEST.cc
+++ b/src/ModelCommandAPI_TEST.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -795,7 +795,9 @@ TEST_F(ElementUpdateFixture, WorldWithModelsExpandedWithOneIncluded)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ElementUpdateFixture, WorldWithModelsUsingRelativeResourceURIs)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ElementUpdateFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldWithModelsUsingRelativeResourceURIs))
 {
   const auto includeUri = std::string("file://") + PROJECT_SOURCE_PATH +
                           "/test/worlds/models/relative_resource_uri";

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -21,6 +21,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/fuel_tools/ClientConfig.hh>
 #include <ignition/fuel_tools/Interface.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Model.hh>
 #include <sdf/Root.hh>
 #include <sdf/sdf.hh>

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -797,7 +797,7 @@ TEST_F(ElementUpdateFixture, WorldWithModelsExpandedWithOneIncluded)
 /////////////////////////////////////////////////
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
 TEST_F(ElementUpdateFixture,
-       IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldWithModelsUsingRelativeResourceURIs))
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldWithModelsUsingRelativeResourceURIs))
 {
   const auto includeUri = std::string("file://") + PROJECT_SOURCE_PATH +
                           "/test/worlds/models/relative_resource_uri";

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -335,7 +335,8 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ServerConfigLogRecordCompress)
+TEST_P(ServerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecordCompress))
 {
   auto logPath = common::joinPaths(
       std::string(PROJECT_BINARY_PATH), "test_log_path");

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -210,7 +210,8 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
+TEST_P(ServerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
 {
   // Start server
   ServerConfig serverConfig;

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -50,7 +50,8 @@ class ServerFixture : public InternalFixture<::testing::TestWithParam<int>>
 };
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, DefaultServerConfig)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultServerConfig))
 {
   ignition::gazebo::ServerConfig serverConfig;
   EXPECT_TRUE(serverConfig.SdfFile().empty());
@@ -158,7 +159,7 @@ TEST_P(ServerFixture, ServerConfigPluginInfo)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ServerConfigRealPlugin)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
 {
   // Start server
   ServerConfig serverConfig;
@@ -209,7 +210,7 @@ TEST_P(ServerFixture, ServerConfigRealPlugin)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ServerConfigSensorPlugin)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
 {
   // Start server
   ServerConfig serverConfig;
@@ -260,7 +261,7 @@ TEST_P(ServerFixture, ServerConfigSensorPlugin)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, SdfServerConfig)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -293,7 +294,7 @@ TEST_P(ServerFixture, SdfServerConfig)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ServerConfigLogRecord)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
 {
   auto logPath = common::joinPaths(
       std::string(PROJECT_BINARY_PATH), "test_log_path");
@@ -483,7 +484,7 @@ TEST_P(ServerFixture, RunNonBlocking)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, RunOnceUnpaused)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOnceUnpaused))
 {
   gazebo::Server server;
   EXPECT_FALSE(server.Running());
@@ -530,7 +531,7 @@ TEST_P(ServerFixture, RunOnceUnpaused)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, RunOncePaused)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOncePaused))
 {
   gazebo::Server server;
   EXPECT_FALSE(server.Running());
@@ -620,7 +621,7 @@ TEST_P(ServerFixture, SigInt)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, AddSystemWhileRunning)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -668,7 +669,7 @@ TEST_P(ServerFixture, AddSystemWhileRunning)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, AddSystemAfterLoad)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -742,7 +743,7 @@ TEST_P(ServerFixture, Seed)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ResourcePath)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 {
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
          (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Rand.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Mesh.hh>
 
 #include "ignition/gazebo/components/AxisAlignedBox.hh"

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1270,7 +1270,8 @@ TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugins))
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerNoPlugins))
+TEST_P(SimulationRunnerTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerNoPlugins))
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1292,7 +1293,8 @@ TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerNoPlugin
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerConfigPlugins))
+TEST_P(SimulationRunnerTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerConfigPlugins))
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1392,7 +1394,8 @@ TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerConfigPl
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsDefault))
+TEST_P(SimulationRunnerTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsDefault))
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1182,7 +1182,8 @@ TEST_P(SimulationRunnerTest, Time)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, LoadPlugins)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugins))
 {
   // Load SDF file
   sdf::Root root;
@@ -1269,7 +1270,7 @@ TEST_P(SimulationRunnerTest, LoadPlugins)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, LoadServerNoPlugins)
+TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerNoPlugins))
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1291,7 +1292,7 @@ TEST_P(SimulationRunnerTest, LoadServerNoPlugins)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, LoadServerConfigPlugins)
+TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerConfigPlugins))
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1391,7 +1392,7 @@ TEST_P(SimulationRunnerTest, LoadServerConfigPlugins)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, LoadPluginsDefault)
+TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsDefault))
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1412,7 +1413,7 @@ TEST_P(SimulationRunnerTest, LoadPluginsDefault)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, LoadPluginsEvent)
+TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsEvent))
 {
   // Load SDF file without plugins
   sdf::Root rootWithout;

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -21,6 +21,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Box.hh>
 #include <sdf/Capsule.hh>
 #include <sdf/Cylinder.hh>

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1183,7 +1183,7 @@ TEST_P(SimulationRunnerTest, Time)
 
 /////////////////////////////////////////////////
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugins))
+TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugins) )
 {
   // Load SDF file
   sdf::Root root;
@@ -1271,7 +1271,7 @@ TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugins))
 
 /////////////////////////////////////////////////
 TEST_P(SimulationRunnerTest,
-       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerNoPlugins))
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerNoPlugins) )
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1294,7 +1294,7 @@ TEST_P(SimulationRunnerTest,
 
 /////////////////////////////////////////////////
 TEST_P(SimulationRunnerTest,
-       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerConfigPlugins))
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadServerConfigPlugins) )
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1395,7 +1395,7 @@ TEST_P(SimulationRunnerTest,
 
 /////////////////////////////////////////////////
 TEST_P(SimulationRunnerTest,
-       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsDefault))
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsDefault) )
 {
   sdf::Root rootWithout;
   rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
@@ -1416,7 +1416,8 @@ TEST_P(SimulationRunnerTest,
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsEvent))
+TEST_P(SimulationRunnerTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPluginsEvent) )
 {
   // Load SDF file without plugins
   sdf::Root rootWithout;

--- a/src/gui/Gui_TEST.cc
+++ b/src/gui/Gui_TEST.cc
@@ -42,7 +42,8 @@ class GuiTest : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // https://github.com/ignitionrobotics/ign-gazebo/issues/8
-TEST_F(GuiTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PathManager))
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(GuiTest, IGN_UTILS_TEST_ENABLE_ONLY_LINUX(PathManager))
 {
   common::Console::SetVerbosity(4);
   igndbg << "Start test" << std::endl;

--- a/src/gui/Gui_TEST.cc
+++ b/src/gui/Gui_TEST.cc
@@ -43,7 +43,7 @@ class GuiTest : public InternalFixture<::testing::Test>
 /////////////////////////////////////////////////
 // https://github.com/ignitionrobotics/ign-gazebo/issues/8
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST_F(GuiTest, IGN_UTILS_TEST_ENABLE_ONLY_LINUX(PathManager))
+TEST_F(GuiTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(PathManager))
 {
   common::Console::SetVerbosity(4);
   igndbg << "Start test" << std::endl;

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -102,7 +102,7 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(CachedFuelWorld))
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, GazeboServer)
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(GazeboServer))
 {
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -55,7 +55,8 @@ std::string customExecStr(std::string _cmd)
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, Server)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(Server))
 {
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";
@@ -87,7 +88,7 @@ TEST(CmdLine, Server)
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, CachedFuelWorld)
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(CachedFuelWorld))
 {
   std::string projectPath = std::string(PROJECT_SOURCE_PATH) + "/test/worlds";
   ignition::common::setenv("IGN_FUEL_CACHE_PATH", projectPath.c_str());
@@ -118,7 +119,7 @@ TEST(CmdLine, GazeboServer)
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, Gazebo)
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(Gazebo))
 {
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";
@@ -135,7 +136,7 @@ TEST(CmdLine, Gazebo)
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, ResourcePath)
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 {
   std::string cmd = kIgnCommand + " -s -r -v 4 --iterations 1 plugins.sdf";
 

--- a/src/systems/physics/EntityFeatureMap_TEST.cc
+++ b/src/systems/physics/EntityFeatureMap_TEST.cc
@@ -93,7 +93,8 @@ class EntityFeatureMapFixture: public InternalFixture<::testing::Test>
 };
 
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST_F(EntityFeatureMapFixture, IGN_UTILS_TEST_ENABLE_ONLY_LINUX(AddCastRemoveEntity))
+TEST_F(EntityFeatureMapFixture,
+       IGN_UTILS_TEST_ENABLE_ONLY_LINUX(AddCastRemoveEntity))
 {
   struct TestOptionalFeatures1
       : physics::FeatureList<physics::LinkFrameSemantics>

--- a/src/systems/physics/EntityFeatureMap_TEST.cc
+++ b/src/systems/physics/EntityFeatureMap_TEST.cc
@@ -94,7 +94,7 @@ class EntityFeatureMapFixture: public InternalFixture<::testing::Test>
 
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
 TEST_F(EntityFeatureMapFixture,
-       IGN_UTILS_TEST_ENABLE_ONLY_LINUX(AddCastRemoveEntity))
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(AddCastRemoveEntity))
 {
   struct TestOptionalFeatures1
       : physics::FeatureList<physics::LinkFrameSemantics>

--- a/src/systems/physics/EntityFeatureMap_TEST.cc
+++ b/src/systems/physics/EntityFeatureMap_TEST.cc
@@ -92,7 +92,8 @@ class EntityFeatureMapFixture: public InternalFixture<::testing::Test>
   public: EnginePtrType engine;
 };
 
-TEST_F(EntityFeatureMapFixture, AddCastRemoveEntity)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(EntityFeatureMapFixture, IGN_UTILS_TEST_ENABLE_ONLY_LINUX(AddCastRemoveEntity))
 {
   struct TestOptionalFeatures1
       : physics::FeatureList<physics::LinkFrameSemantics>

--- a/src/systems/physics/EntityFeatureMap_TEST.cc
+++ b/src/systems/physics/EntityFeatureMap_TEST.cc
@@ -29,6 +29,7 @@
 #include <ignition/physics/RemoveEntities.hh>
 #include <ignition/physics/config.hh>
 #include <ignition/plugin/Loader.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "../../../test/helpers/EnvTestFixture.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"

--- a/test/integration/ackermann_steering_system.cc
+++ b/test/integration/ackermann_steering_system.cc
@@ -193,7 +193,8 @@ class AckermannSteeringTest
 };
 
 /////////////////////////////////////////////////
-TEST_P(AckermannSteeringTest, PublishCmd)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(AckermannSteeringTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
 {
   TestPublishCmd(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
                                    "/test/worlds/ackermann_steering.sdf"),
@@ -201,7 +202,8 @@ TEST_P(AckermannSteeringTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(AckermannSteeringTest, PublishCmdCustomTopics)
+TEST_P(AckermannSteeringTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmdCustomTopics))
 {
   TestPublishCmd(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "/test/worlds/ackermann_steering_custom_topics.sdf"),

--- a/test/integration/ackermann_steering_system.cc
+++ b/test/integration/ackermann_steering_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/ackermann_steering_system.cc
+++ b/test/integration/ackermann_steering_system.cc
@@ -212,7 +212,7 @@ TEST_P(AckermannSteeringTest,
 }
 
 /////////////////////////////////////////////////
-TEST_P(AckermannSteeringTest, SkidPublishCmd)
+TEST_P(AckermannSteeringTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SkidPublishCmd))
 {
   // Start server
   ServerConfig serverConfig;
@@ -310,7 +310,7 @@ TEST_P(AckermannSteeringTest, SkidPublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(AckermannSteeringTest, OdomFrameId)
+TEST_P(AckermannSteeringTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OdomFrameId))
 {
   // Start server
   ServerConfig serverConfig;
@@ -368,7 +368,8 @@ TEST_P(AckermannSteeringTest, OdomFrameId)
 }
 
 /////////////////////////////////////////////////
-TEST_P(AckermannSteeringTest, OdomCustomFrameId)
+TEST_P(AckermannSteeringTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(OdomCustomFrameId))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/air_pressure_system.cc
+++ b/test/integration/air_pressure_system.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/AirPressureSensor.hh"
 #include "ignition/gazebo/components/Name.hh"

--- a/test/integration/air_pressure_system.cc
+++ b/test/integration/air_pressure_system.cc
@@ -41,7 +41,8 @@ class AirPressureTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(AirPressureTest, AirPressure)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(AirPressureTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(AirPressure))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -24,6 +24,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Altimeter.hh"
 #include "ignition/gazebo/components/LinearVelocity.hh"
@@ -59,7 +60,8 @@ void altimeterCb(const msgs::Altimeter &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the world pose and sensor readings of a falling altimeter
-TEST_F(AltimeterTest, ModelFalling)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(AltimeterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFalling))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/apply_joint_force_system.cc
+++ b/test/integration/apply_joint_force_system.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Joint.hh"
 #include "ignition/gazebo/components/Name.hh"
@@ -46,7 +47,9 @@ class ApplyJointForceTestFixture : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Tests that the ApplyJointForce accepts joint velocity commands
-TEST_F(ApplyJointForceTestFixture, JointVelocityCommand)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ApplyJointForceTestFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(JointVelocityCommand))
 {
   using namespace std::chrono_literals;
 

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/common/Filesystem.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include <sdf/Root.hh>
 #include <sdf/World.hh>
@@ -70,8 +71,9 @@ class BatteryPluginTest : public InternalFixture<::testing::Test>
 
 
 /////////////////////////////////////////////////
-// Single model consuming single battery
-TEST_F(BatteryPluginTest, SingleBattery)
+// Single model consuming single batter
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(BatteryPluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SingleBattery))
 {
   const auto sdfPath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "worlds", "battery.sdf");

--- a/test/integration/breadcrumbs.cc
+++ b/test/integration/breadcrumbs.cc
@@ -29,6 +29,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Entity.hh"
 #include "ignition/gazebo/Server.hh"
@@ -75,7 +76,8 @@ void remainingCb(const msgs::Int32 &_msg)
 
 /////////////////////////////////////////////////
 // This test checks the .../deploy/remaining topic
-TEST_F(BreadcrumbsTest, Remaining)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Remaining))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -133,7 +135,7 @@ TEST_F(BreadcrumbsTest, Remaining)
 
 /////////////////////////////////////////////////
 // The test checks breadcrumbs are deployed at the correct pose
-TEST_F(BreadcrumbsTest, DeployAtOffset)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DeployAtOffset))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -198,7 +200,7 @@ TEST_F(BreadcrumbsTest, DeployAtOffset)
 
 /////////////////////////////////////////////////
 // The test checks max deployments
-TEST_F(BreadcrumbsTest, MaxDeployments)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(MaxDeployments))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -254,7 +256,7 @@ TEST_F(BreadcrumbsTest, MaxDeployments)
 /////////////////////////////////////////////////
 // The test checks that including models from fuel works. Also checks custom
 // topic
-TEST_F(BreadcrumbsTest, FuelDeploy)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(FuelDeploy))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -307,7 +309,7 @@ TEST_F(BreadcrumbsTest, FuelDeploy)
 
 /////////////////////////////////////////////////
 // The test checks that breadcrumbs can be performers
-TEST_F(BreadcrumbsTest, Performer)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Performer))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -381,7 +383,7 @@ TEST_F(BreadcrumbsTest, Performer)
 /////////////////////////////////////////////////
 // Test that the volume of the performer is set when deploying a performer
 // breadcrumb
-TEST_F(BreadcrumbsTest, PerformerSetVolume)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PerformerSetVolume))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf", true);
@@ -436,7 +438,7 @@ TEST_F(BreadcrumbsTest, PerformerSetVolume)
 
 /////////////////////////////////////////////////
 // The test verifies breadcrumbs physics is disabled using disable_physics_time
-TEST_F(BreadcrumbsTest, DeployDisablePhysics)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DeployDisablePhysics))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -514,7 +516,7 @@ TEST_F(BreadcrumbsTest, DeployDisablePhysics)
 /////////////////////////////////////////////////
 // The test verifies that if allow_renaming is true, the Breadcrumb system
 // renames spawned models if a model with the same name exists.
-TEST_F(BreadcrumbsTest, AllowRenaming)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(AllowRenaming))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs.sdf");
@@ -568,7 +570,7 @@ std::vector<Entity> ModelsByNameRegex(
 
 // The test checks that models containing Breadcrumbs can be unloaded and loaded
 // safely
-TEST_F(BreadcrumbsTest, LevelLoadUnload)
+TEST_F(BreadcrumbsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelLoadUnload))
 {
   // Start server
   this->LoadWorld("test/worlds/breadcrumbs_levels.sdf", true);

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -19,6 +19,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
@@ -42,7 +43,8 @@ class BuoyancyTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(BuoyancyTest, Movement)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(BuoyancyTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Movement))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/collada_world_exporter.cc
+++ b/test/integration/collada_world_exporter.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Mesh.hh>
 #include <ignition/common/SubMesh.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"
@@ -50,7 +51,9 @@ class ColladaWorldExporterFixture : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(ColladaWorldExporterFixture, ExportWorld)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ColladaWorldExporterFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ExportWorld))
 {
   this->LoadWorld(common::joinPaths("test", "worlds",
         "collada_world_exporter.sdf"));
@@ -71,7 +74,8 @@ TEST_F(ColladaWorldExporterFixture, ExportWorld)
   common::removeAll("./collada_world_exporter_box_test");
 }
 
-TEST_F(ColladaWorldExporterFixture, ExportWorldFromFuelWithSubmesh)
+TEST_F(ColladaWorldExporterFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ExportWorldFromFuelWithSubmesh))
 {
   std::string world_path =
     ignition::common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds");
@@ -108,7 +112,8 @@ TEST_F(ColladaWorldExporterFixture, ExportWorldFromFuelWithSubmesh)
   common::removeAll(outputPath);
 }
 
-TEST_F(ColladaWorldExporterFixture, ExportWorldMadeFromObj)
+TEST_F(ColladaWorldExporterFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ExportWorldMadeFromObj))
 {
   std::string world_path =
     ignition::common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds");
@@ -146,7 +151,8 @@ TEST_F(ColladaWorldExporterFixture, ExportWorldMadeFromObj)
   common::removeAll(outputPath);
 }
 
-TEST_F(ColladaWorldExporterFixture, ExportWorldWithLights)
+TEST_F(ColladaWorldExporterFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ExportWorldWithLights))
 {
   this->LoadWorld(common::joinPaths("test", "worlds",
         "collada_world_exporter_lights.sdf"));

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -24,6 +24,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
@@ -41,7 +42,9 @@ class ContactSystemTest : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // The test checks that contacts are published by the contact system
-TEST_F(ContactSystemTest, MultipleCollisionsAsContactSensors)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ContactSystemTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MultipleCollisionsAsContactSensors))
 {
   // Start server
   ServerConfig serverConfig;
@@ -114,7 +117,8 @@ TEST_F(ContactSystemTest, MultipleCollisionsAsContactSensors)
   }
 }
 
-TEST_F(ContactSystemTest, RemoveContactSensor)
+TEST_F(ContactSystemTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(RemoveContactSensor))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/detachable_joint.cc
+++ b/test/integration/detachable_joint.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/msgs/Utility.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Server.hh"
@@ -57,7 +58,8 @@ class DetachableJointTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(DetachableJointTest, StartConnected)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(DetachableJointTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(StartConnected))
 {
   using namespace std::chrono_literals;
 
@@ -135,7 +137,7 @@ TEST_F(DetachableJointTest, StartConnected)
 }
 
 /////////////////////////////////////////////////
-TEST_F(DetachableJointTest, LinksInSameModel)
+TEST_F(DetachableJointTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LinksInSameModel))
 {
   using namespace std::chrono_literals;
 

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"
@@ -210,7 +211,8 @@ class DiffDriveTest : public InternalFixture<::testing::TestWithParam<int>>
 };
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, PublishCmd)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/diff_drive.sdf",
@@ -218,7 +220,7 @@ TEST_P(DiffDriveTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, PublishCmdCustomTopics)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmdCustomTopics))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) +
@@ -227,7 +229,7 @@ TEST_P(DiffDriveTest, PublishCmdCustomTopics)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, SkidPublishCmd)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SkidPublishCmd))
 {
   // Start server
   ServerConfig serverConfig;
@@ -329,7 +331,7 @@ TEST_P(DiffDriveTest, SkidPublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, EnableDisableCmd)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(EnableDisableCmd))
 {
   // Start server
   ServerConfig serverConfig;
@@ -453,7 +455,7 @@ TEST_P(DiffDriveTest, EnableDisableCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, OdomFrameId)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OdomFrameId))
 {
   // Start server
   ServerConfig serverConfig;
@@ -511,7 +513,7 @@ TEST_P(DiffDriveTest, OdomFrameId)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, OdomCustomFrameId)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OdomCustomFrameId))
 {
   // Start server
   ServerConfig serverConfig;
@@ -568,7 +570,7 @@ TEST_P(DiffDriveTest, OdomCustomFrameId)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, Pose_VFrameId)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Pose_VFrameId))
 {
   // Start server
   ServerConfig serverConfig;
@@ -628,7 +630,7 @@ TEST_P(DiffDriveTest, Pose_VFrameId)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, Pose_VCustomFrameId)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomFrameId))
 {
   // Start server
   ServerConfig serverConfig;
@@ -688,7 +690,7 @@ TEST_P(DiffDriveTest, Pose_VCustomFrameId)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, Pose_VCustomTfTopic)
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomTfTopic))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/each_new_removed.cc
+++ b/test/integration/each_new_removed.cc
@@ -44,7 +44,9 @@ class EachNewRemovedFixture : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(EachNewRemovedFixture, EachNewEachRemovedInSystem)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(EachNewRemovedFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EachNewEachRemovedInSystem))
 {
   ignition::gazebo::ServerConfig serverConfig;
 

--- a/test/integration/each_new_removed.cc
+++ b/test/integration/each_new_removed.cc
@@ -22,6 +22,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/World.hh>
 
 #include "ignition/gazebo/components/Factory.hh"

--- a/test/integration/entity_erase.cc
+++ b/test/integration/entity_erase.cc
@@ -33,7 +33,8 @@ class PhysicsSystemFixture : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(CreatePhysicsWorld))
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(CreatePhysicsWorld))
 {
   ignition::gazebo::ServerConfig serverConfig;
 

--- a/test/integration/entity_erase.cc
+++ b/test/integration/entity_erase.cc
@@ -32,7 +32,8 @@ class PhysicsSystemFixture : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, CreatePhysicsWorld)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(CreatePhysicsWorld))
 {
   ignition::gazebo::ServerConfig serverConfig;
 

--- a/test/integration/entity_erase.cc
+++ b/test/integration/entity_erase.cc
@@ -19,6 +19,8 @@
 
 #include <optional>
 
+#include <ignition/utilities/ExtraTestMacros.hh>
+
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
 #include "../helpers/EnvTestFixture.hh"

--- a/test/integration/events.cc
+++ b/test/integration/events.cc
@@ -34,7 +34,8 @@ class EventTrigger : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(EventTrigger, TriggerPause)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(EventTrigger, IGN_UTILS_TEST_DISABLED_ON_WIN32(TriggerPause))
 {
   // Create server
   ServerConfig config;

--- a/test/integration/events.cc
+++ b/test/integration/events.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/examples_build.cc
+++ b/test/integration/examples_build.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/math/SemanticVersion.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/test_config.hh"
 #include "../helpers/EnvTestFixture.hh"

--- a/test/integration/examples_build.cc
+++ b/test/integration/examples_build.cc
@@ -179,7 +179,8 @@ void ExamplesBuild::Build(const std::string &_type)
 }
 
 //////////////////////////////////////////////////
-TEST_P(ExamplesBuild, Build)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(ExamplesBuild, IGN_UTILS_TEST_DISABLED_ON_WIN32(Build))
 {
   Build(GetParam());
 }

--- a/test/integration/follow_actor_system.cc
+++ b/test/integration/follow_actor_system.cc
@@ -84,7 +84,8 @@ class Relay
 
 
 /////////////////////////////////////////////////
-TEST_P(FollowActorTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PublishCmd))
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(FollowActorTest, IGN_UTILS_TEST_ENABLE_ONLY_LINUX(PublishCmd))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/follow_actor_system.cc
+++ b/test/integration/follow_actor_system.cc
@@ -85,7 +85,8 @@ class Relay
 
 /////////////////////////////////////////////////
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST_P(FollowActorTest, IGN_UTILS_TEST_ENABLE_ONLY_LINUX(PublishCmd))
+TEST_P(FollowActorTest,
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(PublishCmd))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/halt_motion.cc
+++ b/test/integration/halt_motion.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/halt_motion.cc
+++ b/test/integration/halt_motion.cc
@@ -147,7 +147,8 @@ class HaltMotionTest : public InternalFixture<::testing::TestWithParam<int>>
 };
 
 /////////////////////////////////////////////////
-TEST_P(HaltMotionTest, PublishCmd)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(HaltMotionTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/diff_drive.sdf",

--- a/test/integration/imu_system.cc
+++ b/test/integration/imu_system.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
 #include "ignition/gazebo/components/Gravity.hh"

--- a/test/integration/imu_system.cc
+++ b/test/integration/imu_system.cc
@@ -62,7 +62,8 @@ void imuCb(const msgs::IMU &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the world pose and sensor readings of a falling imu
-TEST_F(ImuTest, ModelFalling)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ImuTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFalling))
 {
   double z = 3;
   // TODO(anyone): get step size from sdf
@@ -209,7 +210,7 @@ TEST_F(ImuTest, ModelFalling)
 
 /////////////////////////////////////////////////
 // The test checks to make sure orientation is not published if it is deabled
-TEST_F(ImuTest, OrientationDisabled)
+TEST_F(ImuTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OrientationDisabled))
 {
   imuMsgs.clear();
 

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -46,7 +46,9 @@ class JointControllerTestFixture : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Tests that the JointController accepts joint velocity commands
-TEST_F(JointControllerTestFixture, JointVelocityCommand)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(JointControllerTestFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(JointVelocityCommand))
 {
   using namespace std::chrono_literals;
 
@@ -143,7 +145,8 @@ TEST_F(JointControllerTestFixture, JointVelocityCommand)
 
 /////////////////////////////////////////////////
 // Tests the JointController using joint force commands
-TEST_F(JointControllerTestFixture, JointVelocityCommandWithForce)
+TEST_F(JointControllerTestFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(JointVelocityCommandWithForce))
 {
   using namespace std::chrono_literals;
 

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
 #include "ignition/gazebo/components/Link.hh"

--- a/test/integration/joint_position_controller_system.cc
+++ b/test/integration/joint_position_controller_system.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Joint.hh"
 #include "ignition/gazebo/components/JointPosition.hh"

--- a/test/integration/joint_position_controller_system.cc
+++ b/test/integration/joint_position_controller_system.cc
@@ -47,7 +47,9 @@ class JointPositionControllerTestFixture
 
 /////////////////////////////////////////////////
 // Tests that the JointPositionController accepts joint position commands
-TEST_F(JointPositionControllerTestFixture, JointPositionCommand)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(JointPositionControllerTestFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(JointPositionCommand))
 {
   using namespace std::chrono_literals;
 

--- a/test/integration/joint_state_publisher_system.cc
+++ b/test/integration/joint_state_publisher_system.cc
@@ -35,7 +35,9 @@ class JointStatePublisherTest
 };
 
 /////////////////////////////////////////////////
-TEST_F(JointStatePublisherTest, DefaultPublisher)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(JointStatePublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultPublisher))
 {
   // Start server
   ServerConfig serverConfig;
@@ -86,7 +88,8 @@ TEST_F(JointStatePublisherTest, DefaultPublisher)
 }
 
 /////////////////////////////////////////////////
-TEST_F(JointStatePublisherTest, LimitedPublisher)
+TEST_F(JointStatePublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LimitedPublisher))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/joint_state_publisher_system.cc
+++ b/test/integration/joint_state_publisher_system.cc
@@ -19,6 +19,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"

--- a/test/integration/joint_trajectory_controller_system.cc
+++ b/test/integration/joint_trajectory_controller_system.cc
@@ -25,6 +25,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Joint.hh"
 #include "ignition/gazebo/components/JointPosition.hh"

--- a/test/integration/joint_trajectory_controller_system.cc
+++ b/test/integration/joint_trajectory_controller_system.cc
@@ -52,8 +52,9 @@ class JointTrajectoryControllerTestFixture
 /////////////////////////////////////////////////
 // Tests that JointTrajectoryController accepts position-controlled joint
 // trajectory
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
 TEST_F(JointTrajectoryControllerTestFixture,
-       JointTrajectoryControllerPositionControl)
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(JointTrajectoryControllerPositionControl))
 {
   using namespace std::chrono_literals;
 
@@ -229,7 +230,7 @@ TEST_F(JointTrajectoryControllerTestFixture,
 // Tests that JointTrajectoryController accepts velocity-controlled joint
 // trajectory
 TEST_F(JointTrajectoryControllerTestFixture,
-       JointTrajectoryControllerVelocityControl)
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(JointTrajectoryControllerVelocityControl))
 {
   using namespace std::chrono_literals;
 

--- a/test/integration/kinetic_energy_monitor_system.cc
+++ b/test/integration/kinetic_energy_monitor_system.cc
@@ -24,6 +24,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/kinetic_energy_monitor_system.cc
+++ b/test/integration/kinetic_energy_monitor_system.cc
@@ -51,7 +51,8 @@ void cb(const msgs::Double &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the world pose and sensor readings of a falling altimeter
-TEST_F(KineticEnergyMonitorTest, ModelFalling)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(KineticEnergyMonitorTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFalling))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -178,7 +178,8 @@ class LevelManagerFixture : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 /// Check default level includes entities not included by other levels
-TEST_F(LevelManagerFixture, DefaultLevel)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultLevel))
 {
   std::vector<std::set<std::string>> levelEntityNamesList;
 
@@ -224,7 +225,7 @@ TEST_F(LevelManagerFixture, DefaultLevel)
 ///////////////////////////////////////////////
 /// Check a level is loaded when a performer is inside a level
 /// Check a level is unloaded when a performer is outside a level
-TEST_F(LevelManagerFixture, LevelLoadUnload)
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelLoadUnload))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   this->server->AddSystem(perf1.systemPtr);
@@ -274,7 +275,7 @@ TEST_F(LevelManagerFixture, LevelLoadUnload)
 
 ///////////////////////////////////////////////
 /// Check behaviour of level buffers
-TEST_F(LevelManagerFixture, LevelBuffers)
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelBuffers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   this->server->AddSystem(perf1.systemPtr);
@@ -312,7 +313,8 @@ TEST_F(LevelManagerFixture, LevelBuffers)
 
 ///////////////////////////////////////////////
 /// Check that multiple performers can load/unload multiple levels independently
-TEST_F(LevelManagerFixture, LevelsWithMultiplePerformers)
+TEST_F(LevelManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelsWithMultiplePerformers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   ModelMover perf2(*this->server->EntityByName("box"));
@@ -429,7 +431,8 @@ TEST_F(LevelManagerFixture, LevelsWithMultiplePerformers)
 
 ///////////////////////////////////////////////
 /// Check that buffers work properly with multiple performers
-TEST_F(LevelManagerFixture, LevelBuffersWithMultiplePerformers)
+TEST_F(LevelManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelBuffersWithMultiplePerformers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   ModelMover perf2(*this->server->EntityByName("box"));

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -23,6 +23,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Joint.hh>

--- a/test/integration/level_manager_runtime_performers.cc
+++ b/test/integration/level_manager_runtime_performers.cc
@@ -26,6 +26,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/level_manager_runtime_performers.cc
+++ b/test/integration/level_manager_runtime_performers.cc
@@ -206,7 +206,8 @@ class LevelManagerFixture : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 /// Check default level includes entities not included by other levels
-TEST_F(LevelManagerFixture, DefaultLevel)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultLevel))
 {
   std::vector<std::set<std::string>> levelEntityNamesList;
 
@@ -252,7 +253,7 @@ TEST_F(LevelManagerFixture, DefaultLevel)
 ///////////////////////////////////////////////
 /// Check a level is loaded when a performer is inside a level
 /// Check a level is unloaded when a performer is outside a level
-TEST_F(LevelManagerFixture, LevelLoadUnload)
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelLoadUnload))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   this->server->AddSystem(perf1.systemPtr);
@@ -302,7 +303,7 @@ TEST_F(LevelManagerFixture, LevelLoadUnload)
 
 ///////////////////////////////////////////////
 /// Check behaviour of level buffers
-TEST_F(LevelManagerFixture, LevelBuffers)
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelBuffers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   this->server->AddSystem(perf1.systemPtr);
@@ -340,7 +341,8 @@ TEST_F(LevelManagerFixture, LevelBuffers)
 
 ///////////////////////////////////////////////
 /// Check that multiple performers can load/unload multiple levels independently
-TEST_F(LevelManagerFixture, LevelsWithMultiplePerformers)
+TEST_F(LevelManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelsWithMultiplePerformers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   ModelMover perf2(*this->server->EntityByName("box"));
@@ -457,7 +459,8 @@ TEST_F(LevelManagerFixture, LevelsWithMultiplePerformers)
 
 ///////////////////////////////////////////////
 /// Check that buffers work properly with multiple performers
-TEST_F(LevelManagerFixture, LevelBuffersWithMultiplePerformers)
+TEST_F(LevelManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelBuffersWithMultiplePerformers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   ModelMover perf2(*this->server->EntityByName("box"));

--- a/test/integration/lift_drag_system.cc
+++ b/test/integration/lift_drag_system.cc
@@ -24,6 +24,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
 #include "ignition/gazebo/components/Joint.hh"

--- a/test/integration/lift_drag_system.cc
+++ b/test/integration/lift_drag_system.cc
@@ -69,7 +69,9 @@ class VerticalForceParamFixture
 
 /////////////////////////////////////////////////
 /// Measure / verify force torques against analytical answers.
-TEST_P(VerticalForceParamFixture, VerifyVerticalForce)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(VerticalForceParamFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(VerifyVerticalForce))
 {
   using namespace std::chrono_literals;
   ignition::common::setenv(

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -262,7 +262,8 @@ class LogSystemTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogPlaybackStatistics)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogPlaybackStatistics))
 {
   auto logPath = common::joinPaths(PROJECT_SOURCE_PATH, "test", "media",
       "rolling_shapes_log");
@@ -313,7 +314,7 @@ TEST_F(LogSystemTest, LogPlaybackStatistics)
 
 /////////////////////////////////////////////////
 // Logging behavior when no paths are specified
-TEST_F(LogSystemTest, LogDefaults)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogDefaults))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -417,7 +418,7 @@ TEST_F(LogSystemTest, LogDefaults)
 /////////////////////////////////////////////////
 // Logging behavior when a path is specified either via the C++ API, SDF, or
 // the command line.
-TEST_F(LogSystemTest, LogPaths)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogPaths))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -686,7 +687,7 @@ TEST_F(LogSystemTest, LogPaths)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, RecordAndPlayback)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RecordAndPlayback))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -908,7 +909,7 @@ TEST_F(LogSystemTest, RecordAndPlayback)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogControl)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogControl))
 {
   auto logPath = common::joinPaths(PROJECT_SOURCE_PATH, "test", "media",
       "rolling_shapes_log");
@@ -1022,7 +1023,7 @@ TEST_F(LogSystemTest, LogControl)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogOverwrite)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogOverwrite))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -1171,7 +1172,7 @@ TEST_F(LogSystemTest, LogOverwrite)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogControlLevels)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogControlLevels))
 {
   auto logPath = common::joinPaths(PROJECT_SOURCE_PATH, "test", "media",
       "levels_log");
@@ -1310,7 +1311,7 @@ TEST_F(LogSystemTest, LogControlLevels)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogCompress)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogCompress))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -1416,7 +1417,7 @@ TEST_F(LogSystemTest, LogCompress)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogCompressOverwrite)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogCompressOverwrite))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -1462,7 +1463,7 @@ TEST_F(LogSystemTest, LogCompressOverwrite)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogCompressCmdLine)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogCompressCmdLine))
 {
 #ifndef __APPLE__
   // Create temp directory to store log
@@ -1542,7 +1543,7 @@ TEST_F(LogSystemTest, LogCompressCmdLine)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogResources)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogResources))
 {
   // Create temp directory to store log
   this->CreateLogsDir();
@@ -1629,7 +1630,7 @@ TEST_F(LogSystemTest, LogResources)
 }
 
 /////////////////////////////////////////////////
-TEST_F(LogSystemTest, LogTopics)
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogTopics))
 {
   // Create temp directory to store log
   this->CreateLogsDir();

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -37,6 +37,7 @@
 #include <ignition/transport/log/Playback.hh>
 #include <ignition/transport/log/QualifiedTime.hh>
 #include <ignition/math/Pose3.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include <sdf/Root.hh>
 #include <sdf/World.hh>

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -207,7 +207,7 @@ TEST_F(LogicalAudioTest,
       "world/logical_audio_sensor/model/source_model/sensor/source_1");
 }
 
-TEST_F(LogicalAudioTest, LogicalAudioServices)
+TEST_F(LogicalAudioTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogicalAudioServices))
 {
   ServerConfig serverConfig;
   const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -28,6 +28,7 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/LogicalAudio.hh"
 #include "ignition/gazebo/components/Pose.hh"

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -49,7 +49,9 @@ class LogicalAudioTest : public InternalFixture<::testing::Test>
 {
 };
 
-TEST_F(LogicalAudioTest, LogicalAudioDetections)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(LogicalAudioTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LogicalAudioDetections))
 {
   ServerConfig serverConfig;
   const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/logical_camera_system.cc
+++ b/test/integration/logical_camera_system.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/LogicalCamera.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/logical_camera_system.cc
+++ b/test/integration/logical_camera_system.cc
@@ -66,7 +66,8 @@ void logicalCamera2Cb(const msgs::LogicalCameraImage &_msg)
 /////////////////////////////////////////////////
 // This test checks that both logical cameras in the world can see a box
 // at the correct relative pose.
-TEST_F(LogicalCameraTest, LogicalCameraBox)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(LogicalCameraTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogicalCameraBox))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/magnetometer_system.cc
+++ b/test/integration/magnetometer_system.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/MagneticField.hh"
 #include "ignition/gazebo/components/Magnetometer.hh"

--- a/test/integration/magnetometer_system.cc
+++ b/test/integration/magnetometer_system.cc
@@ -60,7 +60,8 @@ void magnetometerCb(const msgs::Magnetometer &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the detected field from a rotated magnetometer
-TEST_F(MagnetometerTest, RotatedMagnetometer)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(MagnetometerTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RotatedMagnetometer))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/multicopter.cc
+++ b/test/integration/multicopter.cc
@@ -66,7 +66,8 @@ class MulticopterTest : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Test that commanded motor speed is applied
-TEST_F(MulticopterTest, CommandedMotorSpeed)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(MulticopterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(CommandedMotorSpeed))
 {
   // Start server
   auto server = this->StartServer("/test/worlds/quadcopter.sdf");
@@ -132,7 +133,8 @@ TEST_F(MulticopterTest, CommandedMotorSpeed)
 }
 
 /////////////////////////////////////////////////
-TEST_F(MulticopterTest, MulticopterVelocityControl)
+TEST_F(MulticopterTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MulticopterVelocityControl))
 {
   // Start server
   auto server =
@@ -240,7 +242,8 @@ TEST_F(MulticopterTest, MulticopterVelocityControl)
 /////////////////////////////////////////////////
 // Test the interactions between MulticopterVelocityControl and
 // MulticopterMotorModel
-TEST_F(MulticopterTest, ModelAndVelocityControlInteraction)
+TEST_F(MulticopterTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelAndVelocityControlInteraction))
 {
   // Start server
   auto server =

--- a/test/integration/multicopter.cc
+++ b/test/integration/multicopter.cc
@@ -25,6 +25,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
 #include "ignition/gazebo/components/Joint.hh"

--- a/test/integration/nested_model_physics.cc
+++ b/test/integration/nested_model_physics.cc
@@ -41,7 +41,8 @@ class NestedModelPhysicsTest : public InternalFixture<::testing::Test>
 /////////////////////////////////////////////////
 /// Test that a tower of 3 boxes built with an <include> and further nesting
 /// moves appropriately with joints in dartsim
-TEST_F(NestedModelPhysicsTest, Movement)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(NestedModelPhysicsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Movement))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/nested_model_physics.cc
+++ b/test/integration/nested_model_physics.cc
@@ -18,6 +18,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/math/Pose3.hh"
 #include "ignition/gazebo/Server.hh"

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -19,6 +19,8 @@
 #include <chrono>
 #include <condition_variable>
 
+#include <ignition/utilities/ExtraTestMacros.hh>
+
 #include "ignition/msgs/world_control.pb.h"
 #include "ignition/msgs/world_stats.pb.h"
 #include "ignition/transport/Node.hh"

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -66,7 +66,8 @@ class NetworkHandshake : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(NetworkHandshake, Handshake)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(NetworkHandshake, IGN_UTILS_TEST_DISABLED_ON_WIN32(Handshake))
 {
   ServerConfig serverConfig;
   serverConfig.SetSdfString(TestWorldSansPhysics::World());
@@ -122,7 +123,7 @@ TEST_F(NetworkHandshake, Handshake)
 }
 
 /////////////////////////////////////////////////
-TEST_F(NetworkHandshake, Updates)
+TEST_F(NetworkHandshake, IGN_UTILS_TEST_DISABLED_ON_WIN32(Updates))
 {
   auto pluginElem = std::make_shared<sdf::Element>();
   pluginElem->SetName("plugin");

--- a/test/integration/odometry_publisher.cc
+++ b/test/integration/odometry_publisher.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/AngularVelocity.hh"
 #include "ignition/gazebo/components/AngularVelocityCmd.hh"

--- a/test/integration/odometry_publisher.cc
+++ b/test/integration/odometry_publisher.cc
@@ -416,7 +416,7 @@ TEST_P(OdometryPublisherTest,
 }
 
 /////////////////////////////////////////////////
-TEST_P(OdometryPublisherTest, Movement3d)
+TEST_P(OdometryPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Movement3d))
 {
   TestMovement3d(
       ignition::common::joinPaths(PROJECT_SOURCE_PATH,

--- a/test/integration/odometry_publisher.cc
+++ b/test/integration/odometry_publisher.cc
@@ -396,7 +396,8 @@ class OdometryPublisherTest
 };
 
 /////////////////////////////////////////////////
-TEST_P(OdometryPublisherTest, Movement)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(OdometryPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Movement))
 {
   TestMovement(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/odometry_publisher.sdf",
@@ -404,7 +405,8 @@ TEST_P(OdometryPublisherTest, Movement)
 }
 
 /////////////////////////////////////////////////
-TEST_P(OdometryPublisherTest, MovementCustomTopic)
+TEST_P(OdometryPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MovementCustomTopic))
 {
   TestMovement(
       std::string(PROJECT_SOURCE_PATH) +
@@ -422,7 +424,7 @@ TEST_P(OdometryPublisherTest, Movement3d)
 }
 
 /////////////////////////////////////////////////
-TEST_P(OdometryPublisherTest, OdomFrameId)
+TEST_P(OdometryPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OdomFrameId))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/odometry_publisher.sdf",
@@ -432,7 +434,8 @@ TEST_P(OdometryPublisherTest, OdomFrameId)
 }
 
 /////////////////////////////////////////////////
-TEST_P(OdometryPublisherTest, OdomCustomFrameId)
+TEST_P(OdometryPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(OdomCustomFrameId))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/particle_emitter.cc
+++ b/test/integration/particle_emitter.cc
@@ -59,7 +59,8 @@ class ParticleEmitterTest : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Load an SDF with a particle emitter and verify its properties.
-TEST_F(ParticleEmitterTest, SDFLoad)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ParticleEmitterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDFLoad))
 {
   bool updateCustomChecked{false};
   bool updateDefaultChecked{false};

--- a/test/integration/particle_emitter.cc
+++ b/test/integration/particle_emitter.cc
@@ -23,6 +23,7 @@
 
 #include <ignition/math/Color.hh>
 #include <ignition/msgs/Utility.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Entity.hh"
 #include "ignition/gazebo/Server.hh"

--- a/test/integration/particle_emitter2.cc
+++ b/test/integration/particle_emitter2.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Color.hh>
 #include <ignition/msgs/Utility.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Entity.hh"
 #include "ignition/gazebo/Server.hh"

--- a/test/integration/particle_emitter2.cc
+++ b/test/integration/particle_emitter2.cc
@@ -58,7 +58,8 @@ class ParticleEmitter2Test : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Load an SDF with a particle emitter and verify its properties.
-TEST_F(ParticleEmitter2Test, SDFLoad)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ParticleEmitter2Test, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDFLoad))
 {
   bool updateCustomChecked{false};
   bool updateDefaultChecked{false};

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -60,7 +60,8 @@ class PerformerDetectorTest : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Test that commanded motor speed is applied
-TEST_F(PerformerDetectorTest, MovingPerformer)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(PerformerDetectorTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(MovingPerformer))
 {
   auto server = this->StartServer("/test/worlds/performer_detector.sdf");
 
@@ -191,7 +192,8 @@ TEST_F(PerformerDetectorTest, MovingPerformer)
 /////////////////////////////////////////////////
 // Test that Performer detector handles the case where the associated model is
 // removed, for example, by the level manager
-TEST_F(PerformerDetectorTest, HandlesRemovedParentModel)
+TEST_F(PerformerDetectorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(HandlesRemovedParentModel))
 {
   auto server = this->StartServer("/test/worlds/performer_detector.sdf", true);
 

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -19,6 +19,7 @@
 #include <ignition/msgs/pose.pb.h>
 
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -114,8 +114,9 @@ TEST_F(PhysicsSystemFixture, CreatePhysicsWorld)
   // TODO(addisu) add useful EXPECT calls
 }
 
-/////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, FallingObject)
+////////////////////////////////////////////////
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(FallingObject))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -184,7 +185,7 @@ TEST_F(PhysicsSystemFixture, FallingObject)
 // This tests whether links with fixed joints keep their relative transforms
 // after physics. For that to work properly, the canonical link implementation
 // must be correct.
-TEST_F(PhysicsSystemFixture, CanonicalLink)
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(CanonicalLink))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -255,7 +256,8 @@ TEST_F(PhysicsSystemFixture, CanonicalLink)
 
 /////////////////////////////////////////////////
 // Same as the CanonicalLink test, but with a non-default canonical link
-TEST_F(PhysicsSystemFixture, NonDefaultCanonicalLink)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(NonDefaultCanonicalLink))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -310,7 +312,7 @@ TEST_F(PhysicsSystemFixture, NonDefaultCanonicalLink)
 
 /////////////////////////////////////////////////
 // Test physics integration with revolute joints
-TEST_F(PhysicsSystemFixture, RevoluteJoint)
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RevoluteJoint))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -389,7 +391,7 @@ TEST_F(PhysicsSystemFixture, RevoluteJoint)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, CreateRuntime)
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(CreateRuntime))
 {
   ignition::gazebo::ServerConfig serverConfig;
   gazebo::Server server(serverConfig);
@@ -472,7 +474,8 @@ TEST_F(PhysicsSystemFixture, CreateRuntime)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, SetFrictionCoefficient)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SetFrictionCoefficient))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -557,7 +560,8 @@ TEST_F(PhysicsSystemFixture, SetFrictionCoefficient)
 
 /////////////////////////////////////////////////
 /// Test that joint position reported by the physics system include all axes
-TEST_F(PhysicsSystemFixture, MultiAxisJointPosition)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MultiAxisJointPosition))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -636,7 +640,8 @@ TEST_F(PhysicsSystemFixture, MultiAxisJointPosition)
 
 /////////////////////////////////////////////////
 /// Test joint position reset component
-TEST_F(PhysicsSystemFixture, ResetPositionComponent)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ResetPositionComponent))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -735,7 +740,8 @@ TEST_F(PhysicsSystemFixture, ResetPositionComponent)
 
 /////////////////////////////////////////////////
 /// Test joint veocity reset component
-TEST_F(PhysicsSystemFixture, ResetVelocityComponent)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ResetVelocityComponent))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -1207,7 +1213,7 @@ TEST_F(PhysicsSystemFixtureWithDart6_10, JointEffortLimitsCommandComponent)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, GetBoundingBox)
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(GetBoundingBox))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -1278,7 +1284,7 @@ TEST_F(PhysicsSystemFixture, GetBoundingBox)
 
 /////////////////////////////////////////////////
 // This tests whether nested models can be loaded correctly
-TEST_F(PhysicsSystemFixture, NestedModel)
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(NestedModel))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -1383,7 +1389,8 @@ TEST_F(PhysicsSystemFixture, NestedModel)
 }
 
 // This tests whether nested models can be loaded correctly
-TEST_F(PhysicsSystemFixture, IncludeNestedModelDartsim)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(IncludeNestedModelDartsim))
 {
   std::string path = std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models";
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", path.c_str());
@@ -1525,7 +1532,8 @@ TEST_F(PhysicsSystemFixture, IncludeNestedModelDartsim)
 }
 
 // This tests whether nested models can be loaded correctly
-TEST_F(PhysicsSystemFixture, IncludeNestedModelTPE)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(IncludeNestedModelTPE))
 {
   std::string path = std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models";
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", path.c_str());
@@ -1667,7 +1675,8 @@ TEST_F(PhysicsSystemFixture, IncludeNestedModelTPE)
 }
 
 // This tests whether the poses of nested models are updated correctly
-TEST_F(PhysicsSystemFixture, NestedModelIndividualCanonicalLinks)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(NestedModelIndividualCanonicalLinks))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -1768,7 +1777,8 @@ TEST_F(PhysicsSystemFixture, NestedModelIndividualCanonicalLinks)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, DefaultPhysicsOptions)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultPhysicsOptions))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -1854,7 +1864,8 @@ TEST_F(PhysicsSystemFixture, PhysicsOptions)
 /////////////////////////////////////////////////
 // This tests whether pose updates are correct for a model whose canonical link
 // changes, but other links do not
-TEST_F(PhysicsSystemFixture, MovingCanonicalLinkOnly)
+TEST_F(PhysicsSystemFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MovingCanonicalLinkOnly))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
@@ -1981,7 +1992,7 @@ TEST_F(PhysicsSystemFixture, MovingCanonicalLinkOnly)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PhysicsSystemFixture, Heightmap)
+TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
 {
   ignition::gazebo::ServerConfig serverConfig;
 

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -26,6 +26,7 @@
 #endif
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Collision.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Geometry.hh>

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -98,7 +98,8 @@ std::string addDelimiter(const std::vector<std::string> &_name,
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, PublishCmd)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(PosePublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
 {
   // Start server
   ServerConfig serverConfig;
@@ -320,7 +321,7 @@ TEST_F(PosePublisherTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, UpdateFrequency)
+TEST_F(PosePublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateFrequency))
 {
   // Start server
   ServerConfig serverConfig;
@@ -385,7 +386,7 @@ TEST_F(PosePublisherTest, UpdateFrequency)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, StaticPosePublisher)
+TEST_F(PosePublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(StaticPosePublisher))
 {
   // Start server
   ServerConfig serverConfig;
@@ -641,7 +642,8 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, StaticPoseUpdateFrequency)
+TEST_F(PosePublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(StaticPoseUpdateFrequency))
 {
   // Start server
   ServerConfig serverConfig;
@@ -708,7 +710,8 @@ TEST_F(PosePublisherTest, StaticPoseUpdateFrequency)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, NestedModelLoadPlugin)
+TEST_F(PosePublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(NestedModelLoadPlugin))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -76,7 +76,9 @@ class SdfGeneratorFixture : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(SdfGeneratorFixture, WorldWithModelsSpawnedAfterLoad)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(SdfGeneratorFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldWithModelsSpawnedAfterLoad))
 {
   this->LoadWorld("test/worlds/save_world.sdf");
 
@@ -204,7 +206,7 @@ TEST_F(SdfGeneratorFixture, WorldWithModelsSpawnedAfterLoad)
 /////////////////////////////////////////////////
 // Test segfaults on Mac at startup, possible collision with test above?
 TEST_F(SdfGeneratorFixture,
-    IGN_UTILS_TEST_DISABLED_ON_MAC(ModelSpawnedWithNewName))
+    IGN_UTILS_TEST_ENABLE_ONLY_LINUX(ModelSpawnedWithNewName))
 {
   this->LoadWorld("test/worlds/save_world.sdf");
 

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -206,7 +206,7 @@ TEST_F(SdfGeneratorFixture,
 /////////////////////////////////////////////////
 // Test segfaults on Mac at startup, possible collision with test above?
 TEST_F(SdfGeneratorFixture,
-    IGN_UTILS_TEST_ENABLE_ONLY_LINUX(ModelSpawnedWithNewName))
+    IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelSpawnedWithNewName))
 {
   this->LoadWorld("test/worlds/save_world.sdf");
 

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -38,7 +38,8 @@ class SceneBroadcasterTest
 };
 
 /////////////////////////////////////////////////
-TEST_P(SceneBroadcasterTest, PoseInfo)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PoseInfo))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -88,7 +89,7 @@ TEST_P(SceneBroadcasterTest, PoseInfo)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneBroadcasterTest, SceneInfo)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneInfo))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -134,7 +135,7 @@ TEST_P(SceneBroadcasterTest, SceneInfo)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneBroadcasterTest, SceneGraph)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneGraph))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -174,7 +175,7 @@ TEST_P(SceneBroadcasterTest, SceneGraph)
 
 /////////////////////////////////////////////////
 /// Test whether the scene topic is published only when new entities are added
-TEST_P(SceneBroadcasterTest, SceneTopic)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneTopic))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -218,7 +219,8 @@ TEST_P(SceneBroadcasterTest, SceneTopic)
 
 /////////////////////////////////////////////////
 /// Test whether the scene topic is published only when new entities are added
-TEST_P(SceneBroadcasterTest, SceneTopicSensors)
+TEST_P(SceneBroadcasterTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneTopicSensors))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -269,7 +271,7 @@ TEST_P(SceneBroadcasterTest, SceneTopicSensors)
 
 /////////////////////////////////////////////////
 /// Test whether the scene topic is published only when new entities are added
-TEST_P(SceneBroadcasterTest, DeletedTopic)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DeletedTopic))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -329,7 +331,7 @@ TEST_P(SceneBroadcasterTest, DeletedTopic)
 
 /////////////////////////////////////////////////
 /// Test whether the scene is updated when a model is spawned.
-TEST_P(SceneBroadcasterTest, SpawnedModel)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SpawnedModel))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -399,7 +401,7 @@ TEST_P(SceneBroadcasterTest, SpawnedModel)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneBroadcasterTest, State)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(State))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
@@ -510,7 +512,7 @@ TEST_P(SceneBroadcasterTest, State)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneBroadcasterTest, StateStatic)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(StateStatic))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;

--- a/test/integration/sdf_frame_semantics.cc
+++ b/test/integration/sdf_frame_semantics.cc
@@ -135,7 +135,8 @@ class SdfFrameSemanticsTest : public InternalFixture<::testing::Test>
   public: std::unique_ptr<SdfEntityCreator> creator;
 };
 
-TEST_F(SdfFrameSemanticsTest, LinkRelativeTo)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(SdfFrameSemanticsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LinkRelativeTo))
 {
   const std::string modelSdf = R"sdf(
   <sdf version="1.7">
@@ -496,7 +497,8 @@ TEST_F(SdfFrameSemanticsTest, NestedModelsRelativeTo)
   EXPECT_EQ(link2ExpectedPose, this->GetPose(link2));
 }
 
-TEST_F(SdfFrameSemanticsTest, IncludeNestedModelsRelativeToTPE)
+TEST_F(SdfFrameSemanticsTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(IncludeNestedModelsRelativeToTPE))
 {
   std::string path = std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models";
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", path.c_str());
@@ -558,7 +560,8 @@ TEST_F(SdfFrameSemanticsTest, IncludeNestedModelsRelativeToTPE)
   EXPECT_EQ(nestedModelsLink01ExpectedPose, this->GetPose(nestedModelsLink01));
 }
 
-TEST_F(SdfFrameSemanticsTest, IncludeNestedModelsRelativeToDartsim)
+TEST_F(SdfFrameSemanticsTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(IncludeNestedModelsRelativeToDartsim))
 {
   std::string path = std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models";
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", path.c_str());

--- a/test/integration/sdf_frame_semantics.cc
+++ b/test/integration/sdf_frame_semantics.cc
@@ -22,6 +22,8 @@
 #include <sdf/Root.hh>
 #include <sdf/Model.hh>
 
+#include <ignition/utilities/ExtraTestMacros.hh>
+
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/EventManager.hh"
 #include "ignition/gazebo/Link.hh"

--- a/test/integration/sdf_include.cc
+++ b/test/integration/sdf_include.cc
@@ -19,6 +19,7 @@
 #include <sdf/sdf.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/fuel_tools.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
 

--- a/test/integration/sdf_include.cc
+++ b/test/integration/sdf_include.cc
@@ -32,7 +32,8 @@ class SdfInclude : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(SdfInclude, DownloadFromFuel)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(SdfInclude, IGN_UTILS_TEST_DISABLED_ON_WIN32(DownloadFromFuel))
 {
   std::string path = common::cwd() + "/test_cache";
 

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
@@ -194,7 +195,8 @@ void ThrusterTest::TestWorld(const std::string &_world,
 }
 
 /////////////////////////////////////////////////
-TEST_F(ThrusterTest, PIDControl)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(ThrusterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PIDControl))
 {
   auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "thruster_pid.sdf");
@@ -205,7 +207,7 @@ TEST_F(ThrusterTest, PIDControl)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ThrusterTest, VelocityControl)
+TEST_F(ThrusterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(VelocityControl))
 {
   auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "thruster_vel_cmd.sdf");

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -47,7 +47,8 @@ class TouchPluginTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(TouchPluginTest, OneLink)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(TouchPluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OneLink))
 {
   this->StartServer("/test/worlds/touch_plugin.sdf");
 
@@ -105,7 +106,7 @@ TEST_F(TouchPluginTest, OneLink)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TouchPluginTest, MultiLink)
+TEST_F(TouchPluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(MultiLink))
 {
   this->StartServer("/test/worlds/touch_plugin.sdf");
 
@@ -137,7 +138,7 @@ TEST_F(TouchPluginTest, MultiLink)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TouchPluginTest, StartDisabled)
+TEST_F(TouchPluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(StartDisabled))
 {
   this->StartServer("/test/worlds/touch_plugin.sdf");
 
@@ -185,7 +186,7 @@ TEST_F(TouchPluginTest, StartDisabled)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TouchPluginTest, RemovalOfParentModel)
+TEST_F(TouchPluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RemovalOfParentModel))
 {
   this->StartServer("/test/worlds/touch_plugin.sdf");
 
@@ -224,7 +225,7 @@ TEST_F(TouchPluginTest, RemovalOfParentModel)
 /// Tests whether the plugin works when it is spawned after other entities have
 /// already been created and vice versa
 /// This test uses depends on the user_commands system
-TEST_F(TouchPluginTest, SpawnedEntities)
+TEST_F(TouchPluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SpawnedEntities))
 {
   std::string whiteBox = R"EOF(
   <?xml version="1.0" ?>

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -19,6 +19,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"

--- a/test/integration/tracked_vehicle_system.cc
+++ b/test/integration/tracked_vehicle_system.cc
@@ -29,6 +29,7 @@
 #include <ignition/physics/FeaturePolicy.hh>
 #include <ignition/physics/config.hh>
 #include <ignition/plugin/Loader.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"
@@ -563,7 +564,8 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(TrackedVehicleTest, PublishCmd)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(TrackedVehicleTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
 {
   this->TestPublishCmd(
     std::string(PROJECT_SOURCE_PATH) +
@@ -573,7 +575,7 @@ TEST_F(TrackedVehicleTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TrackedVehicleTest, Conveyor)
+TEST_F(TrackedVehicleTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Conveyor))
 {
   this->TestConveyor(
     std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/triggered_publisher.cc
+++ b/test/integration/triggered_publisher.cc
@@ -27,6 +27,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/triggered_publisher.cc
+++ b/test/integration/triggered_publisher.cc
@@ -90,7 +90,9 @@ bool waitUntil(int _timeoutMs, Pred _pred)
 /////////////////////////////////////////////////
 /// Check that empty message types do not need any data to be specified in the
 /// configuration
-TEST_F(TriggeredPublisherTest, EmptyInputEmptyOutput)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EmptyInputEmptyOutput))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Empty>("/in_0");
@@ -114,7 +116,8 @@ TEST_F(TriggeredPublisherTest, EmptyInputEmptyOutput)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, WrongInputMessageTypeDoesNotMatch)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(WrongInputMessageTypeDoesNotMatch))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Boolean>("/in_0");
@@ -137,7 +140,8 @@ TEST_F(TriggeredPublisherTest, WrongInputMessageTypeDoesNotMatch)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, InputMessagesTriggerOutputs)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(InputMessagesTriggerOutputs))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Empty>("/in_1");
@@ -162,7 +166,8 @@ TEST_F(TriggeredPublisherTest, InputMessagesTriggerOutputs)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, MultipleOutputsForOneInput)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MultipleOutputsForOneInput))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Empty>("/in_2");
@@ -207,7 +212,8 @@ TEST_F(TriggeredPublisherTest, MultipleOutputsForOneInput)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, ExactMatchBooleanInputs)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ExactMatchBooleanInputs))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Boolean>("/in_3");
@@ -240,7 +246,8 @@ TEST_F(TriggeredPublisherTest, ExactMatchBooleanInputs)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, MatchersWithLogicTypeAttribute)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MatchersWithLogicTypeAttribute))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Int32>("/in_4");
@@ -276,7 +283,8 @@ TEST_F(TriggeredPublisherTest, MatchersWithLogicTypeAttribute)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, MultipleMatchersAreAnded)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MultipleMatchersAreAnded))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Int32>("/in_5");
@@ -301,7 +309,7 @@ TEST_F(TriggeredPublisherTest, MultipleMatchersAreAnded)
 }
 
 /////////////////////////////////////////////////
-TEST_F(TriggeredPublisherTest, FieldMatchers)
+TEST_F(TriggeredPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(FieldMatchers))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Vector2d>("/in_6");
@@ -340,7 +348,9 @@ TEST_F(TriggeredPublisherTest, FieldMatchers)
 /////////////////////////////////////////////////
 /// Tests that if the specified field is a repeated field, a partial match is
 /// used when comparing against the input.
-TEST_F(TriggeredPublisherTest, FieldMatchersWithRepeatedFieldsUsePartialMatches)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(
+           FieldMatchersWithRepeatedFieldsUsePartialMatches))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Pose>("/in_7");
@@ -377,7 +387,8 @@ TEST_F(TriggeredPublisherTest, FieldMatchersWithRepeatedFieldsUsePartialMatches)
   EXPECT_EQ(1u, recvCount);
 }
 
-TEST_F(TriggeredPublisherTest, WrongInputWhenRepeatedSubFieldExpected)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(WrongInputWhenRepeatedSubFieldExpected))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Empty>("/in_7");
@@ -406,8 +417,8 @@ TEST_F(TriggeredPublisherTest, WrongInputWhenRepeatedSubFieldExpected)
 /// fields by specifying the containing field of the repeated field in the
 /// "field" attribute and setting the desired values of the repeated field in
 /// the value of the <match> tag.
-TEST_F(TriggeredPublisherTest,
-       FieldMatchersWithRepeatedFieldsInValueUseFullMatches)
+TEST_F(TriggeredPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(
+       FieldMatchersWithRepeatedFieldsInValueUseFullMatches))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Pose>("/in_8");
@@ -448,8 +459,8 @@ TEST_F(TriggeredPublisherTest,
 /// Tests that full matchers can be used with repeated fields by specifying the
 /// desired values of the repeated field in the value of the <match> tag. The
 /// message created from the value of <match> must be a full match of the input.
-TEST_F(TriggeredPublisherTest,
-       FullMatchersWithRepeatedFieldsInValueUseFullMatches)
+TEST_F(TriggeredPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(
+       FullMatchersWithRepeatedFieldsInValueUseFullMatches))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Int32_V>("/in_9");
@@ -476,7 +487,8 @@ TEST_F(TriggeredPublisherTest,
   EXPECT_EQ(1u, recvCount);
 }
 
-TEST_F(TriggeredPublisherTest, FullMatchersAcceptToleranceParam)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(FullMatchersAcceptToleranceParam))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Float>("/in_10");
@@ -503,7 +515,8 @@ TEST_F(TriggeredPublisherTest, FullMatchersAcceptToleranceParam)
   EXPECT_EQ(3u, recvCount);
 }
 
-TEST_F(TriggeredPublisherTest, FieldMatchersAcceptToleranceParam)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(FieldMatchersAcceptToleranceParam))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Pose>("/in_11");
@@ -532,7 +545,8 @@ TEST_F(TriggeredPublisherTest, FieldMatchersAcceptToleranceParam)
   EXPECT_EQ(3u, recvCount);
 }
 
-TEST_F(TriggeredPublisherTest, SubfieldsOfRepeatedFieldsNotSupported)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(SubfieldsOfRepeatedFieldsNotSupported))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Header>("/in_12");
@@ -562,7 +576,7 @@ TEST_F(TriggeredPublisherTest, SubfieldsOfRepeatedFieldsNotSupported)
   EXPECT_EQ(0u, recvCount);
 }
 
-TEST_F(TriggeredPublisherTest, TriggerDelay)
+TEST_F(TriggeredPublisherTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(TriggerDelay))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Empty>("/in_13");
@@ -597,7 +611,8 @@ TEST_F(TriggeredPublisherTest, TriggerDelay)
   EXPECT_EQ(pubCount, recvCount);
 }
 
-TEST_F(TriggeredPublisherTest, WrongInputWhenRepeatedFieldExpected)
+TEST_F(TriggeredPublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(WrongInputWhenRepeatedFieldExpected))
 {
   transport::Node node;
   auto inputPub = node.Advertise<msgs::Int32>("/invalid_topic");

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -25,6 +25,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Light.hh"
 #include "ignition/gazebo/components/Link.hh"

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -49,7 +49,8 @@ class UserCommandsTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(UserCommandsTest, Create)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(UserCommandsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Create))
 {
   // Start server
   ServerConfig serverConfig;
@@ -330,7 +331,7 @@ TEST_F(UserCommandsTest, Create)
 }
 
 /////////////////////////////////////////////////
-TEST_F(UserCommandsTest, Remove)
+TEST_F(UserCommandsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Remove))
 {
   // Start server
   ServerConfig serverConfig;
@@ -518,7 +519,7 @@ TEST_F(UserCommandsTest, Remove)
 }
 
 /////////////////////////////////////////////////
-TEST_F(UserCommandsTest, Pose)
+TEST_F(UserCommandsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Pose))
 {
   // Start server
   ServerConfig serverConfig;
@@ -691,7 +692,7 @@ TEST_F(UserCommandsTest, Pose)
 }
 
 /////////////////////////////////////////////////
-TEST_F(UserCommandsTest, Light)
+TEST_F(UserCommandsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Light))
 {
   // Start server
   ServerConfig serverConfig;
@@ -924,7 +925,7 @@ TEST_F(UserCommandsTest, Light)
 }
 
 /////////////////////////////////////////////////
-TEST_F(UserCommandsTest, Physics)
+TEST_F(UserCommandsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Physics))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Name.hh"

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -230,7 +230,8 @@ class VelocityControlTest
 };
 
 /////////////////////////////////////////////////
-TEST_P(VelocityControlTest, PublishCmd)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(VelocityControlTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/velocity_control.sdf",
@@ -238,7 +239,7 @@ TEST_P(VelocityControlTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(VelocityControlTest, PublishLinkCmd)
+TEST_P(VelocityControlTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishLinkCmd))
 {
   TestPublishLinkCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/velocity_control.sdf",

--- a/test/integration/wheel_slip.cc
+++ b/test/integration/wheel_slip.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include <sdf/Sphere.hh>
 #include <sdf/Cylinder.hh>

--- a/test/integration/wheel_slip.cc
+++ b/test/integration/wheel_slip.cc
@@ -103,7 +103,8 @@ class WheelSlipTest : public InternalFixture<::testing::Test>
   };
 };
 
-TEST_F(WheelSlipTest, TireDrum)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(WheelSlipTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(TireDrum))
 {
   const double metersPerMile = 1609.34;
   const double secondsPerHour = 3600.0;
@@ -369,7 +370,7 @@ TEST_F(WheelSlipTest, TireDrum)
   server.Run(true, 250, false);
 }
 
-TEST_F(WheelSlipTest, TricyclesUphill)
+TEST_F(WheelSlipTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(TricyclesUphill))
 {
   ServerConfig serverConfig;
   const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/wind_effects.cc
+++ b/test/integration/wind_effects.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/msgs/Utility.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Server.hh"

--- a/test/integration/wind_effects.cc
+++ b/test/integration/wind_effects.cc
@@ -184,7 +184,8 @@ class BlockingPublisher
 
 /////////////////////////////////////////////////
 /// Check if 'enable_wind' set only in <model> works
-TEST_F(WindEffectsTest, WindEnabledInModel)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_F(WindEffectsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WindEnabledInModel))
 {
   this->StartServer("/test/worlds/wind_effects.sdf");
 
@@ -201,7 +202,7 @@ TEST_F(WindEffectsTest, WindEnabledInModel)
 
 /////////////////////////////////////////////////
 /// Check if 'enable_wind' set only in <link> works
-TEST_F(WindEffectsTest, WindEnabledInLink)
+TEST_F(WindEffectsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WindEnabledInLink))
 {
   this->StartServer("/test/worlds/wind_effects.sdf");
 
@@ -218,7 +219,7 @@ TEST_F(WindEffectsTest, WindEnabledInLink)
 
 
 ////////////////////////////////////////////////
-TEST_F(WindEffectsTest , WindForce)
+TEST_F(WindEffectsTest , IGN_UTILS_TEST_DISABLED_ON_WIN32(WindForce))
 {
   this->StartServer("/test/worlds/wind_effects.sdf");
   LinkComponentRecorder<components::WorldLinearAcceleration> linkAccelerations(
@@ -255,7 +256,7 @@ TEST_F(WindEffectsTest , WindForce)
 }
 
 ////////////////////////////////////////////////
-TEST_F(WindEffectsTest , TopicsAndServices)
+TEST_F(WindEffectsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(TopicsAndServices))
 {
   using namespace std::chrono_literals;
 
@@ -322,7 +323,8 @@ TEST_F(WindEffectsTest , TopicsAndServices)
 
 /// Test if adding a link with wind after first iteration adds
 /// WorldLinearVelocity component properly
-TEST_F(WindEffectsTest, WindEntityAddedAfterStart)
+TEST_F(WindEffectsTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(WindEntityAddedAfterStart))
 {
   const std::string windBox = R"EOF(
   <?xml version="1.0" ?>

--- a/test/performance/level_manager.cc
+++ b/test/performance/level_manager.cc
@@ -22,6 +22,7 @@
 #include <ignition/math/Stopwatch.hh>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/performance/level_manager.cc
+++ b/test/performance/level_manager.cc
@@ -30,7 +30,8 @@
 using namespace ignition;
 using namespace gazebo;
 
-TEST(LevelManagerPerfrormance, LevelVsNoLevel)
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST(LevelManagerPerfrormance, IGN_UTILS_TEST_DISABLED_ON_WIN32(LevelVsNoLevel))
 {
   using namespace std::chrono;
 


### PR DESCRIPTION
Signed-off-by: Jorge Perez jjperez@ekumenlabs.com

First step towards https://github.com/ignitionrobotics/ign-gazebo/issues/1175

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
As the title says, skips Windows tests for `ign-gazebo5`. Will get green Windows buildfarm before merging.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests (actually removing tests)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge**
