### PR TITLE
Re-enable triggered publisher tests

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -56,9 +56,7 @@ set(tests
   thruster.cc
   touch_plugin.cc
   tracked_vehicle_system.cc
-  # TODO(chapulina) Re-enable this test when parsing `type` attributes is fixed
-  # See https://github.com/ignitionrobotics/sdformat/pull/809
-  # triggered_publisher.cc
+  triggered_publisher.cc
   user_commands.cc
   velocity_control_system.cc
   log_system.cc


### PR DESCRIPTION
# 🦟 Bug fix

* Test had been disabled in https://github.com/ignitionrobotics/ign-gazebo/pull/1264
* Tests should pass now that https://github.com/ignitionrobotics/sdformat/pull/809 is merged

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The tests should pass now that the SDFormat issue has been fixed upstream.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
