### PR TITLE
Add project() call to examples

### DIFF
--- a/examples/standalone/custom_server/CMakeLists.txt
+++ b/examples/standalone/custom_server/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ign-gazebo-custom-server)
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   find_package(ignition-gazebo3 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo3_VERSION_MAJOR})

--- a/examples/standalone/each_performance/CMakeLists.txt
+++ b/examples/standalone/each_performance/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ign-gazebo-each-performance)
+
 find_package(ignition-gazebo3 QUIET REQUIRED)
 
 add_executable(each each.cc)

--- a/examples/standalone/external_ecm/CMakeLists.txt
+++ b/examples/standalone/external_ecm/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ign-gazebo-external-ecm)
+
 find_package(ignition-gazebo3 REQUIRED)
 
 add_executable(external_ecm external_ecm.cc)

--- a/examples/standalone/joy_to_twist/CMakeLists.txt
+++ b/examples/standalone/joy_to_twist/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ign-gazebo-joy-to-twist)
+
 find_package(ignition-transport8 QUIET REQUIRED OPTIONAL_COMPONENTS log)
 set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 

--- a/examples/standalone/joystick/CMakeLists.txt
+++ b/examples/standalone/joystick/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 # joystick currently works only on linux
 
+project(ignition-gazebo-joystick)
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   find_package(ignition-transport8 QUIET REQUIRED OPTIONAL_COMPONENTS log)
   set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})

--- a/examples/standalone/keyboard/CMakeLists.txt
+++ b/examples/standalone/keyboard/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ign-gazebo-keyboard)
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   find_package(ignition-transport8 QUIET REQUIRED OPTIONAL_COMPONENTS log)
   set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})

--- a/examples/standalone/marker/CMakeLists.txt
+++ b/examples/standalone/marker/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gazebo-marker)
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   find_package(ignition-transport8 QUIET REQUIRED OPTIONAL_COMPONENTS log)
   set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})

--- a/examples/standalone/scene_requester/CMakeLists.txt
+++ b/examples/standalone/scene_requester/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ign-gazebo-scene-requester)
+
 find_package(ignition-transport8 QUIET REQUIRED OPTIONAL_COMPONENTS log)
 set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 


### PR DESCRIPTION
# 🦟 Bug fix

Similar to

* https://github.com/ignitionrobotics/ign-physics/pull/322
* https://github.com/ignitionrobotics/ign-gui/pull/345

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->


This is needed to silence CMake warnings like this:

```
33: CMake Warning (dev) in CMakeLists.txt:
33:   No project() command is present.  The top-level CMakeLists.txt file must
33:   contain a literal, direct call to the project() command.  Add a line of
33:   code such as
33: 
33:     project(ProjectName)
33: 
33:   near the top of the file, but after cmake_minimum_required().
33: 
33:   CMake is pretending there is a "project(Project)" command on the first
33:   line.
33: This warning is for project developers.  Use -Wno-dev to suppress it.
```

These warnings show up on Jenkins CI since we migrated from Bionic to Focal:

* https://github.com/ignition-tooling/release-tools/pull/565

There are also CMP0072 warnings coming from the examples. I suspect that's coming from `ign-gui` because it currently links to `ignition-rendering-ogre`, but it shouldn't anymore after https://github.com/ignitionrobotics/ign-gui/pull/345.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
