### PR TITLE
Support world reset

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -49,6 +49,7 @@ namespace ignition
     inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     // Forward declarations.
     class IGNITION_GAZEBO_HIDDEN EntityComponentManagerPrivate;
+    class EntityComponentManagerDiff;
 
     /// \brief Type alias for the graph that holds entities.
     /// Each vertex is an entity, and the direction points from the parent to
@@ -70,6 +71,8 @@ namespace ignition
 
       /// \brief Destructor
       public: ~EntityComponentManager();
+
+      public: void Copy(const EntityComponentManager &_fromEcm);
 
       /// \brief Creates a new Entity.
       /// \return An id for the Entity, or kNullEntity on failure.
@@ -669,6 +672,13 @@ namespace ignition
       /// \param[in] _offset Offset value.
       public: void SetEntityCreateOffset(uint64_t _offset);
 
+      /// \brief Given a diff, apply it to this ECM. Note that for removed
+      /// entities, this would mark them for removal instead of actually
+      /// removing the entities.
+      /// \param[in] _other Original EntityComponentManager from which the diff
+      /// was computed.
+      public: void ResetTo(const EntityComponentManager &_other);
+
       /// \brief Return true if there are components marked for removal.
       /// \return True if there are components marked for removal.
       public: bool HasRemovedComponents() const;
@@ -689,6 +699,24 @@ namespace ignition
 
       /// \brief Mark all components as not changed.
       protected: void SetAllComponentsUnchanged();
+
+      /// Compute the diff between this EntityComponentManager and _other at the
+      /// entity level.
+      ///  * If an entity is in `_other`, but not in `this`, insert the entity
+      ///  as an "added" entity.
+      ///  * If an entity is in `this`, but not in `other`, insert the entity
+      ///  as a "removed" entity.
+      ///  \return Data structure containing the added and removed entities
+      protected: EntityComponentManagerDiff ComputeDiff(
+                     const EntityComponentManager &_other) const;
+
+      /// \brief Given a diff, apply it to this ECM. Note that for removed
+      /// entities, this would mark them for removal instead of actually
+      /// removing the entities.
+      /// \param[in] _other Original EntityComponentManager from which the diff
+      /// was computed.
+      protected: void ApplyDiff(const EntityComponentManager &_other,
+                                const EntityComponentManagerDiff &_diff);
 
       /// \brief Get whether an Entity exists and is new.
       ///

--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -72,7 +72,13 @@ namespace ignition
       /// \brief Destructor
       public: ~EntityComponentManager();
 
-      public: void Copy(const EntityComponentManager &_fromEcm);
+      /// \brief Copies the contents of `_from` into this object.
+      /// \note This is a member function instead of a copy constructor so that
+      /// it can have additional parameters if the need arises in the future.
+      /// Additionally, not every data member is copied making its behavior
+      /// different from what would be expected from a copy constructor.
+      /// \param[in] _from Object to copy from
+      public: void CopyFrom(const EntityComponentManager &_fromEcm);
 
       /// \brief Creates a new Entity.
       /// \return An id for the Entity, or kNullEntity on failure.
@@ -701,22 +707,23 @@ namespace ignition
       protected: void SetAllComponentsUnchanged();
 
       /// Compute the diff between this EntityComponentManager and _other at the
-      /// entity level.
+      /// entity level. This does not compute the diff between components of an
+      /// entity.
       ///  * If an entity is in `_other`, but not in `this`, insert the entity
       ///  as an "added" entity.
       ///  * If an entity is in `this`, but not in `other`, insert the entity
       ///  as a "removed" entity.
       ///  \return Data structure containing the added and removed entities
-      protected: EntityComponentManagerDiff ComputeDiff(
+      protected: EntityComponentManagerDiff ComputeEntityDiff(
                      const EntityComponentManager &_other) const;
 
-      /// \brief Given a diff, apply it to this ECM. Note that for removed
-      /// entities, this would mark them for removal instead of actually
+      /// \brief Given an entity diff, apply it to this ECM. Note that for
+      /// removed entities, this would mark them for removal instead of actually
       /// removing the entities.
       /// \param[in] _other Original EntityComponentManager from which the diff
       /// was computed.
-      protected: void ApplyDiff(const EntityComponentManager &_other,
-                                const EntityComponentManagerDiff &_diff);
+      protected: void ApplyEntityDiff(const EntityComponentManager &_other,
+                                      const EntityComponentManagerDiff &_diff);
 
       /// \brief Get whether an Entity exists and is new.
       ///

--- a/include/ignition/gazebo/System.hh
+++ b/include/ignition/gazebo/System.hh
@@ -100,6 +100,11 @@ namespace ignition
                   EventManager &_eventMgr) = 0;
     };
 
