### PR TITLE
Remove EachNew calls from sensor PreUpdates

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,10 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Gazebo 3.12.0 to 3.X.X
+
+* Some sensors will only have the `SensorTopic` component after the 1st iteration.
+
 ## Ignition Gazebo 2.x to 3.x
 
 * Use ign-rendering3, ign-sensors3 and ign-gui3.

--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include <ignition/plugin/Register.hh>

--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -49,30 +49,35 @@ using namespace systems;
 /// \brief Private AirPressure data class.
 class ignition::gazebo::systems::AirPressurePrivate
 {
-  /// \brief A map of air pressure entity to its vertical reference
+  /// \brief A map of air pressure entity to its sensor
   public: std::unordered_map<Entity,
       std::unique_ptr<sensors::AirPressureSensor>> entitySensorMap;
 
   /// \brief Ign-sensors sensor factory for creating sensors
   public: sensors::SensorFactory sensorFactory;
 
+  /// \brief Keep list of sensors that were created during the previous
+  /// `PostUpdate`, so that components can be created during the next
+  /// `PreUpdate`.
+  public: std::unordered_set<Entity> newSensors;
+
   /// True if the rendering component is initialized
   public: bool initialized = false;
 
   /// \brief Create sensor
-  /// \param[in] _ecm Mutable reference to ECM.
+  /// \param[in] _ecm Immutable reference to ECM.
   /// \param[in] _entity Entity of the IMU
   /// \param[in] _airPressure AirPressureSensor component.
   /// \param[in] _parent Parent entity component.
   public: void AddAirPressure(
-    EntityComponentManager &_ecm,
+    const EntityComponentManager &_ecm,
     const Entity _entity,
     const components::AirPressureSensor *_airPressure,
     const components::ParentEntity *_parent);
 
   /// \brief Create air pressure sensor
-  /// \param[in] _ecm Mutable reference to ECM.
-  public: void CreateAirPressureEntities(EntityComponentManager &_ecm);
+  /// \param[in] _ecm Imutable reference to ECM.
+  public: void CreateAirPressureEntities(const EntityComponentManager &_ecm);
 
   /// \brief Update air pressure sensor data based on physics data
   /// \param[in] _ecm Immutable reference to ECM.
@@ -98,7 +103,21 @@ void AirPressure::PreUpdate(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   IGN_PROFILE("AirPressure::PreUpdate");
-  this->dataPtr->CreateAirPressureEntities(_ecm);
+
+  // Create components
+  for (auto entity : this->dataPtr->newSensors)
+  {
+    auto it = this->dataPtr->entitySensorMap.find(entity);
+    if (it == this->dataPtr->entitySensorMap.end())
+    {
+      ignerr << "Entity [" << entity
+             << "] isn't in sensor map, this shouldn't happen." << std::endl;
+      continue;
+    }
+    // Set topic
+    _ecm.CreateComponent(entity, components::SensorTopic(it->second->Topic()));
+  }
+  this->dataPtr->newSensors.clear();
 }
 
 //////////////////////////////////////////////////
@@ -115,6 +134,8 @@ void AirPressure::PostUpdate(const UpdateInfo &_info,
         << std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count()
         << "s]. System may not work properly." << std::endl;
   }
+
+  this->dataPtr->CreateAirPressureEntities(_ecm);
 
   if (!_info.paused)
   {
@@ -134,7 +155,7 @@ void AirPressure::PostUpdate(const UpdateInfo &_info,
 
 //////////////////////////////////////////////////
 void AirPressurePrivate::AddAirPressure(
-  EntityComponentManager &_ecm,
+  const EntityComponentManager &_ecm,
   const Entity _entity,
   const components::AirPressureSensor *_airPressure,
   const components::ParentEntity *_parent)
@@ -171,15 +192,14 @@ void AirPressurePrivate::AddAirPressure(
   math::Pose3d sensorWorldPose = worldPose(_entity, _ecm);
   sensor->SetPose(sensorWorldPose);
 
-  // Set topic
-  _ecm.CreateComponent(_entity, components::SensorTopic(sensor->Topic()));
-
   this->entitySensorMap.insert(
       std::make_pair(_entity, std::move(sensor)));
+  this->newSensors.insert(_entity);
 }
 
 //////////////////////////////////////////////////
-void AirPressurePrivate::CreateAirPressureEntities(EntityComponentManager &_ecm)
+void AirPressurePrivate::CreateAirPressureEntities(
+    const EntityComponentManager &_ecm)
 {
   IGN_PROFILE("AirPressurePrivate::CreateAirPressureEntities");
   if (!this->initialized)
@@ -190,7 +210,7 @@ void AirPressurePrivate::CreateAirPressureEntities(EntityComponentManager &_ecm)
           const components::AirPressureSensor *_airPressure,
           const components::ParentEntity *_parent)->bool
         {
-          AddAirPressure(_ecm, _entity, _airPressure, _parent);
+          this->AddAirPressure(_ecm, _entity, _airPressure, _parent);
           return true;
         });
     this->initialized = true;
@@ -203,7 +223,7 @@ void AirPressurePrivate::CreateAirPressureEntities(EntityComponentManager &_ecm)
           const components::AirPressureSensor *_airPressure,
           const components::ParentEntity *_parent)->bool
         {
-          AddAirPressure(_ecm, _entity, _airPressure, _parent);
+          this->AddAirPressure(_ecm, _entity, _airPressure, _parent);
           return true;
         });
   }

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include <ignition/common/Profiler.hh>

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -51,30 +51,35 @@ using namespace systems;
 /// \brief Private Altimeter data class.
 class ignition::gazebo::systems::AltimeterPrivate
 {
-  /// \brief A map of altimeter entity to its vertical reference
+  /// \brief A map of altimeter entity to its sensor
   public: std::unordered_map<Entity,
       std::unique_ptr<sensors::AltimeterSensor>> entitySensorMap;
 
   /// \brief Ign-sensors sensor factory for creating sensors
   public: sensors::SensorFactory sensorFactory;
 
+  /// \brief Keep list of sensors that were created during the previous
+  /// `PostUpdate`, so that components can be created during the next
+  /// `PreUpdate`.
+  public: std::unordered_set<Entity> newSensors;
+
   /// True if the rendering component is initialized
   public: bool initialized = false;
 
   /// \brief Create sensor
-  /// \param[in] _ecm Mutable reference to ECM.
+  /// \param[in] _ecm Immutable reference to ECM.
   /// \param[in] _entity Entity of the IMU
   /// \param[in] _altimeter Altimeter component.
   /// \param[in] _parent Parent entity component.
   public: void AddAltimeter(
-    EntityComponentManager &_ecm,
+    const EntityComponentManager &_ecm,
     const Entity _entity,
     const components::Altimeter *_altimeter,
     const components::ParentEntity *_parent);
 
   /// \brief Create altimeter sensor
-  /// \param[in] _ecm Mutable reference to ECM.
-  public: void CreateAltimeterEntities(EntityComponentManager &_ecm);
+  /// \param[in] _ecm Immutable reference to ECM.
+  public: void CreateAltimeterEntities(const EntityComponentManager &_ecm);
 
   /// \brief Update altimeter sensor data based on physics data
   /// \param[in] _ecm Immutable reference to ECM.
@@ -99,7 +104,21 @@ void Altimeter::PreUpdate(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   IGN_PROFILE("Altimeter::PreUpdate");
-  this->dataPtr->CreateAltimeterEntities(_ecm);
+
+  // Create components
+  for (auto entity : this->dataPtr->newSensors)
+  {
+    auto it = this->dataPtr->entitySensorMap.find(entity);
+    if (it == this->dataPtr->entitySensorMap.end())
+    {
+      ignerr << "Entity [" << entity
+             << "] isn't in sensor map, this shouldn't happen." << std::endl;
+      continue;
+    }
+    // Set topic
+    _ecm.CreateComponent(entity, components::SensorTopic(it->second->Topic()));
+  }
+  this->dataPtr->newSensors.clear();
 }
 
 //////////////////////////////////////////////////
@@ -115,6 +134,8 @@ void Altimeter::PostUpdate(const UpdateInfo &_info,
         << std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count()
         << "s]. System may not work properly." << std::endl;
   }
+
+  this->dataPtr->CreateAltimeterEntities(_ecm);
 
   // Only update and publish if not paused.
   if (!_info.paused)
@@ -135,7 +156,7 @@ void Altimeter::PostUpdate(const UpdateInfo &_info,
 
 //////////////////////////////////////////////////
 void AltimeterPrivate::AddAltimeter(
-  EntityComponentManager &_ecm,
+  const EntityComponentManager &_ecm,
   const Entity _entity,
   const components::Altimeter *_altimeter,
   const components::ParentEntity *_parent)
@@ -173,15 +194,14 @@ void AltimeterPrivate::AddAltimeter(
   sensor->SetVerticalReference(verticalReference);
   sensor->SetPosition(verticalReference);
 
-  // Set topic
-  _ecm.CreateComponent(_entity, components::SensorTopic(sensor->Topic()));
-
   this->entitySensorMap.insert(
       std::make_pair(_entity, std::move(sensor)));
+  this->newSensors.insert(_entity);
 }
 
 //////////////////////////////////////////////////
-void AltimeterPrivate::CreateAltimeterEntities(EntityComponentManager &_ecm)
+void AltimeterPrivate::CreateAltimeterEntities(
+    const EntityComponentManager &_ecm)
 {
   IGN_PROFILE("Altimeter::CreateAltimeterEntities");
   if (!this->initialized)
@@ -192,7 +212,7 @@ void AltimeterPrivate::CreateAltimeterEntities(EntityComponentManager &_ecm)
           const components::Altimeter *_altimeter,
           const components::ParentEntity *_parent)->bool
         {
-          AddAltimeter(_ecm, _entity, _altimeter, _parent);
+          this->AddAltimeter(_ecm, _entity, _altimeter, _parent);
           return true;
         });
     this->initialized = true;
@@ -205,7 +225,7 @@ void AltimeterPrivate::CreateAltimeterEntities(EntityComponentManager &_ecm)
           const components::Altimeter *_altimeter,
           const components::ParentEntity *_parent)->bool
         {
-          AddAltimeter(_ecm, _entity, _altimeter, _parent);
+          this->AddAltimeter(_ecm, _entity, _altimeter, _parent);
           return true;
         });
   }

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -17,9 +17,10 @@
 
 #include "Imu.hh"
 
