### PR TITLE
Update SdfGenerator to save joint data to file

### DIFF
--- a/src/SdfGenerator.cc
+++ b/src/SdfGenerator.cc
@@ -829,9 +829,9 @@ namespace sdf_generator
 
     // joint type
     auto jointTypeComp = _ecm.Component<components::JointType>(_entity);
+    sdf::JointType jointType = jointTypeComp->Data();
     if (jointTypeComp)
     {
-      sdf::JointType jointType = jointTypeComp->Data();
       std::string jointTypeStr = "invalid";
       switch (jointType)
       {
@@ -883,7 +883,7 @@ namespace sdf_generator
     }
     // thread pitch
     auto threadPitchComp = _ecm.Component<components::ThreadPitch>(_entity);
-    if (threadPitchComp)
+    if (threadPitchComp && jointType == sdf::JointType::SCREW)
     {
       _elem->GetElement("thread_pitch")->Set<double>(threadPitchComp->Data());
     }

--- a/src/SdfGenerator.hh
+++ b/src/SdfGenerator.hh
@@ -131,6 +131,17 @@ namespace sdf_generator
   bool updateLightElement(sdf::ElementPtr _elem,
                            const EntityComponentManager &_ecm,
                            const Entity &_entity);
+
+  /// \brief Update an sdf::Element of a joint.
+  /// Intended for internal use.
+  /// \input[in, out] _elem sdf::Element to update
+  /// \input[in] _ecm Immutable reference to the Entity Component Manager
+  /// \input[in] _entity joint entity
+  /// \returns true if update succeeded.
+  IGNITION_GAZEBO_VISIBLE
+  bool updateJointElement(sdf::ElementPtr _elem,
+                           const EntityComponentManager &_ecm,
+                           const Entity &_entity);
 }  // namespace sdf_generator
 }  // namespace IGNITION_GAZEBO_VERSION_NAMESPACE
 }  // namespace gazebo

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -860,7 +860,8 @@ TEST_F(SdfGeneratorFixture, WorldWithLights)
 /////////////////////////////////////////////////
 TEST_F(SdfGeneratorFixture, ModelWithJoints)
 {
-  this->LoadWorld("test/worlds/joint_sensor.sdf");
+  this->LoadWorld(ignition::common::joinPaths("test", "worlds",
+      "joint_sensor.sdf"));
 
   const std::string worldGenSdfRes =
       this->RequestGeneratedSdf("joint_sensor");

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -26,6 +26,8 @@
 #include <sdf/Collision.hh>
 #include <sdf/ForceTorque.hh>
 #include <sdf/Imu.hh>
+#include <sdf/Joint.hh>
+#include <sdf/JointAxis.hh>
 #include <sdf/Magnetometer.hh>
 #include <sdf/Model.hh>
 #include <sdf/Lidar.hh>
@@ -853,6 +855,104 @@ TEST_F(SdfGeneratorFixture, WorldWithLights)
   ASSERT_NE(nullptr, genSdfDoc.RootElement());
   auto genWorld = genSdfDoc.RootElement()->FirstChildElement("world");
   ASSERT_NE(nullptr, genWorld);
+}
+
+/////////////////////////////////////////////////
+TEST_F(SdfGeneratorFixture, ModelWithJoints)
+{
+  this->LoadWorld("test/worlds/joint_sensor.sdf");
+
+  const std::string worldGenSdfRes =
+      this->RequestGeneratedSdf("joint_sensor");
+
+  sdf::Root root;
+  sdf::Errors err = root.LoadSdfString(worldGenSdfRes);
+  EXPECT_TRUE(err.empty());
+  auto *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  EXPECT_EQ(1u, world->ModelCount());
+
+  EXPECT_TRUE(world->ModelNameExists("model"));
+  auto *model = world->ModelByName("model");
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ(2u, model->LinkCount());
+  auto *link1 = model->LinkByName("link1");
+  ASSERT_NE(nullptr, link1);
+  auto *link2 = model->LinkByName("link2");
+  ASSERT_NE(nullptr, link2);
+  EXPECT_EQ(1u, model->JointCount());
+  auto *joint = model->JointByName("joint");
+  ASSERT_NE(nullptr, joint);
+
+  EXPECT_EQ("link1", joint->ParentLinkName());
+  EXPECT_EQ("link2", joint->ChildLinkName());
+  EXPECT_EQ(sdf::JointType::REVOLUTE2, joint->Type());
+
+  // Get the first axis
+  const sdf::JointAxis *axis = joint->Axis();
+  ASSERT_NE(nullptr, axis);
+  ASSERT_NE(nullptr, axis->Element());
+
+  // Get the second axis
+  const sdf::JointAxis *axis2 = joint->Axis(1);
+  ASSERT_NE(nullptr, axis2);
+
+  EXPECT_EQ(ignition::math::Vector3d::UnitZ, axis->Xyz());
+  EXPECT_EQ(ignition::math::Vector3d::UnitY, axis2->Xyz());
+
+  EXPECT_EQ("__model__", axis->XyzExpressedIn());
+  EXPECT_TRUE(axis2->XyzExpressedIn().empty());
+
+  EXPECT_DOUBLE_EQ(-0.5, axis->Lower());
+  EXPECT_DOUBLE_EQ(0.5, axis->Upper());
+  EXPECT_DOUBLE_EQ(-1.0, axis2->Lower());
+  EXPECT_DOUBLE_EQ(1.0, axis2->Upper());
+
+  EXPECT_DOUBLE_EQ(123.4, axis->Effort());
+  EXPECT_DOUBLE_EQ(0.5, axis2->Effort());
+
+  EXPECT_DOUBLE_EQ(12.0, axis->MaxVelocity());
+  EXPECT_DOUBLE_EQ(200.0, axis2->MaxVelocity());
+
+  EXPECT_DOUBLE_EQ(0.1, axis->Damping());
+  EXPECT_DOUBLE_EQ(0.0, axis2->Damping());
+
+  EXPECT_DOUBLE_EQ(0.2, axis->Friction());
+  EXPECT_DOUBLE_EQ(0.0, axis2->Friction());
+
+  EXPECT_DOUBLE_EQ(1.3, axis->SpringReference());
+  EXPECT_DOUBLE_EQ(0.0, axis2->SpringReference());
+
+  EXPECT_DOUBLE_EQ(10.6, axis->SpringStiffness());
+  EXPECT_DOUBLE_EQ(0.0, axis2->SpringStiffness());
+
+  // sensor
+  const sdf::Sensor *forceTorqueSensor =
+    joint->SensorByName("force_torque_sensor");
+  ASSERT_NE(nullptr, forceTorqueSensor);
+  EXPECT_EQ("force_torque_sensor", forceTorqueSensor->Name());
+  EXPECT_EQ(sdf::SensorType::FORCE_TORQUE, forceTorqueSensor->Type());
+  EXPECT_EQ(ignition::math::Pose3d(10, 11, 12, 0, 0, 0),
+      forceTorqueSensor->RawPose());
+  auto forceTorqueSensorObj = forceTorqueSensor->ForceTorqueSensor();
+  ASSERT_NE(nullptr, forceTorqueSensorObj);
+  EXPECT_EQ(sdf::ForceTorqueFrame::PARENT, forceTorqueSensorObj->Frame());
+  EXPECT_EQ(sdf::ForceTorqueMeasureDirection::PARENT_TO_CHILD,
+      forceTorqueSensorObj->MeasureDirection());
+
+  EXPECT_DOUBLE_EQ(0.0, forceTorqueSensorObj->ForceXNoise().Mean());
+  EXPECT_DOUBLE_EQ(0.1, forceTorqueSensorObj->ForceXNoise().StdDev());
+  EXPECT_DOUBLE_EQ(1.0, forceTorqueSensorObj->ForceYNoise().Mean());
+  EXPECT_DOUBLE_EQ(1.1, forceTorqueSensorObj->ForceYNoise().StdDev());
+  EXPECT_DOUBLE_EQ(2.0, forceTorqueSensorObj->ForceZNoise().Mean());
+  EXPECT_DOUBLE_EQ(2.1, forceTorqueSensorObj->ForceZNoise().StdDev());
+
+  EXPECT_DOUBLE_EQ(3.0, forceTorqueSensorObj->TorqueXNoise().Mean());
+  EXPECT_DOUBLE_EQ(3.1, forceTorqueSensorObj->TorqueXNoise().StdDev());
+  EXPECT_DOUBLE_EQ(4.0, forceTorqueSensorObj->TorqueYNoise().Mean());
+  EXPECT_DOUBLE_EQ(4.1, forceTorqueSensorObj->TorqueYNoise().StdDev());
+  EXPECT_DOUBLE_EQ(5.0, forceTorqueSensorObj->TorqueZNoise().Mean());
+  EXPECT_DOUBLE_EQ(5.1, forceTorqueSensorObj->TorqueZNoise().StdDev());
 }
 
 /////////////////////////////////////////////////