+    class ISystemReset {
+      public: virtual void Reset(const UpdateInfo &_info,
+                                 EntityComponentManager &_ecm) = 0;
+    };
+
     /// \class ISystemPreUpdate ISystem.hh ignition/gazebo/System.hh
     /// \brief Interface for a system that uses the PreUpdate phase
     class ISystemPreUpdate {

--- a/include/ignition/gazebo/detail/BaseView.hh
+++ b/include/ignition/gazebo/detail/BaseView.hh
@@ -18,6 +18,7 @@
 #define IGNITION_GAZEBO_DETAIL_BASEVIEW_HH_
 
 #include <cstddef>
+#include <memory>
 #include <set>
 #include <unordered_map>
 #include <vector>
@@ -186,6 +187,8 @@ class IGNITION_GAZEBO_VISIBLE BaseView
   /// added to the view are actually added to the view.
   /// \sa ToAddEntities
   public: void ClearToAddEntities();
+
+  public: virtual std::unique_ptr<BaseView> Clone() const = 0;
 
   // TODO(adlarkin) make this a std::unordered_set for better performance.
   // We need to make sure nothing else depends on the ordered preserved by

--- a/include/ignition/gazebo/detail/View.hh
+++ b/include/ignition/gazebo/detail/View.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_DETAIL_VIEW_HH_
 #define IGNITION_GAZEBO_DETAIL_VIEW_HH_
 
+#include <memory>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -104,6 +105,8 @@ class View : public BaseView
 
   /// \brief Documentation inherited
   public: void Reset() override;
+
+  public: std::unique_ptr<BaseView> Clone() const override;
 
   /// \brief A map of entities to their component data. Since tuples are defined
   /// at compile time, we need separate containers that have tuples for both
@@ -328,6 +331,13 @@ void View<ComponentTypeTs...>::Reset()
   this->invalidData.clear();
   this->invalidConstData.clear();
   this->missingCompTracker.clear();
+}
+
+//////////////////////////////////////////////////
+template<typename ...ComponentTypeTs>
+std::unique_ptr<BaseView> View<ComponentTypeTs...>::Clone() const
+{
+  return std::make_unique<View<ComponentTypeTs...>>(*this);
 }
 }  // namespace detail
 }  // namespace IGNITION_GAZEBO_VERSION_NAMESPACE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set (sources
   BaseView.cc
   Conversions.cc
   EntityComponentManager.cc
+  EntityComponentManagerDiff.cc
   LevelManager.cc
   Link.cc
   Model.cc

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -16,6 +16,7 @@
 */
 
 #include "ignition/gazebo/EntityComponentManager.hh"
+#include "EntityComponentManagerDiff.hh"
 
 #include <map>
 #include <memory>
@@ -70,6 +71,8 @@ class ignition::gazebo::EntityComponentManagerPrivate
   /// \brief Allots the work for multiple threads prior to running
   /// `AddEntityToMessage`.
   public: void CalculateStateThreadLoad();
+
+  public: void Copy(const EntityComponentManagerPrivate &_from);
 
   /// \brief Create a message for the removed components
   /// \param[in] _entity Entity with the removed components
@@ -286,6 +289,47 @@ EntityComponentManager::EntityComponentManager()
 
 //////////////////////////////////////////////////
 EntityComponentManager::~EntityComponentManager() = default;