-#include <unordered_map>
-#include <utility>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 
 #include <ignition/plugin/Register.hh>
 

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -56,6 +56,11 @@ class ignition::gazebo::systems::ImuPrivate
   /// \brief Ign-sensors sensor factory for creating sensors
   public: sensors::SensorFactory sensorFactory;
 
+  /// \brief Keep list of sensors that were created during the previous
+  /// `PostUpdate`, so that components can be created during the next
+  /// `PreUpdate`.
+  public: std::unordered_set<Entity> newSensors;
+
   /// \brief Keep track of world ID, which is equivalent to the scene's
   /// root visual.
   /// Defaults to zero, which is considered invalid by Ignition Gazebo.
@@ -64,21 +69,21 @@ class ignition::gazebo::systems::ImuPrivate
   /// True if the rendering component is initialized
   public: bool initialized = false;
 
-  /// \brief Create IMU sensor
-  /// \param[in] _ecm Mutable reference to ECM.
-  public: void CreateImuEntities(EntityComponentManager &_ecm);
+  /// \brief Create IMU sensors in ign-sensors
+  /// \param[in] _ecm Immutable reference to ECM.
+  public: void CreateImuEntities(const EntityComponentManager &_ecm);
 
   /// \brief Update IMU sensor data based on physics data
   /// \param[in] _ecm Immutable reference to ECM.
   public: void Update(const EntityComponentManager &_ecm);
 
   /// \brief Create sensor