--- a/test/worlds/joint_sensor.sdf
+++ b/test/worlds/joint_sensor.sdf
@@ -1,0 +1,107 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <world name="joint_sensor">
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <model name="model">
+      <link name="link1"/>
+      <link name="link2"/>
+      <joint name="joint" type="revolute2">
+        <child>link2</child>
+        <parent>link1</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <initial_position>0.5</initial_position>
+          <use_parent_model_frame>true</use_parent_model_frame>
+          <limit>
+            <lower>-0.5</lower>
+            <upper>0.5</upper>
+            <effort>123.4</effort>
+            <velocity>12</velocity>
+          </limit>
+          <dynamics>
+            <damping>0.1</damping>
+            <friction>0.2</friction>
+            <spring_reference>1.3</spring_reference>
+            <spring_stiffness>10.6</spring_stiffness>
+          </dynamics>
+        </axis>
+        <axis2>
+          <xyz>0 1 0</xyz>
+          <initial_position>1.5</initial_position>
+          <use_parent_model_frame>false</use_parent_model_frame>
+          <limit>
+            <lower>-1</lower>
+            <upper>1</upper>
+            <effort>0.5</effort>
+            <velocity>200</velocity>
+          </limit>
+        </axis2>
+        <physics>
+          <ode>
+            <cfm_damping>1</cfm_damping>
+            <limit>
+              <cfm>0</cfm>
+              <erp>0.2</erp>
+            </limit>
+          </ode>
+        </physics>
+          <sensor name="force_torque_sensor" type="force_torque">
+            <pose>10 11 12 0 0 0</pose>
+            <force_torque>
+              <frame>parent</frame>
+              <measure_direction>parent_to_child</measure_direction>
+              <force>
+                <x>
+                  <noise type="gaussian">
+                    <mean>0</mean>
+                    <stddev>0.1</stddev>
+                  </noise>
+                </x>
+                <y>
+                  <noise type="gaussian">
+                    <mean>1</mean>
+                    <stddev>1.1</stddev>
+                  </noise>
+                </y>
+                <z>
+                  <noise type="gaussian">
+                    <mean>2</mean>
+                    <stddev>2.1</stddev>
+                  </noise>
+                </z>
+              </force>
+              <torque>
+                <x>
+                  <noise type="gaussian">
+                    <mean>3</mean>
+                    <stddev>3.1</stddev>
+                  </noise>
+                </x>
+                <y>
+                  <noise type="gaussian">
+                    <mean>4</mean>
+                    <stddev>4.1</stddev>
+                  </noise>
+                </y>
+                <z>
+                  <noise type="gaussian">
+                    <mean>5</mean>
+                    <stddev>5.1</stddev>
+                  </noise>
+                </z>
+              </torque>
+            </force_torque>
+          </sensor>
+      </joint>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

depends on:
* #1209 
* https://github.com/ignitionrobotics/sdformat/pull/759

## Summary

similar to #1209, this PR extends SdfGenerator to pull joint data from ECM and save them to SDF file.

Note that the `components::Joint` component does not store a `sdf::Joint` DOM object. Various joint properties are stored in different Joint* components, and currently ign-gazebo does not have components for all joint properties. So as the result, not all joint properties can be saved to sdf file.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

