### PR TITLE
Implement /server_control::stop

### DIFF
--- a/include/ignition/gazebo/Server.hh
+++ b/include/ignition/gazebo/Server.hh
@@ -89,6 +89,10 @@ namespace ignition
     ///   3. `/gazebo/resource_paths/add` : ignition::msgs::Empty
     ///     + Add new resource paths.
     ///
+    ///   4. `/server_control`(ignition::msgs::ServerControl) :
+    ///         ignition::msgs::Boolean
+    ///     + Control the simulation server.
+    ///
     /// ## Topics
     ///
     /// The following are topics provided by the Server.

--- a/include/ignition/gazebo/gui/TmpIface.hh
+++ b/include/ignition/gazebo/gui/TmpIface.hh
@@ -63,15 +63,6 @@ namespace ignition
       /// \param[in] _path Path to world file.
       public slots: void OnSaveWorldAs(const QString &_path);
 
-      /// \brief Server control service callback
-      /// This is the server-side logic which provides the world_control
-      /// service.
-      /// \param[in] _req Request
-      /// \param[out] _res Response
-      /// \return True for success
-      private: bool OnServerControl(const msgs::ServerControl &_req,
-                                          msgs::Boolean &_res);
-
       /// \brief Communication node
       private: transport::Node node;
 

--- a/include/ignition/gazebo/gui/TmpIface.hh
+++ b/include/ignition/gazebo/gui/TmpIface.hh
@@ -63,6 +63,15 @@ namespace ignition
       /// \param[in] _path Path to world file.
       public slots: void OnSaveWorldAs(const QString &_path);
 
+      /// \brief This function does nothing and is kept only for retaining ABI
+      /// compatibility. /server_control service handling was moved to
+      /// ServerPrivate.
+      /// \param[in] _req Request
+      /// \param[out] _res Response
+      /// \return False.
+      private: bool IGN_DEPRECATED(3) OnServerControl(
+        const msgs::ServerControl &_req, msgs::Boolean &_res);
+
       /// \brief Communication node
       private: transport::Node node;
 

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -419,6 +419,19 @@ void ServerPrivate::SetupTransport()
     ignerr << "Something went wrong, failed to advertise [" << pathTopic
            << "]" << std::endl;
   }
+
+  std::string serverControlService{"/server_control"};
+  if (this->node.Advertise(serverControlService,
+                           &ServerPrivate::ServerControlService, this))
+  {
+    ignmsg << "Server control service on [" << serverControlService << "]."
+           << std::endl;
+  }
+  else
+  {
+    ignerr << "Something went wrong, failed to advertise ["
+           << serverControlService << "]" << std::endl;
+  }
 }
 
 //////////////////////////////////////////////////
@@ -431,6 +444,42 @@ bool ServerPrivate::WorldsService(ignition::msgs::StringMsg_V &_res)
   for (const auto &name : this->worldNames)
   {
     _res.add_data(name);
+  }
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool ServerPrivate::ServerControlService(
+  const ignition::msgs::ServerControl &_req, msgs::Boolean &_res)
+{
+  _res.set_data(false);
+
+  if (_req.stop())
+  {
+    this->Stop();
+    _res.set_data(true);
+  }
+
+  // TODO(anyone): implement world cloning
+  if (_req.clone() || _req.new_port() != 0 || !_req.save_world_name().empty())
+  {
+    ignerr << "ServerControl::clone is not implemented" << std::endl;
+    _res.set_data(false);
+  }
+
+  // TODO(anyone): implement adding a new world
+  if (_req.new_world())
+  {
+    ignerr << "ServerControl::new_world is not implemented" << std::endl;
+    _res.set_data(false);
+  }
+
+  // TODO(anyone): implement loading a world
+  if (!_req.open_filename().empty())
+  {
+    ignerr << "ServerControl::open_filename is not implemented" << std::endl;
+    _res.set_data(false);
   }
 
   return true;

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -100,6 +100,10 @@ ServerPrivate::~ServerPrivate()
   {
     this->runThread.join();
   }
+  if (this->stopThread && this->stopThread->joinable())
+  {
+    this->stopThread->join();
+  }
 }
 
 //////////////////////////////////////////////////