-  /// \param[in] _ecm Mutable reference to ECM.
+  /// \param[in] _ecm Immutable reference to ECM.
   /// \param[in] _entity Entity of the IMU
   /// \param[in] _imu IMU component.
   /// \param[in] _parent Parent entity component.
-  public: void addIMU(
-    EntityComponentManager &_ecm,
+  public: void AddSensor(
+    const EntityComponentManager &_ecm,
     const Entity _entity,
     const components::Imu *_imu,
     const components::ParentEntity *_parent);
@@ -102,7 +107,21 @@ void Imu::PreUpdate(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   IGN_PROFILE("Imu::PreUpdate");
-  this->dataPtr->CreateImuEntities(_ecm);
+
+  // Create components
+  for (auto entity : this->dataPtr->newSensors)
+  {
+    auto it = this->dataPtr->entitySensorMap.find(entity);
+    if (it == this->dataPtr->entitySensorMap.end())
+    {
+      ignerr << "Entity [" << entity
+             << "] isn't in sensor map, this shouldn't happen." << std::endl;
+      continue;
+    }
+    // Set topic
+    _ecm.CreateComponent(entity, components::SensorTopic(it->second->Topic()));
+  }
+  this->dataPtr->newSensors.clear();
 }
 
 //////////////////////////////////////////////////
@@ -118,6 +137,8 @@ void Imu::PostUpdate(const UpdateInfo &_info,
         << std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count()
         << "s]. System may not work properly." << std::endl;
   }
+
+  this->dataPtr->CreateImuEntities(_ecm);
 
   // Only update and publish if not paused.
   if (!_info.paused)
@@ -137,8 +158,8 @@ void Imu::PostUpdate(const UpdateInfo &_info,
 }
 
 //////////////////////////////////////////////////
-void ImuPrivate::addIMU(
-  EntityComponentManager &_ecm,
+void ImuPrivate::AddSensor(
+  const EntityComponentManager &_ecm,
   const Entity _entity,
   const components::Imu *_imu,
   const components::ParentEntity *_parent)
@@ -186,15 +207,13 @@ void ImuPrivate::addIMU(
   math::Pose3d p = worldPose(_entity, _ecm);
   sensor->SetOrientationReference(p.Rot());
 
-  // Set topic
-  _ecm.CreateComponent(_entity, components::SensorTopic(sensor->Topic()));
-
   this->entitySensorMap.insert(
       std::make_pair(_entity, std::move(sensor)));
+  this->newSensors.insert(_entity);
 }
 
 //////////////////////////////////////////////////
-void ImuPrivate::CreateImuEntities(EntityComponentManager &_ecm)
+void ImuPrivate::CreateImuEntities(const EntityComponentManager &_ecm)
 {
   IGN_PROFILE("ImuPrivate::CreateImuEntities");
   // Get World Entity
@@ -214,7 +233,7 @@ void ImuPrivate::CreateImuEntities(EntityComponentManager &_ecm)
           const components::Imu *_imu,
           const components::ParentEntity *_parent)->bool
         {
-          addIMU(_ecm, _entity, _imu, _parent);
+          this->AddSensor(_ecm, _entity, _imu, _parent);
           return true;
         });
       this->initialized = true;
@@ -227,7 +246,7 @@ void ImuPrivate::CreateImuEntities(EntityComponentManager &_ecm)
           const components::Imu *_imu,
           const components::ParentEntity *_parent)->bool
         {
-          addIMU(_ecm, _entity, _imu, _parent);
+          this->AddSensor(_ecm, _entity, _imu, _parent);
           return true;
         });
     }

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -22,6 +22,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include <ignition/common/Profiler.hh>

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -59,23 +59,28 @@ class ignition::gazebo::systems::LogicalCameraPrivate
   /// \brief Ign-sensors sensor factory for creating sensors
   public: sensors::SensorFactory sensorFactory;
 
