### PR TITLE
Fix ViewAngle's size

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.qml
+++ b/src/gui/plugins/view_angle/ViewAngle.qml
@@ -24,7 +24,7 @@ import "qrc:/qml"
 
 ColumnLayout {
   Layout.minimumWidth: 320
-  Layout.minimumHeight: 380
+  Layout.minimumHeight: 530
   anchors.fill: parent
 
   ToolBar {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

We added more fields to `ViewAngle` but didn't increase its minimum size. This means that if a plugin is added under it, the widget ends up compressed and we can't see the bottom options.

Before | After
-- | --
![before_vq](https://user-images.githubusercontent.com/5751272/145128749-f6b93d6c-5fac-4b7c-80ab-bac0be53b2b3.gif) | ![after_va](https://user-images.githubusercontent.com/5751272/145128765-49a5947b-f852-41f5-9c07-5438776bfa0e.gif)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
