### PR TITLE
Disable more tests on Windows

### DIFF
--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -1211,7 +1211,8 @@ TEST_P(EntityComponentManagerFixture,
 }
 
 ////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachRemoveAlreadyRemove)
+TEST_P(EntityComponentManagerFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(EachRemoveAlreadyRemove))
 {
   // Create an entities
   Entity e1 = manager.CreateEntity();
@@ -1359,7 +1360,8 @@ TEST_P(EntityComponentManagerFixture,
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, EachAddRemoveComponent)
+TEST_P(EntityComponentManagerFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(EachAddRemoveComponent))
 {
   // test calling ecm.Each on entities that have components added/removed
   // frequently. This is common with *Cmd components
@@ -2284,7 +2286,8 @@ TEST_P(EntityComponentManagerFixture,
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, SetEntityCreateOffset)
+TEST_P(EntityComponentManagerFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(SetEntityCreateOffset))
 {
   // First entity should have a value of 1.
   Entity entity = manager.CreateEntity();
@@ -2650,7 +2653,8 @@ static void CompareEntityComponents(const EntityComponentManager &_ecm,
 }
 
 //////////////////////////////////////////////////
-TEST_P(EntityComponentManagerFixture, CloneEntities)
+TEST_P(EntityComponentManagerFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(CloneEntities))
 {
   // testing entity cloning with the following entity structure:
   // - topLevelEntity
@@ -2917,7 +2921,8 @@ TEST_P(EntityComponentManagerFixture, CloneEntities)
 
 /////////////////////////////////////////////////
 // Check that some widely used deprecated APIs still work
-TEST_P(EntityComponentManagerFixture, Deprecated)
+TEST_P(EntityComponentManagerFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(Deprecated))
 {
   IGN_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
 

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -644,7 +644,7 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2/";
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {

--- a/test/integration/buoyancy_engine.cc
+++ b/test/integration/buoyancy_engine.cc
@@ -21,6 +21,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/msgs/double.pb.h>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
@@ -53,7 +54,7 @@ class BuoyancyEngineTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(BuoyancyEngineTest, TestDownward)
+TEST_F(BuoyancyEngineTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(TestDownward))
 {
   ServerConfig serverConfig;
   const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
@@ -102,7 +103,7 @@ TEST_F(BuoyancyEngineTest, TestDownward)
 }
 
 /////////////////////////////////////////////////
-TEST_F(BuoyancyEngineTest, TestUpward)
+TEST_F(BuoyancyEngineTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(TestUpward))
 {
   ServerConfig serverConfig;
   const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/force_torque_system.cc
+++ b/test/integration/force_torque_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Sensor.hh"
@@ -40,13 +41,13 @@ class ForceTorqueTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(ForceTorqueTest, MeasureWeight)
+TEST_F(ForceTorqueTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(MeasureWeight))
 {
   using namespace std::chrono_literals;
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile =
-      std::string(PROJECT_SOURCE_PATH) + "/test/worlds/force_torque.sdf";
+  const auto sdfFile = common::joinPaths(
+      std::string(PROJECT_SOURCE_PATH), "test", "worlds", "force_torque.sdf");
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);
@@ -98,13 +99,13 @@ TEST_F(ForceTorqueTest, MeasureWeight)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ForceTorqueTest, SensorPoseOffset)
+TEST_F(ForceTorqueTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SensorPoseOffset))
 {
   using namespace std::chrono_literals;
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile =
-      std::string(PROJECT_SOURCE_PATH) + "/test/worlds/force_torque.sdf";
+  const auto sdfFile = common::joinPaths(
+      std::string(PROJECT_SOURCE_PATH), "test", "worlds", "force_torque.sdf");
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);

--- a/test/integration/navsat_system.cc
+++ b/test/integration/navsat_system.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/LinearVelocity.hh"
 #include "ignition/gazebo/components/Model.hh"
@@ -59,7 +60,7 @@ void navsatCb(const msgs::NavSat &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the world pose and sensor readings of a falling navsat
-TEST_F(NavSatTest, ModelFalling)
+TEST_F(NavSatTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFalling))
 {
   TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "worlds", "navsat.sdf"));

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -2077,7 +2077,8 @@ TEST_F(PhysicsSystemFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
 
 /////////////////////////////////////////////////
 // Joint force
-TEST_F(PhysicsSystemFixture, JointTransmittedWrench)
+TEST_F(PhysicsSystemFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(JointTransmittedWrench))
 {
   common::Console::SetVerbosity(4);
   ignition::gazebo::ServerConfig serverConfig;

--- a/test/integration/recreate_entities.cc
+++ b/test/integration/recreate_entities.cc
@@ -22,6 +22,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/World.hh>
 
 #include "ignition/gazebo/components/Factory.hh"
@@ -52,12 +53,13 @@ class RecreateEntitiesFixture : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(RecreateEntitiesFixture, RecreateEntities)
+TEST_F(RecreateEntitiesFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(RecreateEntities))
 {
   // Start server
   ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "shapes.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -321,12 +323,13 @@ TEST_F(RecreateEntitiesFixture, RecreateEntities)
 }
 
 /////////////////////////////////////////////////
-TEST_F(RecreateEntitiesFixture, RecreateEntities_Joints)
+TEST_F(RecreateEntitiesFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(RecreateEntities_Joints))
 {
   // Start server
   ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/double_pendulum.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "double_pendulum.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -479,12 +482,13 @@ TEST_F(RecreateEntitiesFixture, RecreateEntities_Joints)
 }
 
 /////////////////////////////////////////////////
-TEST_F(RecreateEntitiesFixture, RecreateEntities_WorldJoint)
+TEST_F(RecreateEntitiesFixture,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(RecreateEntities_WorldJoint))
 {
   // Start server
   ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/fixed_world_joint.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "fixed_world_joint.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -621,7 +621,7 @@ TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(StateStatic))
 
 /////////////////////////////////////////////////
 /// Test whether the scene topic is published when a component is removed.
-TEST_P(SceneBroadcasterTest, RemovedComponent)
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RemovedComponent))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;

--- a/test/integration/spherical_coordinates.cc
+++ b/test/integration/spherical_coordinates.cc
@@ -20,6 +20,7 @@
 #include <ignition/math/SphericalCoordinates.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/TestFixture.hh"
 #include "ignition/gazebo/Util.hh"
@@ -84,7 +85,8 @@ TEST_F(SphericalCoordinatesTest, InitialFromSDF)
 }
 
 /////////////////////////////////////////////////
-TEST_F(SphericalCoordinatesTest, SetWorldOriginFromTransport)
+TEST_F(SphericalCoordinatesTest,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(SetWorldOriginFromTransport))
 {
   TestFixture fixture(std::string(PROJECT_SOURCE_PATH) +
       "/test/worlds/spherical_coordinates.sdf");
@@ -191,7 +193,7 @@ TEST_F(SphericalCoordinatesTest, SetWorldOriginFromComponent)
 }
 
 /////////////////////////////////////////////////
-TEST_F(SphericalCoordinatesTest, MoveEntity)
+TEST_F(SphericalCoordinatesTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(MoveEntity))
 {
   TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "spherical_coordinates.sdf"));
@@ -262,7 +264,7 @@ TEST_F(SphericalCoordinatesTest, MoveEntity)
 }
 
 /////////////////////////////////////////////////
-TEST_F(SphericalCoordinatesTest, CreateEntity)
+TEST_F(SphericalCoordinatesTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(CreateEntity))
 {
   TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "spherical_coordinates.sdf"));

--- a/test/integration/spherical_coordinates.cc
+++ b/test/integration/spherical_coordinates.cc
@@ -48,8 +48,8 @@ class SphericalCoordinatesTest : public InternalFixture<::testing::Test>
 /////////////////////////////////////////////////
 TEST_F(SphericalCoordinatesTest, InitialFromSDF)
 {
-  TestFixture fixture(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/spherical_coordinates.sdf");
+  TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "spherical_coordinates.sdf"));
 
   int iterations{0};
   math::SphericalCoordinates latest;
@@ -146,8 +146,8 @@ TEST_F(SphericalCoordinatesTest, SetWorldOriginFromTransport)
 /////////////////////////////////////////////////
 TEST_F(SphericalCoordinatesTest, SetWorldOriginFromComponent)
 {
-  TestFixture fixture(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/spherical_coordinates.sdf");
+  TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "spherical_coordinates.sdf"));
 
   int iterations{0};
   math::SphericalCoordinates latest;
@@ -193,8 +193,8 @@ TEST_F(SphericalCoordinatesTest, SetWorldOriginFromComponent)
 /////////////////////////////////////////////////
 TEST_F(SphericalCoordinatesTest, MoveEntity)
 {
-  TestFixture fixture(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/spherical_coordinates.sdf");
+  TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "spherical_coordinates.sdf"));
 
   int iterations{0};
   Entity modelEntity{kNullEntity};
@@ -264,8 +264,8 @@ TEST_F(SphericalCoordinatesTest, MoveEntity)
 /////////////////////////////////////////////////
 TEST_F(SphericalCoordinatesTest, CreateEntity)
 {
-  TestFixture fixture(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/spherical_coordinates.sdf");
+  TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "spherical_coordinates.sdf"));
 
   int iterations{0};
   Entity modelEntity{kNullEntity};

--- a/test/integration/world_control_state.cc
+++ b/test/integration/world_control_state.cc
@@ -17,8 +17,10 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/msgs.hh"
-#include "ignition/transport.hh"
+#include <ignition/msgs/serialized_map.pb.h>
+#include <ignition/transport/Node.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
+
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/components/Name.hh"
 
@@ -37,7 +39,7 @@ class WorldControlState : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(WorldControlState, SetState)
+TEST_F(WorldControlState, IGN_UTILS_TEST_DISABLED_ON_WIN32(SetState))
 {
   common::Console::SetVerbosity(4);
 


### PR DESCRIPTION
# 🦟 Bug fix

* Follow up to #1205 after it was forward-ported on https://github.com/ignitionrobotics/ign-gazebo/pull/1277
* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1175

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This addresses tests that are new on Fortress.

The goal is to have zero failing tests on Windows, this way we know if we're introducing new failures.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