@@ -457,7 +461,14 @@ bool ServerPrivate::ServerControlService(
 
   if (_req.stop())
   {
-    this->Stop();
+    if (!this->stopThread)
+    {
+      this->stopThread.reset(new std::thread([this]{
+        ignlog << "Stopping Gazebo" << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        this->Stop();
+      }));
+    }
     _res.set_data(true);
   }
 

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -463,11 +463,11 @@ bool ServerPrivate::ServerControlService(
   {
     if (!this->stopThread)
     {
-      this->stopThread.reset(new std::thread([this]{
+      this->stopThread = std::make_shared<std::thread>([this]{
         ignlog << "Stopping Gazebo" << std::endl;
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         this->Stop();
-      }));
+      });
     }
     _res.set_data(true);
   }

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -461,21 +461,21 @@ bool ServerPrivate::ServerControlService(
     _res.set_data(true);
   }
 
-  // TODO(anyone): implement world cloning
+  // TODO(chapulina): implement world cloning
   if (_req.clone() || _req.new_port() != 0 || !_req.save_world_name().empty())
   {
     ignerr << "ServerControl::clone is not implemented" << std::endl;
     _res.set_data(false);
   }
 
-  // TODO(anyone): implement adding a new world
+  // TODO(chapulina): implement adding a new world
   if (_req.new_world())
   {
     ignerr << "ServerControl::new_world is not implemented" << std::endl;
     _res.set_data(false);
   }
 
-  // TODO(anyone): implement loading a world
+  // TODO(chapulina): implement loading a world
   if (!_req.open_filename().empty())
   {
     ignerr << "ServerControl::open_filename is not implemented" << std::endl;

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -39,6 +39,8 @@
 
 #include <ignition/transport/Node.hh>
 
+#include <ignition/msgs/server_control.pb.h>
+
 #include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/Export.hh"
 #include "ignition/gazebo/ServerConfig.hh"
@@ -113,6 +115,13 @@ namespace ignition
       /// \param[out] _res Response filled with all current paths.
       /// \return True if successful.
       private: bool ResourcePathsService(ignition::msgs::StringMsg_V &_res);
+
+      /// \brief Callback for server control service.
+      /// \param[out] _req The control request.
+      /// \param[out] _res Whether the request was successfully fullfilled.
+      /// \return True if successful.
+      private: bool ServerControlService(
+        const ignition::msgs::ServerControl &_req, msgs::Boolean &_res);
 
       /// \brief A pool of worker threads.
       public: common::WorkerPool workerPool{2};

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -139,6 +139,9 @@ namespace ignition
       /// \brief Thread that executes systems.
       public: std::thread runThread;
 
+      /// \brief Thread that shuts down the system.
+      public: std::shared_ptr<std::thread> stopThread;
+
       /// \brief Our signal handler.
       public: ignition::common::SignalHandler sigHandler;
 

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -620,6 +620,64 @@ TEST_P(ServerFixture, SigInt)
 }
 
 /////////////////////////////////////////////////
+TEST_P(ServerFixture, ServerControlStop)
+{
+  // Test that the server correctly reacts to requests on /server_control
+  // service with `stop` set to either false or true.
+
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run forever, non-blocking.
+  server.Run(false, 0, false);
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_TRUE(server.Running());
+  EXPECT_TRUE(*server.Running(0));
+
+  transport::Node node;
+  msgs::ServerControl req;
+  msgs::Boolean res;
+  bool result{false};
+  bool executed{false};
+  int sleep{0};
+  int maxSleep{30};
+
+  // first, call with stop = false; the server should keep running
+  while (!executed && sleep < maxSleep)
+  {
+    igndbg << "Requesting /server_control" << std::endl;
+    executed = node.Request("/server_control", req, 100, res, result);
+    sleep++;
+  }
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_FALSE(res.data());
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_TRUE(server.Running());
+  EXPECT_TRUE(*server.Running(0));
+
+  // now call with stop = true; the server should stop
+  req.set_stop(true);
+
+  igndbg << "Requesting /server_control" << std::endl;
+  executed = node.Request("/server_control", req, 100, res, result);
+
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(res.data());
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
 TEST_P(ServerFixture, TwoServersNonBlocking)
 {
   ignition::gazebo::ServerConfig serverConfig;

--- a/src/gui/TmpIface.cc
+++ b/src/gui/TmpIface.cc
@@ -27,6 +27,16 @@ TmpIface::TmpIface()
 {
 }
 
+
+/////////////////////////////////////////////////
+bool TmpIface::OnServerControl(const msgs::ServerControl &_req,
+                                     msgs::Boolean &_res)
+{
+  ignerr << "Called wrong /server_control callback. Call the one in "
+         << "ServerPrivate instead." << std::endl;
+  return false;
+}
+
 /////////////////////////////////////////////////
 void TmpIface::OnNewWorld()
 {

--- a/src/gui/TmpIface.cc
+++ b/src/gui/TmpIface.cc
@@ -25,24 +25,6 @@ using namespace gazebo;
 /////////////////////////////////////////////////
 TmpIface::TmpIface()
 {
-  // Server control
-  this->node.Advertise("/server_control",
-      &TmpIface::OnServerControl, this);
-}
-
-/////////////////////////////////////////////////
-bool TmpIface::OnServerControl(const msgs::ServerControl &_req,
-                                     msgs::Boolean &_res)
-{
-  igndbg << "OnServerControl: request" << std::endl;
-  igndbg << _req.DebugString() << std::endl;
-
-  _res.set_data(true);
-
-  igndbg << "OnServerControl: response" << std::endl;
-  igndbg << _res.DebugString() << std::endl;
-
-  return true;
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/TmpIface.cc
+++ b/src/gui/TmpIface.cc
@@ -29,8 +29,8 @@ TmpIface::TmpIface()
 
 
 /////////////////////////////////////////////////
-bool TmpIface::OnServerControl(const msgs::ServerControl &_req,
-                                     msgs::Boolean &_res)
+bool TmpIface::OnServerControl(const msgs::ServerControl &/*_req*/,
+                                     msgs::Boolean &/*_res*/)
 {
   ignerr << "Called wrong /server_control callback. Call the one in "
          << "ServerPrivate instead." << std::endl;


### PR DESCRIPTION
# 🎉 New feature

Closes #1237

## Summary
Implemented the `stop` part of `/server_control` service.

## Test it
1. `ign gazebo -v4`
2. `ign service -s /server_control --reqtype ignition.msgs.ServerControl --reptype ignition.msgs.Boolean --timeout 1000 --req 'stop: 1'`
3. The server should stop and exit in a while.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**