### PR TITLE
Min and max parameters for velocity, acceleration, and jerk apply to linear and angular separately.

### DIFF
--- a/examples/worlds/diff_drive.sdf
+++ b/examples/worlds/diff_drive.sdf
@@ -252,6 +252,14 @@
         <wheel_separation>1.25</wheel_separation>
         <wheel_radius>0.3</wheel_radius>
         <odom_publish_frequency>1</odom_publish_frequency>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
       </plugin>
 
     </model>
@@ -431,6 +439,14 @@
         <right_joint>right_wheel_joint</right_joint>
         <wheel_separation>1.25</wheel_separation>
         <wheel_radius>0.3</wheel_radius>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
       </plugin>
 
     </model>

--- a/examples/worlds/diff_drive_skid.sdf
+++ b/examples/worlds/diff_drive_skid.sdf
@@ -346,6 +346,14 @@
         <right_joint>rear_right_wheel_joint</right_joint>
         <wheel_separation>1.25</wheel_separation>
         <wheel_radius>0.3</wheel_radius>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
       </plugin>
 
     </model>

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -210,61 +210,108 @@ void DiffDrive::Configure(const Entity &_entity,
   this->dataPtr->limiterAng = std::make_unique<ignition::math::SpeedLimiter>();
 
   // Parse speed limiter parameters.
+
+  // Min Velocity
+  if (_sdf->HasElement("min_velocity"))
+  {
+    const double minVel = _sdf->Get<double>("min_velocity");
+    this->dataPtr->limiterLin->SetMinVelocity(minVel);
+    this->dataPtr->limiterAng->SetMinVelocity(minVel);
+  }
   if (_sdf->HasElement("min_linear_velocity"))
   {
     const double minLinVel = _sdf->Get<double>("min_linear_velocity");
     this->dataPtr->limiterLin->SetMinVelocity(minLinVel);
+  }
+  if (_sdf->HasElement("min_angular_velocity"))
+  {
+    const double minAngVel = _sdf->Get<double>("min_angular_velocity");
+    this->dataPtr->limiterAng->SetMinVelocity(minAngVel);
+  }
+
+  // Max Velocity
+  if (_sdf->HasElement("max_velocity"))
+  {
+    const double maxVel = _sdf->Get<double>("max_velocity");
+    this->dataPtr->limiterLin->SetMaxVelocity(maxVel);
+    this->dataPtr->limiterAng->SetMaxVelocity(maxVel);
   }
   if (_sdf->HasElement("max_linear_velocity"))
   {
     const double maxLinVel = _sdf->Get<double>("max_linear_velocity");
     this->dataPtr->limiterLin->SetMaxVelocity(maxLinVel);
   }
-  if (_sdf->HasElement("min_linear_acceleration"))
-  {
-    const double minLinAccel = _sdf->Get<double>("min_linear_acceleration");
-    this->dataPtr->limiterLin->SetMinAcceleration(minLinAccel);
-  }
-  if (_sdf->HasElement("max_linear_acceleration"))
-  {
-    const double maxLinAccel = _sdf->Get<double>("max_linear_acceleration");
-    this->dataPtr->limiterLin->SetMaxAcceleration(maxLinAccel);
-  }
-  if (_sdf->HasElement("min_linear_jerk"))
-  {
-    const double minLinJerk = _sdf->Get<double>("min_linear_jerk");
-    this->dataPtr->limiterLin->SetMinJerk(minLinJerk);
-  }
-  if (_sdf->HasElement("max_linear_jerk"))
-  {
-    const double maxLinJerk = _sdf->Get<double>("max_linear_jerk");
-    this->dataPtr->limiterLin->SetMaxJerk(maxLinJerk);
-  }
-
-  if (_sdf->HasElement("min_angular_velocity"))
-  {
-    const double minAngVel = _sdf->Get<double>("min_angular_velocity");
-    this->dataPtr->limiterAng->SetMinVelocity(minAngVel);
-  }
   if (_sdf->HasElement("max_angular_velocity"))
   {
     const double maxAngVel = _sdf->Get<double>("max_angular_velocity");
     this->dataPtr->limiterAng->SetMaxVelocity(maxAngVel);
+  }
+
+  // Min Acceleration
+  if (_sdf->HasElement("min_acceleration"))
+  {
+    const double minAccel = _sdf->Get<double>("min_acceleration");
+    this->dataPtr->limiterLin->SetMinAcceleration(minAccel);
+    this->dataPtr->limiterAng->SetMinAcceleration(minAccel);
+  }
+  if (_sdf->HasElement("min_linear_acceleration"))
+  {
+    const double minLinAccel = _sdf->Get<double>("min_linear_acceleration");
+    this->dataPtr->limiterLin->SetMinAcceleration(minLinAccel);
   }
   if (_sdf->HasElement("min_angular_acceleration"))
   {
     const double minAngAccel = _sdf->Get<double>("min_angular_acceleration");
     this->dataPtr->limiterAng->SetMinAcceleration(minAngAccel);
   }
+
+  // Max Acceleration
+  if (_sdf->HasElement("max_acceleration"))
+  {
+    const double maxAccel = _sdf->Get<double>("max_acceleration");
+    this->dataPtr->limiterLin->SetMaxAcceleration(maxAccel);
+    this->dataPtr->limiterAng->SetMaxAcceleration(maxAccel);
+  }
+  if (_sdf->HasElement("max_linear_acceleration"))
+  {
+    const double maxLinAccel = _sdf->Get<double>("max_linear_acceleration");
+    this->dataPtr->limiterLin->SetMaxAcceleration(maxLinAccel);
+  }
   if (_sdf->HasElement("max_angular_acceleration"))
   {
     const double maxAngAccel = _sdf->Get<double>("max_angular_acceleration");
     this->dataPtr->limiterAng->SetMaxAcceleration(maxAngAccel);
   }
+
+  // Min Jerk
+  if (_sdf->HasElement("min_jerk"))
+  {
+    const double minJerk = _sdf->Get<double>("min_jerk");
+    this->dataPtr->limiterLin->SetMinJerk(minJerk);
+    this->dataPtr->limiterAng->SetMinJerk(minJerk);
+  }
+  if (_sdf->HasElement("min_linear_jerk"))
+  {
+    const double minLinJerk = _sdf->Get<double>("min_linear_jerk");
+    this->dataPtr->limiterLin->SetMinJerk(minLinJerk);
+  }
   if (_sdf->HasElement("min_angular_jerk"))
   {
     const double minAngJerk = _sdf->Get<double>("min_angular_jerk");
     this->dataPtr->limiterAng->SetMinJerk(minAngJerk);
+  }
+
+  // Max Jerk
+  if (_sdf->HasElement("max_jerk"))
+  {
+    const double maxJerk = _sdf->Get<double>("max_jerk");
+    this->dataPtr->limiterLin->SetMaxJerk(maxJerk);
+    this->dataPtr->limiterAng->SetMaxJerk(maxJerk);
+  }
+  if (_sdf->HasElement("max_linear_jerk"))
+  {
+    const double maxLinJerk = _sdf->Get<double>("max_linear_jerk");
+    this->dataPtr->limiterLin->SetMaxJerk(maxLinJerk);
   }
   if (_sdf->HasElement("max_angular_jerk"))
   {

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -210,42 +210,68 @@ void DiffDrive::Configure(const Entity &_entity,
   this->dataPtr->limiterAng = std::make_unique<ignition::math::SpeedLimiter>();
 
   // Parse speed limiter parameters.
-  if (_sdf->HasElement("min_velocity"))
+  if (_sdf->HasElement("min_linear_velocity"))
   {
-    const double minVel = _sdf->Get<double>("min_velocity");
-    this->dataPtr->limiterLin->SetMinVelocity(minVel);
-    this->dataPtr->limiterAng->SetMinVelocity(minVel);
+    const double minLinVel = _sdf->Get<double>("min_linear_velocity");
+    this->dataPtr->limiterLin->SetMinVelocity(minLinVel);
   }
-  if (_sdf->HasElement("max_velocity"))
+  if (_sdf->HasElement("max_linear_velocity"))
   {
-    const double maxVel = _sdf->Get<double>("max_velocity");
-    this->dataPtr->limiterLin->SetMaxVelocity(maxVel);
-    this->dataPtr->limiterAng->SetMaxVelocity(maxVel);
+    const double maxLinVel = _sdf->Get<double>("max_linear_velocity");
+    this->dataPtr->limiterLin->SetMaxVelocity(maxLinVel);
   }
-  if (_sdf->HasElement("min_acceleration"))
+  if (_sdf->HasElement("min_linear_acceleration"))
   {
-    const double minAccel = _sdf->Get<double>("min_acceleration");
-    this->dataPtr->limiterLin->SetMinAcceleration(minAccel);
-    this->dataPtr->limiterAng->SetMinAcceleration(minAccel);
+    const double minLinAccel = _sdf->Get<double>("min_linear_acceleration");
+    this->dataPtr->limiterLin->SetMinAcceleration(minLinAccel);
   }
-  if (_sdf->HasElement("max_acceleration"))
+  if (_sdf->HasElement("max_linear_acceleration"))
   {
-    const double maxAccel = _sdf->Get<double>("max_acceleration");
-    this->dataPtr->limiterLin->SetMaxAcceleration(maxAccel);
-    this->dataPtr->limiterAng->SetMaxAcceleration(maxAccel);
+    const double maxLinAccel = _sdf->Get<double>("max_linear_acceleration");
+    this->dataPtr->limiterLin->SetMaxAcceleration(maxLinAccel);
   }
-  if (_sdf->HasElement("min_jerk"))
+  if (_sdf->HasElement("min_linear_jerk"))
   {
-    const double minJerk = _sdf->Get<double>("min_jerk");
-    this->dataPtr->limiterLin->SetMinJerk(minJerk);
-    this->dataPtr->limiterAng->SetMinJerk(minJerk);
+    const double minLinJerk = _sdf->Get<double>("min_linear_jerk");
+    this->dataPtr->limiterLin->SetMinJerk(minLinJerk);
   }
-  if (_sdf->HasElement("max_jerk"))
+  if (_sdf->HasElement("max_linear_jerk"))
   {
-    const double maxJerk = _sdf->Get<double>("max_jerk");
-    this->dataPtr->limiterLin->SetMaxJerk(maxJerk);
-    this->dataPtr->limiterAng->SetMaxJerk(maxJerk);
+    const double maxLinJerk = _sdf->Get<double>("max_linear_jerk");
+    this->dataPtr->limiterLin->SetMaxJerk(maxLinJerk);
   }
+
+  if (_sdf->HasElement("min_angular_velocity"))
+  {
+    const double minAngVel = _sdf->Get<double>("min_angular_velocity");
+    this->dataPtr->limiterAng->SetMinVelocity(minAngVel);
+  }
+  if (_sdf->HasElement("max_angular_velocity"))
+  {
+    const double maxAngVel = _sdf->Get<double>("max_angular_velocity");
+    this->dataPtr->limiterAng->SetMaxVelocity(maxAngVel);
+  }
+  if (_sdf->HasElement("min_angular_acceleration"))
+  {
+    const double minAngAccel = _sdf->Get<double>("min_angular_acceleration");
+    this->dataPtr->limiterAng->SetMinAcceleration(minAngAccel);
+  }
+  if (_sdf->HasElement("max_angular_acceleration"))
+  {
+    const double maxAngAccel = _sdf->Get<double>("max_angular_acceleration");
+    this->dataPtr->limiterAng->SetMaxAcceleration(maxAngAccel);
+  }
+  if (_sdf->HasElement("min_angular_jerk"))
+  {
+    const double minAngJerk = _sdf->Get<double>("min_angular_jerk");
+    this->dataPtr->limiterAng->SetMinJerk(minAngJerk);
+  }
+  if (_sdf->HasElement("max_angular_jerk"))
+  {
+    const double maxAngJerk = _sdf->Get<double>("max_angular_jerk");
+    this->dataPtr->limiterAng->SetMaxJerk(maxAngJerk);
+  }
+  
 
   double odomFreq = _sdf->Get<double>("odom_publish_frequency", 50).first;
   if (odomFreq > 0)

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -318,7 +318,6 @@ void DiffDrive::Configure(const Entity &_entity,
     const double maxAngJerk = _sdf->Get<double>("max_angular_jerk");
     this->dataPtr->limiterAng->SetMaxJerk(maxAngJerk);
   }
-  
 
   double odomFreq = _sdf->Get<double>("odom_publish_frequency", 50).first;
   if (odomFreq > 0)

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -78,42 +78,57 @@ namespace systems
   /// `ignition.msgs.Odometry` message. This element if optional,
   ///  and the default value is `{name_of_model}/{name_of_link}`.
   ///
-  /// `<min_velocity>`: Sets both the minimum linear and minimum angular velocity.
+  /// `<min_velocity>`: Sets both the minimum linear and minimum angular
+  ///  velocity.
   ///
-  /// `<max_velocity>`: Sets both the maximum linear and maximum angular velocity.
+  /// `<max_velocity>`: Sets both the maximum linear and maximum angular
+  /// velocity.
   ///
-  /// `<min_acceleration>`: Sets both the minimum linear and minimum angular acceleration.
+  /// `<min_acceleration>`: Sets both the minimum linear and minimum angular
+  /// acceleration.
   ///
-  /// `<max_acceleration>`: Sets both the maximum linear and maximum angular acceleration.
+  /// `<max_acceleration>`: Sets both the maximum linear and maximum angular
+  /// acceleration.
   ///
   /// `<min_jerk>`: Sets both the minimum linear and minimum angular jerk.
   ///
   /// `<max_jerk>`: Sets both the maximum linear and maximum angular jerk.
   ///
-  /// `<min_linear_velocity>`: Sets the minimum linear velocity. Overrides `<min_velocity>` if set.
+  /// `<min_linear_velocity>`: Sets the minimum linear velocity. Overrides
+  /// `<min_velocity>` if set.
   ///
-  /// `<max_linear_velocity>`: Sets the maximum linear velocity. Overrides `<max_velocity>` if set.
+  /// `<max_linear_velocity>`: Sets the maximum linear velocity. Overrides
+  /// `<max_velocity>` if set.
   ///
-  /// `<min_angular_velocity>`: Sets the minimum angular velocity. Overrides `<min_velocity>` if set.
+  /// `<min_angular_velocity>`: Sets the minimum angular velocity. Overrides
+  /// `<min_velocity>` if set.
   ///
-  /// `<max_angular_velocity>`: Sets the maximum angular velocity. Overrides `<max_velocity>` if set.
+  /// `<max_angular_velocity>`: Sets the maximum angular velocity. Overrides
+  /// `<max_velocity>` if set.
   ///
-  /// `<min_linear_acceleration>`: Sets the minimum linear acceleration. Overrides `<min_acceleration>` if set.
+  /// `<min_linear_acceleration>`: Sets the minimum linear acceleration.
+  /// Overrides `<min_acceleration>` if set.
   ///
-  /// `<max_linear_acceleration>`: Sets the maximum linear acceleration. Overrides `<max_acceleration>` if set.
+  /// `<max_linear_acceleration>`: Sets the maximum linear acceleration.
+  /// Overrides `<max_acceleration>` if set.
   ///
-  /// `<min_angular_acceleration>`: Sets the minimum angular acceleration. Overrides `<min_acceleration>` if set.
+  /// `<min_angular_acceleration>`: Sets the minimum angular acceleration.
+  /// Overrides `<min_acceleration>` if set.
   ///
-  /// `<max_angular_acceleration>`: Sets the maximum angular acceleration. Overrides `<max_acceleration>` if set.
+  /// `<max_angular_acceleration>`: Sets the maximum angular acceleration.
+  /// Overrides `<max_acceleration>` if set.
   ///
-  /// `<min_linear_jerk>`: Sets the minimum linear jerk. Overrides `<min_jerk>` if set.
+  /// `<min_linear_jerk>`: Sets the minimum linear jerk. Overrides `<min_jerk>`
+  /// if set.
   ///
-  /// `<max_linear_jerk>`: Sets the maximum linear jerk. Overrides `<max_jerk>` if set.
+  /// `<max_linear_jerk>`: Sets the maximum linear jerk. Overrides `<max_jerk>`
+  /// if set.
   ///
-  /// `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides `<min_jerk>` if set.
+  /// `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides `<min_jerk>`
+  /// if set.
   ///
-  /// `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides `<max_jerk>` if set.
-
+  /// `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides `<max_jerk>`
+  /// if set.
   class DiffDrive
       : public System,
         public ISystemConfigure,

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -77,6 +77,43 @@ namespace systems
   /// `ignition.msgs.Pose_V` message and the `<odom_topic>`
   /// `ignition.msgs.Odometry` message. This element if optional,
   ///  and the default value is `{name_of_model}/{name_of_link}`.
+  ///
+  /// `<min_velocity>`: Sets both the minimum linear and minimum angular velocity.
+  ///
+  /// `<max_velocity>`: Sets both the maximum linear and maximum angular velocity.
+  ///
+  /// `<min_acceleration>`: Sets both the minimum linear and minimum angular acceleration.
+  ///
+  /// `<max_acceleration>`: Sets both the maximum linear and maximum angular acceleration.
+  ///
+  /// `<min_jerk>`: Sets both the minimum linear and minimum angular jerk.
+  ///
+  /// `<max_jerk>`: Sets both the maximum linear and maximum angular jerk.
+  ///
+  /// `<min_linear_velocity>`: Sets the minimum linear velocity. Overrides `<min_velocity>` if set.
+  ///
+  /// `<max_linear_velocity>`: Sets the maximum linear velocity. Overrides `<max_velocity>` if set.
+  ///
+  /// `<min_angular_velocity>`: Sets the minimum angular velocity. Overrides `<min_velocity>` if set.
+  ///
+  /// `<max_angular_velocity>`: Sets the maximum angular velocity. Overrides `<max_velocity>` if set.
+  ///
+  /// `<min_linear_acceleration>`: Sets the minimum linear acceleration. Overrides `<min_acceleration>` if set.
+  ///
+  /// `<max_linear_acceleration>`: Sets the maximum linear acceleration. Overrides `<max_acceleration>` if set.
+  ///
+  /// `<min_angular_acceleration>`: Sets the minimum angular acceleration. Overrides `<min_acceleration>` if set.
+  ///
+  /// `<max_angular_acceleration>`: Sets the maximum angular acceleration. Overrides `<max_acceleration>` if set.
+  ///
+  /// `<min_linear_jerk>`: Sets the minimum linear jerk. Overrides `<min_jerk>` if set.
+  ///
+  /// `<max_linear_jerk>`: Sets the maximum linear jerk. Overrides `<max_jerk>` if set.
+  ///
+  /// `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides `<min_jerk>` if set.
+  ///
+  /// `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides `<max_jerk>` if set.
+
   class DiffDrive
       : public System,
         public ISystemConfigure,

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -124,11 +124,11 @@ namespace systems
   /// `<max_linear_jerk>`: Sets the maximum linear jerk. Overrides `<max_jerk>`
   /// if set.
   ///
-  /// `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides `<min_jerk>`
-  /// if set.
+  /// `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides
+  /// `<min_jerk>` if set.
   ///
-  /// `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides `<max_jerk>`
-  /// if set.
+  /// `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides
+  /// `<max_jerk>` if set.
   class DiffDrive
       : public System,
         public ISystemConfigure,

--- a/test/worlds/diff_drive.sdf
+++ b/test/worlds/diff_drive.sdf
@@ -227,10 +227,14 @@
         <right_joint>right_wheel_joint</right_joint>
         <wheel_separation>1.25</wheel_separation>
         <wheel_radius>0.3</wheel_radius>
-        <max_acceleration>1</max_acceleration>
-        <min_acceleration>-1</min_acceleration>
-        <max_velocity>0.5</max_velocity>
-        <min_velocity>-0.5</min_velocity>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
         <!-- no odom_publisher_frequency defaults to 50 Hz -->
       </plugin>
 

--- a/test/worlds/diff_drive_custom_topics.sdf
+++ b/test/worlds/diff_drive_custom_topics.sdf
@@ -229,10 +229,14 @@
         <wheel_radius>0.3</wheel_radius>
         <topic>/model/foo/cmdvel</topic>
         <odom_topic>/model/bar/odom</odom_topic>
-        <max_acceleration>1</max_acceleration>
-        <max_velocity>0.5</max_velocity>
-        <min_acceleration>-1</min_acceleration>
-        <min_velocity>-0.5</min_velocity>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
         <!-- no odom_publisher_frequency defaults to 50 Hz -->
       </plugin>
 


### PR DESCRIPTION

# 🎉 New feature

Closes #1227

## Summary
`min_velocity` is now separated into `min_linear_velocity` and `min_angular_velocity`. Same for other parameters.

## Test it
Use DiffDrive plugin with the new parameter tags. i.e. `<min_linear_velocity>1.0</min_linear_velocity>`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
