### PR TITLE
Prevent GzScene3D 💥 if another scene is already loaded

### DIFF
--- a/src/gui/plugins/scene3d/GzScene3D.qml
+++ b/src/gui/plugins/scene3d/GzScene3D.qml
@@ -40,7 +40,7 @@ Rectangle {
     anchors.fill: parent
     hoverEnabled: true
     acceptedButtons: Qt.NoButton
-    visible: Scene3D.loadingError.length == 0
+    visible: GzScene3D.loadingError.length == 0
     onEntered: {
       GzScene3D.OnFocusWindow()
     }
@@ -53,7 +53,7 @@ Rectangle {
     id: renderWindow
     objectName: "renderWindow"
     anchors.fill: parent
-    visible: Scene3D.loadingError.length == 0
+    visible: GzScene3D.loadingError.length == 0
 
     /**
      * Message to be displayed over the render window
@@ -127,8 +127,8 @@ Rectangle {
   Label {
     anchors.fill: parent
     anchors.margins: 10
-    text: Scene3D.loadingError
-    visible: (Scene3D.loadingError.length > 0);
+    text: GzScene3D.loadingError
+    visible: (GzScene3D.loadingError.length > 0);
     wrapMode: Text.WordWrap
   }
 }

--- a/src/gui/plugins/scene3d/GzScene3D.qml
+++ b/src/gui/plugins/scene3d/GzScene3D.qml
@@ -14,16 +14,18 @@
  * limitations under the License.
  *
 */
+import IgnGazebo 1.0 as IgnGazebo
+import QtGraphicalEffects 1.0
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.3
 import RenderWindow 1.0
-import QtGraphicalEffects 1.0
-import IgnGazebo 1.0 as IgnGazebo
 
 Rectangle {
-  width: 1000
-  height: 800
+  Layout.minimumWidth: 200
+  Layout.minimumHeight: 200
+  anchors.fill: parent
 
   /**
    * True to enable gamma correction
@@ -38,6 +40,7 @@ Rectangle {
     anchors.fill: parent
     hoverEnabled: true
     acceptedButtons: Qt.NoButton
+    visible: Scene3D.loadingError.length == 0
     onEntered: {
       GzScene3D.OnFocusWindow()
     }
@@ -50,6 +53,7 @@ Rectangle {
     id: renderWindow
     objectName: "renderWindow"
     anchors.fill: parent
+    visible: Scene3D.loadingError.length == 0
 
     /**
      * Message to be displayed over the render window
@@ -120,4 +124,11 @@ Rectangle {
     standardButtons: Dialog.Ok
   }
 
+  Label {
+    anchors.fill: parent
+    anchors.margins: 10
+    text: Scene3D.loadingError
+    visible: (Scene3D.loadingError.length > 0);
+    wrapMode: Text.WordWrap
+  }
 }

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1643,17 +1643,25 @@ void IgnRenderer::HandleMouseViewControl()
 }
 
 /////////////////////////////////////////////////
-void IgnRenderer::Initialize()
+std::string IgnRenderer::Initialize()
 {
   if (this->initialized)
-    return;
+    return std::string();
+
+  // Only one engine / scene / user camera is currently supported.
+  // Fail gracefully even before getting to renderUtil.
+  if (!rendering::loadedEngines().empty())
+  {
+    return "Currently only one plugin providing a 3D scene is supported at a "
+            "time.";
+  }
 
   this->dataPtr->renderUtil.SetUseCurrentGLContext(true);
   this->dataPtr->renderUtil.Init();
 
   rendering::ScenePtr scene = this->dataPtr->renderUtil.Scene();
   if (!scene)
-    return;
+    return "Failed to create a 3D scene.";
 
   auto root = scene->RootVisual();
 
@@ -1674,6 +1682,7 @@ void IgnRenderer::Initialize()
   this->dataPtr->rayQuery = this->dataPtr->camera->Scene()->CreateRayQuery();
 
   this->initialized = true;
+  return std::string();
 }
 
 /////////////////////////////////////////////////
@@ -2067,6 +2076,12 @@ RenderThread::RenderThread()
 }
 
 /////////////////////////////////////////////////
+void RenderThread::SetErrorCb(std::function<void(const QString&)> _cb)
+{
+  this->errorCb = _cb;
+}
+
+/////////////////////////////////////////////////
 void RenderThread::RenderNext()
 {
   this->context->makeCurrent(this->surface);
@@ -2074,7 +2089,12 @@ void RenderThread::RenderNext()
   if (!this->ignRenderer.initialized)
   {
     // Initialize renderer
-    this->ignRenderer.Initialize();
+    auto loadingError = this->ignRenderer.Initialize();
+    if (!loadingError.empty())
+    {
+      this->errorCb(QString::fromStdString(loadingError));
+      return;
+    }
   }
 
   // check if engine has been successfully initialized
@@ -2092,18 +2112,24 @@ void RenderThread::RenderNext()
 /////////////////////////////////////////////////
 void RenderThread::ShutDown()
 {
-  this->context->makeCurrent(this->surface);
+  if (this->context && this->surface)
+    this->context->makeCurrent(this->surface);
 
   this->ignRenderer.Destroy();
 
-  this->context->doneCurrent();
-  delete this->context;
+  if (this->context)
+  {
+    this->context->doneCurrent();
+    delete this->context;
+  }
 
   // schedule this to be deleted only after we're done cleaning up
-  this->surface->deleteLater();
+  if (this->surface)
+    this->surface->deleteLater();
 
   // Stop event processing, move the thread to GUI and make sure it is deleted.
-  this->moveToThread(QGuiApplication::instance()->thread());
+  if (this->ignRenderer.initialized)
+    this->moveToThread(QGuiApplication::instance()->thread());
 }
 
 
@@ -2203,16 +2229,6 @@ void TextureNode::PrepareNode()
 RenderWindowItem::RenderWindowItem(QQuickItem *_parent)
   : QQuickItem(_parent), dataPtr(new RenderWindowItemPrivate)
 {
-  // FIXME(anyone) Ogre 1/2 singletons crash when there's an attempt to load
-  // this plugin twice, so shortcut here. Ideally this would be caught at
-  // Ignition Rendering.
-  static bool done{false};
-  if (done)
-  {
-    return;
-  }
-  done = true;
-
   this->setAcceptedMouseButtons(Qt::AllButtons);
   this->setFlag(ItemHasContents);
   this->dataPtr->renderThread = new RenderThread();
@@ -2378,18 +2394,6 @@ Scene3D::~Scene3D() = default;
 /////////////////////////////////////////////////
 void Scene3D::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 {
-  // FIXME(anyone) Ogre 1/2 singletons crash when there's an attempt to load
-  // this plugin twice, so shortcut here. Ideally this would be caught at
-  // Ignition Rendering.
-  static bool done{false};
-  if (done)
-  {
-    ignerr << "Only one Scene3D is supported per process at the moment."
-           << std::endl;
-    return;
-  }
-  done = true;
-
   auto renderWindow = this->PluginItem()->findChild<RenderWindowItem *>();
   if (!renderWindow)
   {
@@ -2397,6 +2401,8 @@ void Scene3D::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
            << "Render window will not be created" << std::endl;
     return;
   }
+  renderWindow->SetErrorCb(std::bind(&Scene3D::SetLoadingError, this,
+      std::placeholders::_1));
 
   if (this->title.empty())
     this->title = "3D Scene";
@@ -2892,6 +2898,19 @@ void Scene3D::OnFocusWindow()
 }
 
 /////////////////////////////////////////////////
+QString Scene3D::LoadingError() const
+{
+  return this->loadingError;
+}
+
+/////////////////////////////////////////////////
+void Scene3D::SetLoadingError(const QString &_loadingError)
+{
+  this->loadingError = _loadingError;
+  this->LoadingErrorChanged();
+}
+
+/////////////////////////////////////////////////
 void RenderWindowItem::SetXYZSnap(const math::Vector3d &_xyz)
 {
   this->dataPtr->renderThread->ignRenderer.SetXYZSnap(_xyz);
@@ -3178,6 +3197,12 @@ void RenderWindowItem::SetRecordVideoBitrate(unsigned int _bitrate)
 void RenderWindowItem::OnHovered(const ignition::math::Vector2i &_hoverPos)
 {
   this->dataPtr->renderThread->ignRenderer.NewHoverEvent(_hoverPos);
+}
+
+/////////////////////////////////////////////////
+void RenderWindowItem::SetErrorCb(std::function<void(const QString&)> _cb)
+{
+  this->dataPtr->renderThread->SetErrorCb(_cb);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/scene3d/Scene3D.hh
+++ b/src/gui/plugins/scene3d/Scene3D.hh
@@ -56,9 +56,12 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
   class Scene3DPrivate;
   class RenderUtil;
 
-  /// \brief Creates a new ignition rendering scene or adds a user-camera to an
-  /// existing scene. It is possible to orbit the camera around the scene with
+  /// \brief Creates an ignition rendering scene and user camera.
+  /// It is possible to orbit the camera around the scene with
   /// the mouse. Use other plugins to manage objects in the scene.
+  ///
+  /// Only one plugin displaying an Ignition Rendering scene can be used at a
+  /// time.
   ///
   /// ## Configuration
   ///
@@ -86,6 +89,14 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
       READ ErrorPopupText
       WRITE SetErrorPopupText
       NOTIFY ErrorPopupTextChanged
+    )
+
+    /// \brief Loading error message
+    Q_PROPERTY(
+      QString loadingError
+      READ LoadingError
+      WRITE SetLoadingError
+      NOTIFY LoadingErrorChanged
     )
 
     /// \brief Constructor
@@ -185,6 +196,20 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// the connection to work on the QML side
     signals: void popupError();
 
+    /// \brief Get the loading error string.
+    /// \return String explaining the loading error. If empty, there's no error.
+    public: Q_INVOKABLE QString LoadingError() const;
+
+    /// \brief Set the loading error message.
+    /// \param[in] _loadingError Error message.
+    public: Q_INVOKABLE void SetLoadingError(const QString &_loadingError);
+
+    /// \brief Notify that loading error has changed
+    signals: void LoadingErrorChanged();
+
+    /// \brief Loading error message
+    public: QString loadingError;
+
     /// \internal
     /// \brief Pointer to private data.
     private: std::unique_ptr<Scene3DPrivate> dataPtr;
@@ -210,7 +235,9 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     public: void Render();
 
     /// \brief Initialize the render engine
-    public: void Initialize();
+    /// \return Error message if initialization failed. If empty, no errors
+    /// occurred.
+    public: std::string Initialize();
 
     /// \brief Destroy camera associated with this renderer
     public: void Destroy();
@@ -519,6 +546,13 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \param[in] _size Size of the texture
     signals: void TextureReady(int _id, const QSize &_size);
 
+    /// \brief Set a callback to be called in case there are errors.
+    /// \param[in] _cb Error callback
+    public: void SetErrorCb(std::function<void(const QString &)> _cb);
+
+    /// \brief Function to be called if there are errors.
+    public: std::function<void(const QString &)> errorCb;
+
     /// \brief Offscreen surface to render to
     public: QOffscreenSurface *surface = nullptr;
 
@@ -725,6 +759,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Qt callback when context menu request is received
     /// \param[in] _entity Scoped name of entity.
     public slots: void OnContextMenuRequested(QString _entity);
+
+    /// \brief Set a callback to be called in case there are errors.
+    /// \param[in] _cb Error callback
+    public: void SetErrorCb(std::function<void(const QString &)> _cb);
 
     /// \internal
     /// \brief Pointer to private data.


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254
* Similar to https://github.com/ignitionrobotics/ign-gui/pull/347

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Current issue:

1. Start `ign gazebo`
2. From the top-right menu, select `Gz Scene 3D`
3. Wait a bit
4. :boom: 

This PR prevents a crash and prints a message explaining to the user what happened.

![gzscene_boom](https://user-images.githubusercontent.com/5751272/149585495-bd1fb3f0-643e-4da5-add4-1bc01eb2ec6e.gif)

The message will be printed if there's any other plugin already loading a render engine, so it's compatible with both `GzScene3D` and `Scene3D`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
