### PR TITLE
Docker fixs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -69,25 +69,25 @@ distribution using debians.
 **Steps**
 
 1. Build a docker image using the `build.bash` command. The first argument
-   must be the name of the Ignition distribution. For example, to build an
-   image of Ignition Blueprint:
+   must be the name of the Ignition distribution. The list of Ignition distribution can be found at [Ignition distribution](https://ignitionrobotics.org/docs). For example, to build an
+   image of Ignition Fortress:
 
     ```
-    ./build.bash ignition-blueprint ./Dockerfile.ignition
+    ./build.bash ignition-fortress ./Dockerfile.ignition
     ```
 
 2. Run the docker image using `run.bash`, and pass in the name of the docker
    image (first argument to the build.bash script).
 
     ```
-    ./run.bash ignition-blueprint
+    ./run.bash ignition-fortress
     ```
 
 3. You can pass arguments to Ignition Gazebo by appending them the
    `run.bash` command. For example, to load the shapes.sdf file:
 
     ```
-    ./run.bash ignition-blueprint -f shapes.sdf
+    ./run.bash ignition-fortress -f shapes.sdf
     ```
 
 ## Appendix

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -14,7 +14,7 @@ fi
 user_id=$(id -u)
 image_name=$1
 dir_name=$(dirname $2)
-image_plus_tag=$image_name:$(date +%Y_%b_%d_%H%M)
+image_plus_tag=$image_name:$(date +%Y_%m_%d_%H%M)
 
 docker build --rm -t $image_plus_tag --build-arg user_id=$user_id --build-arg ign_distribution=$1 -f $2 .
 docker tag $image_plus_tag $image_name:latest


### PR DESCRIPTION
# 🦟 Bug fix

Fix unaccepted caracters on docker tagging : 
```
docker tag ubuntu:latest test:$(date +%Y_%b_%d_%H%M)
Error parsing reference: "test:2021_déc._07_2129" is not a valid repository/tag: invalid reference format
```
using %b from date on a french computer output déc for December and the é isn't accepted on docker image tag.


## Summary

The fix change the image tag to number only. 
The second commit update the readme info to the latest Ignition distribution and give a link on where to find distribution name.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