+
+// //////////////////////////////////////////////////
+// EntityComponentManager::EntityComponentManager(
+//     EntityComponentManager &&_ecm) noexcept = default;
+
+//////////////////////////////////////////////////
+void EntityComponentManagerPrivate::Copy(
+    const EntityComponentManagerPrivate &_from)
+{
+  this->createdCompTypes = _from.createdCompTypes;
+  this->entities = _from.entities;
+  this->periodicChangedComponents = _from.periodicChangedComponents;
+  this->oneTimeChangedComponents = _from.oneTimeChangedComponents;
+  this->newlyCreatedEntities = _from.newlyCreatedEntities;
+  this->toRemoveEntities = _from.toRemoveEntities;
+  this->modifiedComponents = _from.modifiedComponents;
+  this->removeAllEntities = _from.removeAllEntities;
+  this->views.clear();
+  this->lockAddEntitiesToViews = _from.lockAddEntitiesToViews;
+  this->descendantCache.clear();
+  this->entityCount = _from.entityCount;
+  this->removedComponents = _from.removedComponents;
+  this->componentsMarkedAsRemoved = _from.componentsMarkedAsRemoved;
+
+  for (const auto &[entity, comps] : _from.componentStorage)
+  {
+    this->componentStorage[entity].clear();
+    for (const auto &comp : comps)
+    {
+      this->componentStorage[entity].emplace_back(comp->Clone());
+    }
+  }
+  this->componentTypeIndex = _from.componentTypeIndex;
+  this->componentTypeIndexIterators.clear();
+  this->componentTypeIndexDirty = true;
+
+  // Not copying maps related to cloning since they are transient variables
+  // that are used as return values of some member functions.
+
+  this->pinnedEntities = _from.pinnedEntities;
+}
 
 //////////////////////////////////////////////////
 size_t EntityComponentManager::EntityCount() const
