### PR TITLE
Increase maximum values in ViewAngle widget

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.qml
+++ b/src/gui/plugins/view_angle/ViewAngle.qml
@@ -233,8 +233,8 @@ ColumnLayout {
       Layout.row: 0
       Layout.column: 1
       value: ViewAngle.camPose[0]
-      maximumValue: 1000000
-      minimumValue: -1000000
+      maximumValue: Number.MAX_VALUE
+      minimumValue: -Number.MAX_VALUE
       decimals: 6
       stepSize: 0.01
       onEditingFinished: ViewAngle.SetCamPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
@@ -252,8 +252,8 @@ ColumnLayout {
       Layout.row: 1
       Layout.column: 1
       value: ViewAngle.camPose[1]
-      maximumValue: 1000000
-      minimumValue: -1000000
+      maximumValue: Number.MAX_VALUE
+      minimumValue: -Number.MAX_VALUE
       decimals: 6
       stepSize: 0.01
       onEditingFinished: ViewAngle.SetCamPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
@@ -271,8 +271,8 @@ ColumnLayout {
       Layout.row: 2
       Layout.column: 1
       value: ViewAngle.camPose[2]
-      maximumValue: 1000000
-      minimumValue: -1000000
+      maximumValue: Number.MAX_VALUE
+      minimumValue: -Number.MAX_VALUE
       decimals: 6
       stepSize: 0.01
       onEditingFinished: ViewAngle.SetCamPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
@@ -383,7 +383,7 @@ ColumnLayout {
       Layout.row: 0
       Layout.column: 3
       value: ViewAngle.camClipDist[1]
-      maximumValue: 1000000
+      maximumValue: Number.MAX_VALUE
       minimumValue: nearClip.value
       decimals: 6
       stepSize: 0.01


### PR DESCRIPTION
## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Use the absolute maximum number for the widget. I'm dealing with some really large worlds and the current limits aren't enough:

![Screenshot from 2021-11-24 15-19-00](https://user-images.githubusercontent.com/5751272/143324947-0a7a7e83-b5d8-407f-88f9-1037e235ed74.png)


## Test it
<!--Explain how reviewers can test this new feature manually.-->

Load the widget and input crazily large numbers.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
