### PR TITLE
Add surface to buoyancy engine.

### DIFF
--- a/examples/worlds/buoyancy_engine.sdf
+++ b/examples/worlds/buoyancy_engine.sdf
@@ -30,21 +30,27 @@ listens to the topic `buoyancy_engine` or
 * Publishes a ignition::msgs::Double on `buoyancy_engine` or
  `/model/{namespace}/buoyancy_engine/current_volume` on the current volume
 ## Examples
+
 To get started run:
 ```
 ign gazebo buoyancy_engine.sdf
 ```
+You will see two boxes. The box on the right doesn't have a surface set whereas
+the box on the left does. When commanded t go up, the box on the left will rise
+till it breaches and then start oscillating around the surface. On the other
+hand the box on the right will rise forever as no surface is set.
 Enter the following in a separate terminal:
 ```
 ign topic -t  /model/buoyant_box/buoyancy_engine/ -m ignition.msgs.Double
    -p "data: 0.003"
 ```
-To see the box float up.
+The boxes will float up. Note that the box on the left will start oscillating
+once it breaches the surface.
 ```
 ign topic -t  /model/buoyant_box/buoyancy_engine/ -m ignition.msgs.Double
    -p "data: 0.001"
 ```
-To see the box go down.
+The boxes will go down.
 To see the current volume enter:
 ```
 ign topic -t  /model/buoyant_box/buoyancy_engine/current_volume -e
@@ -136,7 +142,47 @@ ign topic -t  /model/buoyant_box/buoyancy_engine/current_volume -e
         <max_volume>0.003</max_volume>
         <max_inflation_rate>0.0003</max_inflation_rate>
       </plugin>
+    </model>
 
+
+    <model name="buoyant_box_urface">
+      <pose>0 5 -0.8 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>1000</mass>
+          <inertia>
+            <ixx>133.3333</ixx>
+            <iyy>133.3333</iyy>
+            <izz>133.3333</izz>
+          </inertia>
+        </inertial>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <plugin
+        filename="libignition-gazebo-buoyancy-engine-system.so"
+        name="ignition::gazebo::systems::BuoyancyEngine">
+        <link_name>body</link_name>
+        <namespace>buoyant_box</namespace>
+        <min_volume>0.0</min_volume>
+        <neutral_volume>0.002</neutral_volume>
+        <default_volume>0.002</default_volume>
+        <max_volume>0.003</max_volume>
+        <max_inflation_rate>0.0003</max_inflation_rate>
+        <surface>0</surface>
+      </plugin>
     </model>
   </world>
 </sdf>

--- a/src/systems/buoyancy_engine/BuoyancyEngine.cc
+++ b/src/systems/buoyancy_engine/BuoyancyEngine.cc
@@ -95,7 +95,7 @@ double BuoyancyEnginePrivateData::CurrentFluidDensity(
   if (!this->surface.has_value())
     return fluidDensity;
 
-  auto pose =_link.WorldPose(_ecm);
+  auto pose = _link.WorldPose(_ecm);
   if (!pose.has_value())
     return fluidDensity;
 

--- a/src/systems/buoyancy_engine/BuoyancyEngine.hh
+++ b/src/systems/buoyancy_engine/BuoyancyEngine.hh
@@ -55,6 +55,8 @@ namespace systems
   ///   float, default=0.000003m^3/s]
   /// <fluid_density> - The fluid density of the liquid its suspended in kgm^-3.
   ///   [optional, float, default=1000kgm^-3]
+  /// <surface> - The Z height in metres at which the surface of the water is.
+  /// If not defined then there is no surface [optional, float]
   ///
   /// ## Topics
   /// * Subscribes to a ignition::msgs::Double on `buoyancy_engine` or

--- a/test/integration/buoyancy_engine.cc
+++ b/test/integration/buoyancy_engine.cc
@@ -150,3 +150,54 @@ TEST_F(BuoyancyEngineTest, TestUpward)
   EXPECT_NEAR(poses.rbegin()->Pos().Y(), poses.begin()->Pos().Y(), 1e-3);
 }
 
+/////////////////////////////////////////////////
+TEST_F(BuoyancyEngineTest, TestUpwardSurface)
+{
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/buoyancy_engine.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  using namespace std::chrono_literals;
+  server.SetUpdatePeriod(1ns);
+
+  std::size_t iterations = 10000;
+
+  test::Relay testSystem;
+  std::vector<ignition::math::Pose3d> poses;
+
+  testSystem.OnPostUpdate([&](const gazebo::UpdateInfo &/*_info*/,
+                             const gazebo::EntityComponentManager &_ecm)
+  {
+    // Check pose
+    Entity buoyantBox = _ecm.EntityByComponents(
+      components::Model(), components::Name("buoyant_box_w_surface"));
+    EXPECT_NE(kNullEntity, buoyantBox);
+
+    auto submarineBuoyantPose = _ecm.Component<components::Pose>(buoyantBox);
+    EXPECT_NE(submarineBuoyantPose, nullptr);
+    if (submarineBuoyantPose == nullptr)
+    {
+      ignerr << "Unable to get pose" <<std::endl;
+      return;
+    }
+    poses.push_back(submarineBuoyantPose->Data());
+    double tol = 0.1;
+    EXPECT_LT(submarineBuoyantPose->Data().Z(), 0 + tol);
+  });
+
+  server.AddSystem(testSystem.systemPtr);
+  ignition::msgs::Double volume;
+  volume.set_data(10);
+  this->pub.Publish(volume);
+  server.Run(true, iterations, false);
+
+  EXPECT_GT(poses.rbegin()->Pos().Z(), poses.begin()->Pos().Z());
+  EXPECT_NEAR(poses.rbegin()->Pos().X(), poses.begin()->Pos().X(), 1e-3);
+  EXPECT_NEAR(poses.rbegin()->Pos().Y(), poses.begin()->Pos().Y(), 1e-3);
+}
+

--- a/test/worlds/buoyancy_engine.sdf
+++ b/test/worlds/buoyancy_engine.sdf
@@ -66,7 +66,47 @@
         <max_volume>0.003</max_volume>
         <max_inflation_rate>0.0003</max_inflation_rate>
       </plugin>
+    </model>
 
+
+    <model name="buoyant_box_w_surface">
+      <pose>5 0 -0.1 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>1000</mass>
+          <inertia>
+            <ixx>133.3333</ixx>
+            <iyy>133.3333</iyy>
+            <izz>133.3333</izz>
+          </inertia>
+        </inertial>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <plugin
+        filename="libignition-gazebo-buoyancy-engine-system.so"
+        name="ignition::gazebo::systems::BuoyancyEngine">
+        <link_name>body</link_name>
+        <namespace>buoyant_box</namespace>
+        <min_volume>0.001</min_volume>
+        <neutral_volume>0.002</neutral_volume>
+        <default_volume>0.002</default_volume>
+        <max_volume>0.003</max_volume>
+        <max_inflation_rate>0.0003</max_inflation_rate>
+        <surface>0</surface>
+      </plugin>
     </model>
   </world>
 </sdf>


### PR DESCRIPTION
# 🎉 New feature

## Summary
The buoyancy engine should stop working when it crosses the water surface. 
This PR adds a `<surface>` tag which stops the buoyancy engine from exerting
an upward force when the vehicle is surfacing.

## Test it

To test it run:
```
ign gazebo buoyancy_engine.sdf
```
You will see two boxes. The box on the right doesn't have a surface set whereas
the box on the left does. When commanded t go up, the box on the left will rise
till it breaches and then start oscillating around the surface. On the other
hand the box on the right will rise forever as no surface is set.

![buoyancy_engine](https://user-images.githubusercontent.com/542272/149440646-0c15b5de-6775-44ce-ac0c-b3aa078fc73e.gif)

Enter the following in a separate terminal:
```
ign topic -t  /model/buoyant_box/buoyancy_engine/ -m ignition.msgs.Double
   -p "data: 0.003"
```
The boxes will float up. Note that the box on the left will start oscillating
once it breaches the surface.
```
ign topic -t  /model/buoyant_box/buoyancy_engine/ -m ignition.msgs.Double
   -p "data: 0.001"
```
The boxes will go down.
To see the current volume enter:
```
ign topic -t  /model/buoyant_box/buoyancy_engine/current_volume -e
```
## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