@@ -2067,4 +2111,104 @@ void EntityComponentManager::UnpinEntity(const Entity _entity, bool _recursive)
 void EntityComponentManager::UnpinAllEntities()
 {
   this->dataPtr->pinnedEntities.clear();
+}
+
+/////////////////////////////////////////////////
+void EntityComponentManager::Copy(const EntityComponentManager &_fromEcm)
+{
+  this->dataPtr->Copy(*_fromEcm.dataPtr);
+}
+
+/////////////////////////////////////////////////
+EntityComponentManagerDiff EntityComponentManager::ComputeDiff(
+    const EntityComponentManager &_other) const
+{
+  EntityComponentManagerDiff diff;
+  for (const auto &item : _other.dataPtr->entities.Vertices())
+  {
+    const auto &v = item.second.get();
+    if (!this->dataPtr->entities.VertexFromId(v.Id()).Valid())
+    {
+      // In `_other` but not in `this`, so insert the entity as an "added"
+      // entity.
+      diff.InsertAddedEntity(v.Data());
+    }
+  }
+
+  for (const auto &item : this->dataPtr->entities.Vertices())
+  {
+    const auto &v = item.second.get();
+    if (!_other.dataPtr->entities.VertexFromId(v.Id()).Valid())
+    {
+      // In `this` but not in `other`, so insert the entity as a "removed"
+      // entity.
+      diff.InsertRemovedEntity(v.Data());
+    }
+  }
+  return diff;
+}
+
+/////////////////////////////////////////////////
+void EntityComponentManager::ApplyDiff(const EntityComponentManager &_other,
+                                       const EntityComponentManagerDiff &_diff)
+{
+  auto copyComponents = [&](Entity _entity)
+  {
+    for (const auto compTypeId : _other.ComponentTypes(_entity))
+    {
+      const components::BaseComponent *data =
+          _other.ComponentImplementation(_entity, compTypeId);
+      this->CreateComponentImplementation(_entity, compTypeId,
+                                          data->Clone().get());
+    }
+  };
+
+  for(auto entity : _diff.AddedEntities())
+  {
+    if (!this->HasEntity(entity))
+    {
+      this->dataPtr->CreateEntityImplementation(entity);
+      if (entity >= this->dataPtr->entityCount)
+      {
+        this->dataPtr->entityCount = entity;
+      }
+      copyComponents(entity);
+      this->SetParentEntity(entity, _other.ParentEntity(entity));
+    }
+  }
+
+  for (const auto &entity : _diff.RemovedEntities())
+  {
+    // if the entity is not in this ECM, add it before requesting for its
+    // removal.
+    if (!this->HasEntity(entity))
+    {
+      this->dataPtr->CreateEntityImplementation(entity);
+      this->RequestRemoveEntity(entity, false);
+      // We want to set this entity as "removed", but
+      // CreateEntityImplementation sets it as "newlyCreated",
+      // so remove it from that list.
+      {
+        std::lock_guard<std::mutex> lock(this->dataPtr->entityCreatedMutex);
+        this->dataPtr->newlyCreatedEntities.erase(entity);
+      }
+      // Copy components so that EachRemoved match correctly
+      if (entity >= this->dataPtr->entityCount)
+      {
+        this->dataPtr->entityCount = entity;
+      }
+      copyComponents(entity);
+      this->SetParentEntity(entity, _other.ParentEntity(entity));
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+void EntityComponentManager::ResetTo(const EntityComponentManager &_other)
+{
+  auto ecmDiff = this->ComputeDiff(_other);
+  EntityComponentManager tmpCopy;
+  tmpCopy.Copy(_other);
+  tmpCopy.ApplyDiff(*this, ecmDiff);
+  this->Copy(tmpCopy);
 }

--- a/src/EntityComponentManagerDiff.cc
+++ b/src/EntityComponentManagerDiff.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "EntityComponentManagerDiff.hh"
+
+#include "ignition/gazebo/Entity.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+//////////////////////////////////////////////////
+void EntityComponentManagerDiff::InsertAddedEntity(const Entity &_entity)
+{
+  this->addedEntities.push_back(_entity);
+}
+
+//////////////////////////////////////////////////
+void EntityComponentManagerDiff::InsertRemovedEntity(const Entity &_entity)
+{
+  this->removedEntities.push_back(_entity);
+}
+
+//////////////////////////////////////////////////
+const std::vector<Entity> &EntityComponentManagerDiff::AddedEntities() const
+{
+  return this->addedEntities;
+}
+
+//////////////////////////////////////////////////
+const std::vector<Entity> &EntityComponentManagerDiff::RemovedEntities() const
+{
+  return this->removedEntities;
+}
+
+//////////////////////////////////////////////////
+void EntityComponentManagerDiff::ClearAddedEntities()
+{
+  this->addedEntities.clear();
+}
+
+//////////////////////////////////////////////////
+void EntityComponentManagerDiff::ClearRemovedEntities()
+{
+  this->removedEntities.clear();
+}

--- a/src/EntityComponentManagerDiff.hh
+++ b/src/EntityComponentManagerDiff.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef IGNITION_GAZEBO_ENTITYCOMPONENTMANAGER_DIFF_HH_
+#define IGNITION_GAZEBO_ENTITYCOMPONENTMANAGER_DIFF_HH_
+
+#include "ignition/gazebo/Entity.hh"
+#include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/Types.hh"
+
+#include <vector>
+
+namespace ignition
+{
+  namespace gazebo
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+
+    class EntityComponentManagerDiff
+    {
+      public: void InsertAddedEntity(const Entity &_entity);
+      public: void InsertRemovedEntity(const Entity &_entity);
+
+      public: const std::vector<Entity> &RemovedEntities() const;
+      public: const std::vector<Entity> &AddedEntities() const;
+
+      public: void ClearAddedEntities();
+      public: void ClearRemovedEntities();
+
+      private: std::vector<Entity> addedEntities;
+      private: std::vector<Entity> removedEntities;
+    };
+  }
+  }
+}
+
+#endif

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -35,6 +35,7 @@
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/config.hh"
+#include "EntityComponentManagerDiff.hh"
 #include "../test/helpers/EnvTestFixture.hh"
 
 using namespace ignition;
@@ -105,6 +106,18 @@ class EntityCompMgrTest : public EntityComponentManager
   public: void RunClearRemovedComponents()
   {
     this->ClearRemovedComponents();
+  }
+
+  public: EntityComponentManagerDiff RunComputeDiff(
+              const EntityComponentManager &_other) const
+  {
+    return this->ComputeDiff(_other);
+  }
+
+  public: void RunApplyDiff(const EntityComponentManager &_other,
+                            const EntityComponentManagerDiff &_diff)
+  {
+    this->ApplyDiff(_other, _diff);
   }
 };
 
@@ -3148,6 +3161,167 @@ TEST_P(EntityComponentManagerFixture,
         return true;
       });
   EXPECT_EQ(1, foundEntities);
