### PR TITLE
Cleanup update call for non-rendering sensors

### DIFF
--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -123,9 +123,7 @@ void AirPressure::PostUpdate(const UpdateInfo &_info,
     for (auto &it : this->dataPtr->entitySensorMap)
     {
       // Update measurement time
-      auto time = math::durationToSecNsec(_info.simTime);
-      dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          math::secNsecToDuration(time.first, time.second), false);
+      it.second.get()->sensors::Sensor::Update(_info.simTime, false);
     }
   }
 

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -124,9 +124,7 @@ void Altimeter::PostUpdate(const UpdateInfo &_info,
     for (auto &it : this->dataPtr->entitySensorMap)
     {
       // Update measurement time
-      auto time = math::durationToSecNsec(_info.simTime);
-      dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          math::secNsecToDuration(time.first, time.second), false);
+      it.second.get()->sensors::Sensor::Update(_info.simTime, false);
     }
   }
 

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -127,9 +127,7 @@ void Imu::PostUpdate(const UpdateInfo &_info,
     for (auto &it : this->dataPtr->entitySensorMap)
     {
       // Update measurement time
-      auto time = math::durationToSecNsec(_info.simTime);
-      dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          math::secNsecToDuration(time.first, time.second), false);
+      it.second.get()->sensors::Sensor::Update(_info.simTime, false);
     }
   }
 

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -126,9 +126,7 @@ void LogicalCamera::PostUpdate(const UpdateInfo &_info,
     for (auto &it : this->dataPtr->entitySensorMap)
     {
       // Update sensor
-      auto time = math::durationToSecNsec(_info.simTime);
-      dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          math::secNsecToDuration(time.first, time.second), false);
+      it.second.get()->sensors::Sensor::Update(_info.simTime, false);
     }
   }
 

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -125,9 +125,7 @@ void Magnetometer::PostUpdate(const UpdateInfo &_info,
     for (auto &it : this->dataPtr->entitySensorMap)
     {
       // Update measurement time
-      auto time = math::durationToSecNsec(_info.simTime);
-      dynamic_cast<sensors::Sensor *>(it.second.get())->Update(
-          math::secNsecToDuration(time.first, time.second), false);
+      it.second.get()->sensors::Sensor::Update(_info.simTime, false);
     }
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

* Follow up to https://github.com/ignitionrobotics/ign-gazebo/pull/1159

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

There are a few `Update` calls to choose in `ign-sensors`, and sometimes we choose the wrong one. Luckily, all of these sensors have been calling the correct one, which is the one that takes a boolean. So this PR is not changing behaviour or fixing any bugs, just simplifying a bit of unnecessary logic:

* Removing the back-and-forth time conversion 
* Removing the unnecessary dynamic cast. C++ is weird in that we can't call the base class's function if there's an overload on the derived class, so we can't just do this:

    `it.second->Update(_info.simTime, false);`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