+  /// \brief Keep list of sensors that were created during the previous
+  /// `PostUpdate`, so that components can be created during the next
+  /// `PreUpdate`.
+  public: std::unordered_set<Entity> newSensors;
+
   /// True if the rendering component is initialized
   public: bool initialized = false;
 
   /// \brief Create sensor
-  /// \param[in] _ecm Mutable reference to ECM.
+  /// \param[in] _ecm Immutable reference to ECM.
   /// \param[in] _entity Entity of the IMU
   /// \param[in] _logicalCamera LogicalCamera component.
   /// \param[in] _parent Parent entity component.
   public: void AddLogicalCamera(
-    EntityComponentManager &_ecm,
+    const EntityComponentManager &_ecm,
     const Entity _entity,
     const components::LogicalCamera *_logicalCamera,
     const components::ParentEntity *_parent);
 
   /// \brief Create logicalCamera sensor
-  /// \param[in] _ecm Mutable reference to ECM.
-  public: void CreateLogicalCameraEntities(EntityComponentManager &_ecm);
+  /// \param[in] _ecm Immutable reference to ECM.
+  public: void CreateLogicalCameraEntities(const EntityComponentManager &_ecm);
 
   /// \brief Update logicalCamera sensor data based on physics data
   /// \param[in] _ecm Immutable reference to ECM.