+}
+
+TEST_P(EntityComponentManagerFixture, CopyEcm)
+{
+  Entity entity = manager.CreateEntity();
+  math::Pose3d testPose{1, 2, 3, 0.1, 0.2, 0.3};
+  manager.CreateComponent(entity, components::Pose{testPose});
+
+  EntityCompMgrTest managerCopy;
+  managerCopy.Copy(manager);
+  EXPECT_EQ(manager.EntityCount(), managerCopy.EntityCount());
+  EXPECT_TRUE(managerCopy.HasEntity(entity));
+  EXPECT_TRUE(
+      managerCopy.EntityHasComponentType(entity, components::Pose::typeId));
+  managerCopy.EachNew<components::Pose>(
+      [&](const Entity &_entity, const components::Pose *_pose)
+      {
+        EXPECT_EQ(_entity, entity);
+        EXPECT_EQ(testPose, _pose->Data());
+        return true;
+      });
+}
+
+TEST_P(EntityComponentManagerFixture, ComputDiff)
+{
+  Entity entity1 = manager.CreateEntity();
+  math::Pose3d testPose{1, 2, 3, 0.1, 0.2, 0.3};
+  manager.CreateComponent(entity1, components::Pose{testPose});
+
+  EntityCompMgrTest managerCopy;
+  managerCopy.Copy(manager);
+
+  Entity entity2 = manager.CreateEntity();
+  manager.CreateComponent(entity2, components::StringComponent{"Entity2"});
+
+  manager.RunClearNewlyCreatedEntities();
+
+  // manager now has:
+  // - entity1 [Pose]
+  // - entity2 [StringComponent]
+  // managerCopy has
+  // - entity1 [Pose]
+
+  {
+    EntityComponentManagerDiff diff = managerCopy.RunComputeDiff(manager);
+    EXPECT_EQ(1u, diff.AddedEntities().size());
+    EXPECT_EQ(0u, diff.RemovedEntities().size());
+  }
+
+  // Now add another component to managerCopy. We should expect one more entity
+  // in RemovedEntities
+  managerCopy.SetEntityCreateOffset(10);
+  managerCopy.CreateEntity();
+  {
+    EntityComponentManagerDiff diff = managerCopy.RunComputeDiff(manager);
+    EXPECT_EQ(1u, diff.AddedEntities().size());
+    EXPECT_EQ(1u, diff.RemovedEntities().size());
+
+    diff.ClearRemovedEntities();
+    EXPECT_EQ(1u, diff.AddedEntities().size());
+    EXPECT_EQ(0u, diff.RemovedEntities().size());
+  }
+
+  {
+    EntityComponentManagerDiff diff = managerCopy.RunComputeDiff(manager);
+    EXPECT_EQ(1u, diff.RemovedEntities().size());
+    managerCopy.RunApplyDiff(manager, diff);
+    EXPECT_TRUE(managerCopy.HasEntitiesMarkedForRemoval());
+  }
+}
+
+TEST_P(EntityComponentManagerFixture, ResetToWithDeletedEntity)
+{
+  Entity entity1 = manager.CreateEntity();
+  math::Pose3d testPose{1, 2, 3, 0.1, 0.2, 0.3};
+  manager.CreateComponent(entity1, components::Pose{testPose});
+  manager.CreateComponent(entity1, components::Name{"entity1"});
+
+  Entity entity2 = manager.CreateEntity();
+  manager.CreateComponent(entity2, components::Name{"entity2"});
+
+  {
+    std::vector<Entity> newEntities;
+    manager.EachNew<components::Name>(
+        [&](const Entity &_entity, const components::Name *)
+        {
+          newEntities.push_back(_entity);
+          return true;
+        });
+    ASSERT_EQ(2u, newEntities.size());
+  }
+
+  EntityCompMgrTest managerCopy;
+  managerCopy.Copy(manager);
+
+  manager.RequestRemoveEntity(entity1);
+
+  // Emulate a step so that entity1 can be actually removed.
+  manager.RunClearNewlyCreatedEntities();
+  manager.ProcessEntityRemovals();
+  manager.RunClearRemovedComponents();
+  manager.RunSetAllComponentsUnchanged();
+
+  EXPECT_FALSE(manager.HasNewEntities());
+
+  // Now reset to the copy
+  manager.ResetTo(managerCopy);
+  EXPECT_TRUE(manager.HasNewEntities());
+
+  {
+    std::vector<Entity> newEntities;
+    manager.EachNew<components::Name>(
+        [&](const Entity &_entity, const components::Name *)
+        {
+          newEntities.push_back(_entity);
+          return true;
+        });
+    ASSERT_EQ(2u, newEntities.size());
+  }
+}
+
+TEST_P(EntityComponentManagerFixture, ResetToWithAddedEntity)
+{
+  Entity entity1 = manager.CreateEntity();
+  math::Pose3d testPose{1, 2, 3, 0.1, 0.2, 0.3};
+  manager.CreateComponent(entity1, components::Pose{testPose});
+  manager.CreateComponent(entity1, components::Name{"entity1"});
+
+  Entity entity2 = manager.CreateEntity();
+  manager.CreateComponent(entity2, components::Name{"entity2"});
+
+  EntityCompMgrTest managerCopy;
+  managerCopy.Copy(manager);
+
+  // Add entity3 after a copy has been made.
+  Entity entity3 = manager.CreateEntity();
+  manager.CreateComponent(entity3, components::Name{"entity3"});
+
+  // Emulate a step so that entity1 can be actually removed.
+  manager.RunClearNewlyCreatedEntities();
+  manager.ProcessEntityRemovals();
+  manager.RunClearRemovedComponents();
+  manager.RunSetAllComponentsUnchanged();
+
+  EXPECT_FALSE(manager.HasNewEntities());
+
+  // Now reset to the copy
+  manager.ResetTo(managerCopy);
+  EXPECT_TRUE(manager.HasNewEntities());
+
+  {
+    std::vector<Entity> removedEntities;
+    manager.EachRemoved<components::Name>(
+        [&](const Entity &_entity, const components::Name *)
+        {
+          removedEntities.push_back(_entity);
+          return true;
+        });
+    ASSERT_EQ(1u, removedEntities.size());
+    EXPECT_EQ(entity3, removedEntities.front());
+  }
 }
 
 // Run multiple times. We want to make sure that static globals don't cause

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -111,13 +111,13 @@ class EntityCompMgrTest : public EntityComponentManager
   public: EntityComponentManagerDiff RunComputeDiff(
               const EntityComponentManager &_other) const
   {
-    return this->ComputeDiff(_other);
+    return this->ComputeEntityDiff(_other);
   }
 
   public: void RunApplyDiff(const EntityComponentManager &_other,
                             const EntityComponentManagerDiff &_diff)
   {
-    this->ApplyDiff(_other, _diff);
+    this->ApplyEntityDiff(_other, _diff);
   }
 };
 
