### PR TITLE
Add visibility to ModelEditorAddEntity to fix Windows

### DIFF
--- a/include/ignition/gazebo/gui/GuiEvents.hh
+++ b/include/ignition/gazebo/gui/GuiEvents.hh
@@ -181,7 +181,7 @@ namespace events
   };
 
   /// \brief Event that notifies an entity is to be added to the model editor
-  class ModelEditorAddEntity : public QEvent
+  class IGNITION_GAZEBO_GUI_VISIBLE ModelEditorAddEntity : public QEvent
   {
     /// \brief Constructor
     /// \param[in] _entity Entity added


### PR DESCRIPTION
# 🦟 Bug fix

Fixes problem with Windows compilation after #1231 

## Summary
[Jenkins for ign-gazebo6](https://build.osrfoundation.org/job/ign_gazebo-ign-6-win/36/consoleFull#-17948050678ff58640-3599-4406-a210-216932f1748c) branch was not happy after #1231 on Windows.

MSVC complains about:


> ComponentInspectorEditor.obj : error LNK2001: unresolved external symbol "public: class QMap<class QString,class QString> & __cdecl ignition::gazebo::gui::v6::events::ModelEditorAddEntity::Data(void)" (?Data@ModelEditorAddEntity@events@v6@gui@gazebo@ignition@@QEAAAEAV?$QMap@VQString@@V1@@@XZ) [C:\Jenkins\workspace\ign_gazebo-ign-6-win\ws\build\ignition-gazebo6\src\gui\plugins\component_inspector_editor\ComponentInspectorEditor.vcxproj]
> ComponentInspectorEditor.obj : error LNK2001: unresolved external symbol "public: __cdecl ignition::gazebo::gui::v6::events::ModelEditorAddEntity::ModelEditorAddEntity(class QString,class QString,unsigned __int64)" (??0ModelEditorAddEntity@events@v6@gui@gazebo@ignition@@QEAA@VQString@@0_K@Z) [C:\Jenkins\workspace\ign_gazebo-ign-6-win\ws\build\ignition-gazebo6\src\gui\plugins\component_inspector_editor\ComponentInspectorEditor.vcxproj]
> ModelEditor.obj : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl ignition::gazebo::gui::v6::events::ModelEditorAddEntity::ParentEntity(void)const " (?ParentEntity@ModelEditorAddEntity@events@v6@gui@gazebo@ignition@@QEBA_KXZ) [C:\Jenkins\workspace\ign_gazebo-ign-6-win\ws\build\ignition-gazebo6\src\gui\plugins\component_inspector_editor\ComponentInspectorEditor.vcxproj]
> ModelEditor.obj : error LNK2001: unresolved external symbol "public: class QString __cdecl ignition::gazebo::gui::v6::events::ModelEditorAddEntity::EntityType(void)const " (?EntityType@ModelEditorAddEntity@events@v6@gui@gazebo@ignition@@QEBA?AVQString@@XZ) [C:\Jenkins\workspace\ign_gazebo-ign-6-win\ws\build\ignition-gazebo6\src\gui\plugins\component_inspector_editor\ComponentInspectorEditor.vcxproj]
> ModelEditor.obj : error LNK2001: unresolved external symbol "public: class QString __cdecl ignition::gazebo::gui::v6::events::ModelEditorAddEntity::Entity(void)const " (?Entity@ModelEditorAddEntity@events@v6@gui@gazebo@ignition@@QEBA?AVQString@@XZ) [C:\Jenkins\workspace\ign_gazebo-ign-6-win\ws\build\ignition-gazebo6\src\gui\plugins\component_inspector_editor\ComponentInspectorEditor.vcxproj]

Seems clear to me that `ModelEditorAddEntity`class added in #1231 is somehow problematic when the rest of classes are trying to link against it. I'm adding the same visibility that the rest of the header in this PR. Let's see if that is enough.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