@@ -101,7 +106,21 @@ void LogicalCamera::PreUpdate(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   IGN_PROFILE("LogicalCamera::PreUpdate");
-  this->dataPtr->CreateLogicalCameraEntities(_ecm);
+
+  // Create components
+  for (auto entity : this->dataPtr->newSensors)
+  {
+    auto it = this->dataPtr->entitySensorMap.find(entity);
+    if (it == this->dataPtr->entitySensorMap.end())
+    {
+      ignerr << "Entity [" << entity
+             << "] isn't in sensor map, this shouldn't happen." << std::endl;
+      continue;
+    }
+    // Set topic
+    _ecm.CreateComponent(entity, components::SensorTopic(it->second->Topic()));
+  }
+  this->dataPtr->newSensors.clear();
 }
 
 //////////////////////////////////////////////////
@@ -117,6 +136,8 @@ void LogicalCamera::PostUpdate(const UpdateInfo &_info,
         << std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count()
         << "s]. System may not work properly." << std::endl;
   }
+
+  this->dataPtr->CreateLogicalCameraEntities(_ecm);
 
   // Only update and publish if not paused.
   if (!_info.paused)
@@ -137,7 +158,7 @@ void LogicalCamera::PostUpdate(const UpdateInfo &_info,
 
 //////////////////////////////////////////////////
 void LogicalCameraPrivate::AddLogicalCamera(
-  EntityComponentManager &_ecm,
+  const EntityComponentManager &_ecm,
   const Entity _entity,
   const components::LogicalCamera *_logicalCamera,
   const components::ParentEntity *_parent)
@@ -172,16 +193,14 @@ void LogicalCameraPrivate::AddLogicalCamera(
   math::Pose3d sensorWorldPose = worldPose(_entity, _ecm);
   sensor->SetPose(sensorWorldPose);
 
-  // Set topic
-  _ecm.CreateComponent(_entity, components::SensorTopic(sensor->Topic()));
-
   this->entitySensorMap.insert(
       std::make_pair(_entity, std::move(sensor)));
+  this->newSensors.insert(_entity);
 }
 
 //////////////////////////////////////////////////
 void LogicalCameraPrivate::CreateLogicalCameraEntities(
-    EntityComponentManager &_ecm)
+    const EntityComponentManager &_ecm)
 {
   IGN_PROFILE("LogicalCameraPrivate::CreateLogicalCameraEntities");
   if (!this->initialized)
@@ -192,7 +211,7 @@ void LogicalCameraPrivate::CreateLogicalCameraEntities(
           const components::LogicalCamera *_logicalCamera,
           const components::ParentEntity *_parent)->bool
         {
-          AddLogicalCamera(_ecm, _entity, _logicalCamera, _parent);
+          this->AddLogicalCamera(_ecm, _entity, _logicalCamera, _parent);
           return true;
         });
     this->initialized = true;