@@ -3170,7 +3170,7 @@ TEST_P(EntityComponentManagerFixture, CopyEcm)
   manager.CreateComponent(entity, components::Pose{testPose});
 
   EntityCompMgrTest managerCopy;
-  managerCopy.Copy(manager);
+  managerCopy.CopyFrom(manager);
   EXPECT_EQ(manager.EntityCount(), managerCopy.EntityCount());
   EXPECT_TRUE(managerCopy.HasEntity(entity));
   EXPECT_TRUE(
@@ -3184,14 +3184,14 @@ TEST_P(EntityComponentManagerFixture, CopyEcm)
       });
 }
 
-TEST_P(EntityComponentManagerFixture, ComputDiff)
+TEST_P(EntityComponentManagerFixture, ComputeDiff)
 {
   Entity entity1 = manager.CreateEntity();
   math::Pose3d testPose{1, 2, 3, 0.1, 0.2, 0.3};
   manager.CreateComponent(entity1, components::Pose{testPose});
 
   EntityCompMgrTest managerCopy;
-  managerCopy.Copy(manager);
+  managerCopy.CopyFrom(manager);
 
   Entity entity2 = manager.CreateEntity();
   manager.CreateComponent(entity2, components::StringComponent{"Entity2"});
@@ -3254,7 +3254,7 @@ TEST_P(EntityComponentManagerFixture, ResetToWithDeletedEntity)
   }
 
   EntityCompMgrTest managerCopy;
-  managerCopy.Copy(manager);
+  managerCopy.CopyFrom(manager);
 
   manager.RequestRemoveEntity(entity1);
 
@@ -3293,7 +3293,7 @@ TEST_P(EntityComponentManagerFixture, ResetToWithAddedEntity)
   manager.CreateComponent(entity2, components::Name{"entity2"});
 
   EntityCompMgrTest managerCopy;
-  managerCopy.Copy(manager);
+  managerCopy.CopyFrom(manager);
 
   // Add entity3 after a copy has been made.
   Entity entity3 = manager.CreateEntity();

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -170,7 +170,7 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   this->levelMgr->UpdateLevelsState();
 
   // Store the initial state of the ECM;
-  this->initialEntityCompMgr.Copy(this->entityCompMgr);
+  this->initialEntityCompMgr.CopyFrom(this->entityCompMgr);
 
   // Load any additional plugins from the Server Configuration
   this->LoadServerPlugins(this->serverConfig.Plugins());
@@ -537,7 +537,7 @@ void SimulationRunner::UpdateSystems()
   if (this->resetInitiated)
   {
     IGN_PROFILE("Reset");
-    for (auto &system : this->systemsReset)
+    for (auto &system : this->systemMgr->SystemsReset())
       system->Reset(this->currentInfo, this->entityCompMgr);
     return;
   }

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -169,6 +169,9 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   // Load the active levels
   this->levelMgr->UpdateLevelsState();
 
+  // Store the initial state of the ECM;
+  this->initialEntityCompMgr.Copy(this->entityCompMgr);
+
   // Load any additional plugins from the Server Configuration
   this->LoadServerPlugins(this->serverConfig.Plugins());
 
@@ -264,7 +267,7 @@ void SimulationRunner::UpdateCurrentInfo()
     this->realTimeWatch.Reset();
     if (!this->currentInfo.paused)
       this->realTimeWatch.Start();
-
+    this->resetInitiated = true;
     this->requestedRewind = false;
 
     return;
@@ -531,6 +534,14 @@ void SimulationRunner::UpdateSystems()
   // WorkerPool.cc). We could turn on parallel updates in the future, and/or
   // turn it on if there are sufficient systems. More testing is required.
 
+  if (this->resetInitiated)
+  {
+    IGN_PROFILE("Reset");
+    for (auto &system : this->systemsReset)
+      system->Reset(this->currentInfo, this->entityCompMgr);
+    return;
+  }
+
   {
     IGN_PROFILE("PreUpdate");
     for (auto& system : this->systemMgr->SystemsPreUpdate())
@@ -748,6 +759,11 @@ bool SimulationRunner::Run(const uint64_t _iterations)
     // Update time information. This will update the iteration count, RTF,
     // and other values.
     this->UpdateCurrentInfo();
+    if (this->resetInitiated)
+    {
+      this->entityCompMgr.ResetTo(this->initialEntityCompMgr);
+    }
+
     if (!this->currentInfo.paused)
     {
       processedIterations++;
@@ -772,6 +788,8 @@ bool SimulationRunner::Run(const uint64_t _iterations)
       this->currentInfo.iterations++;
       this->blockingPausedStepPending = false;
     }
+
+    this->resetInitiated = false;
   }
 
   this->running = false;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -404,6 +404,10 @@ namespace ignition
       /// \brief Manager of all components.
       private: EntityComponentManager entityCompMgr;
 
+      /// \brief Copy of the EntityComponentManager immediately after the
+      /// initial entity creation/world load.
+      private: EntityComponentManager initialEntityCompMgr;
+
       /// \brief Manager of all levels.
       private: std::unique_ptr<LevelManager> levelMgr;
 
@@ -532,6 +536,7 @@ namespace ignition
       /// at the appropriate time.
       private: std::unique_ptr<msgs::WorldControlState> newWorldControlState;
 
+      private: bool resetInitiated{false};
       friend class LevelManager;
     };
     }

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -43,6 +43,7 @@ namespace ignition
               : systemPlugin(std::move(_systemPlugin)),
                 system(systemPlugin->QueryInterface<System>()),
                 configure(systemPlugin->QueryInterface<ISystemConfigure>()),
+                reset(systemPlugin->QueryInterface<ISystemReset>()),
                 preupdate(systemPlugin->QueryInterface<ISystemPreUpdate>()),
                 update(systemPlugin->QueryInterface<ISystemUpdate>()),
                 postupdate(systemPlugin->QueryInterface<ISystemPostUpdate>())
@@ -55,6 +56,7 @@ namespace ignition
               : systemShared(_system),
                 system(_system.get()),
                 configure(dynamic_cast<ISystemConfigure *>(_system.get())),