@@ -206,7 +225,7 @@ void LogicalCameraPrivate::CreateLogicalCameraEntities(
           const components::LogicalCamera *_logicalCamera,
           const components::ParentEntity *_parent)->bool
         {
-          AddLogicalCamera(_ecm, _entity, _logicalCamera, _parent);
+          this->AddLogicalCamera(_ecm, _entity, _logicalCamera, _parent);
           return true;
         });
   }

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include <ignition/plugin/Register.hh>

--- a/test/integration/air_pressure_system.cc
+++ b/test/integration/air_pressure_system.cc
@@ -62,7 +62,7 @@ TEST_F(AirPressureTest, AirPressure)
 
   // Create a system that checks sensor topic
   test::Relay testSystem;
-  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
+  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &_info,
                               const gazebo::EntityComponentManager &_ecm)
       {
         _ecm.Each<components::AirPressureSensor, components::Name>(
@@ -75,6 +75,10 @@ TEST_F(AirPressureTest, AirPressure)
               auto sensorComp = _ecm.Component<components::Sensor>(_entity);
               EXPECT_NE(nullptr, sensorComp);
 
+              if (_info.iterations == 1)
+                return true;
+
+              // This component is created on the 2nd PreUpdate
               auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
               EXPECT_NE(nullptr, topicComp);
               if (topicComp)

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -80,7 +80,7 @@ TEST_F(AltimeterTest, ModelFalling)
   test::Relay testSystem;
   std::vector<math::Pose3d> poses;
   std::vector<math::Vector3d> velocities;
-  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
+  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &_info,
                               const gazebo::EntityComponentManager &_ecm)
       {
         _ecm.Each<components::Altimeter, components::Name,
@@ -100,6 +100,10 @@ TEST_F(AltimeterTest, ModelFalling)
               auto sensorComp = _ecm.Component<components::Sensor>(_entity);
               EXPECT_NE(nullptr, sensorComp);
 
+              if (_info.iterations == 1)
+                return true;
+
+              // This component is created on the 2nd PreUpdate
               auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
               EXPECT_NE(nullptr, topicComp);
               if (topicComp)

--- a/test/integration/imu_system.cc
+++ b/test/integration/imu_system.cc
@@ -89,7 +89,7 @@ TEST_F(ImuTest, ModelFalling)
   std::vector<math::Pose3d> poses;
   std::vector<math::Vector3d> accelerations;
   std::vector<math::Vector3d> angularVelocities;
-  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
+  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &_info,
                               const gazebo::EntityComponentManager &_ecm)
       {
         _ecm.Each<components::Imu,
@@ -113,6 +113,10 @@ TEST_F(ImuTest, ModelFalling)
               auto sensorComp = _ecm.Component<components::Sensor>(_entity);
               EXPECT_NE(nullptr, sensorComp);
 
+              if (_info.iterations == 1)
+                return true;
+
+              // This component is created on the 2nd PreUpdate
               auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
               EXPECT_NE(nullptr, topicComp);
               if (topicComp)

--- a/test/integration/logical_camera_system.cc
+++ b/test/integration/logical_camera_system.cc
@@ -91,7 +91,7 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
 
   // Create a system that checks sensor topics
   test::Relay testSystem;
-  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
+  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &_info,
                               const gazebo::EntityComponentManager &_ecm)
       {
         _ecm.Each<components::LogicalCamera, components::Name>(
@@ -105,11 +105,15 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
                 auto sensorComp = _ecm.Component<components::Sensor>(_entity);
                 EXPECT_NE(nullptr, sensorComp);
 
-                auto topicComp =
-                    _ecm.Component<components::SensorTopic>(_entity);
-                EXPECT_NE(nullptr, topicComp);
-                if (topicComp) {
-                  EXPECT_EQ(topic1, topicComp->Data());
+                if (_info.iterations != 1)
+                {
+                  auto topicComp =
+                      _ecm.Component<components::SensorTopic>(_entity);
+                  EXPECT_NE(nullptr, topicComp);
+                  if (topicComp)
+                  {
+                    EXPECT_EQ(topic1, topicComp->Data());
+                  }
                 }
                 update1Checked = true;
               }
@@ -119,11 +123,15 @@ TEST_F(LogicalCameraTest, LogicalCameraBox)
                 auto sensorComp = _ecm.Component<components::Sensor>(_entity);
                 EXPECT_NE(nullptr, sensorComp);
 
-                auto topicComp =
-                    _ecm.Component<components::SensorTopic>(_entity);
-                EXPECT_NE(nullptr, topicComp);
-                if (topicComp) {
-                EXPECT_EQ(topic2, topicComp->Data());
+                if (_info.iterations != 1)
+                {
+                  auto topicComp =
+                      _ecm.Component<components::SensorTopic>(_entity);
+                  EXPECT_NE(nullptr, topicComp);
+                  if (topicComp)
+                  {
+                    EXPECT_EQ(topic2, topicComp->Data());
+                  }
                 }
                 update2Checked = true;
               }

--- a/test/integration/magnetometer_system.cc
+++ b/test/integration/magnetometer_system.cc
@@ -81,7 +81,7 @@ TEST_F(MagnetometerTest, RotatedMagnetometer)
   test::Relay testSystem;
 
   std::vector<math::Pose3d> poses;
-  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &,
+  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &_info,
                               const gazebo::EntityComponentManager &_ecm)
       {
         _ecm.Each<components::Magnetometer,
@@ -98,6 +98,10 @@ TEST_F(MagnetometerTest, RotatedMagnetometer)
               auto sensorComp = _ecm.Component<components::Sensor>(_entity);
               EXPECT_NE(nullptr, sensorComp);
 
+              if (_info.iterations == 1)
+                return true;
+
+              // This component is created on the 2nd PreUpdate
               auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
               EXPECT_NE(nullptr, topicComp);
               if (topicComp)


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/797

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Calling `EachNew` in `PreUpdate` is unreliable because new entities may be created during another system's `PreUpdate` and then you miss it. See #797 for a detailed description of the issue.

This PR tackles only non-rendering sensors. I'm using the same approach as in #1248 . This is the new flow:

1. `SdfEntityCreator` creates the sensor entity and fills some components from SDF
2. `PreUpdate`: the first `PreUpdate` doesn't do anything
3. `Update`: `Physics` populates the components created by `SdfEntityCreator`
4. `PostUpdate`: The sensor system does a few things:
    1. Creates new `ign-sensors` objects for new sensors
    2. Updates all sensors with the data from the components that were filled by physics
    3. Removes sensors that need to be removed
1. The next `PreUpdate` creates new components for the new sensors created during the previous `PostUpdate`, which is only `SensorTopic`

There's a slight change in behaviour, which is that a sensor won't have a `SensorTopic` component in the first iteration. This means that any `Each` call that includes that component will only be called from the 2nd iteration after the component is created. Since that component is not critical to the sensor's functioning and I've only seen it being used by the GUI, I think this is a safe change. See the consequences on the updated tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