+                reset(dynamic_cast<ISystemReset *>(_system.get())),
                 preupdate(dynamic_cast<ISystemPreUpdate *>(_system.get())),
                 update(dynamic_cast<ISystemUpdate *>(_system.get())),
                 postupdate(dynamic_cast<ISystemPostUpdate *>(_system.get()))
@@ -76,6 +78,10 @@ namespace ignition
       /// \brief Access this system via the ISystemConfigure interface
       /// Will be nullptr if the System doesn't implement this interface.
       public: ISystemConfigure *configure = nullptr;
+
+      /// \brief Access this system via the ISystemReset interface
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemReset *reset = nullptr;
 
       /// \brief Access this system via the ISystemPreUpdate interface
       /// Will be nullptr if the System doesn't implement this interface.

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -84,6 +84,9 @@ size_t SystemManager::ActivatePendingSystems()
     if (system.configure)
       this->systemsConfigure.push_back(system.configure);
 
+    if (system.reset)
+      this->systemsReset.push_back(system.reset);
+
     if (system.preupdate)
       this->systemsPreupdate.push_back(system.preupdate);
 
@@ -138,6 +141,12 @@ void SystemManager::AddSystemImpl(
 const std::vector<ISystemConfigure *>& SystemManager::SystemsConfigure()
 {
   return this->systemsConfigure;
+}
+
+//////////////////////////////////////////////////
+const std::vector<ISystemReset *>& SystemManager::SystemsReset()
+{
+  return this->systemsReset;
 }
 
 //////////////////////////////////////////////////

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -95,6 +95,9 @@ namespace ignition
       /// \brief Get an vector of all systems implementing "Configure"
       public: const std::vector<ISystemConfigure *>& SystemsConfigure();
 
+      /// \brief Get an vector of all systems implementing "Reset"
+      public: const std::vector<ISystemReset *>& SystemsReset();
+
       /// \brief Get an vector of all systems implementing "PreUpdate"
       public: const std::vector<ISystemPreUpdate *>& SystemsPreUpdate();
 
@@ -125,6 +128,9 @@ namespace ignition
 
       /// \brief Systems implementing Configure
       private: std::vector<ISystemConfigure *> systemsConfigure;
+
+      /// \brief Systems implementing Reset 
+      private: std::vector<ISystemReset *> systemsReset;
 
       /// \brief Systems implementing PreUpdate
       private: std::vector<ISystemPreUpdate *> systemsPreupdate;

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -129,7 +129,7 @@ namespace ignition
       /// \brief Systems implementing Configure
       private: std::vector<ISystemConfigure *> systemsConfigure;
 
-      /// \brief Systems implementing Reset 
+      /// \brief Systems implementing Reset
       private: std::vector<ISystemReset *> systemsReset;
 
       /// \brief Systems implementing PreUpdate

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -918,7 +918,7 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogControl))
     latestSpherePose = spherePose;
   }
 
-  // Rewind
+  // Rewind to zero
   req.Clear();
   req.set_rewind(true);
 
@@ -926,7 +926,7 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogControl))
   EXPECT_TRUE(result);
   EXPECT_TRUE(res.data());
 
-  server.Run(true, 2, false);
+  server.Run(true, 3, false);
 
   EXPECT_TRUE(sphereFound);
   sphereFound = false;


### PR DESCRIPTION
# 🎉 New feature

Toward #1107 

## Summary
This adds a new phase in which systems can implement special Reset functionality. The approach taken is to make an initial copy of the ECM after the entities have been created. When reset is requested, a diff is computed between the current ECM and the initial copy. This is necessary to ensure that entities that were added later on are marked as removed after reset. Likewise, entities that were removed later on are marked as newly added after reset.

The physics system has been updated to make use of the Reset phase. The changes were nontrivial because we keep a lot of state in the physics system to help with performance. Hopefully, updating other systems will be more straightforward.

The Reset API allows systems to make changes to the ECM. This can be used to, for example, change the poses of objects in the scene at every reset without having to reload the the world. As an example, I have created a small and very trivial joint position randomizer.

There things that still need to be cleaned up and tests that need to be added, but I wanted open this as a draft PR to get feedback on the approach.
 
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

