### PR TITLE
Mark Component::Clone as const

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -73,6 +73,10 @@ since pose information is being logged in the `changed_state` topic.
 * The `gui.config` and `server.config` files are now located in a versioned
   folder inside `$HOME/.ignition/gazebo`, i.e. `$HOME/.ignition/gazebo/6/gui.config`.
 
+* The `Component::Clone` method has been marked `const` to reflect that it 
+  should not mutate internal component state. Component implementations that
+  overrode the `Clone` method must also be marked `const`.
+
 ## Ignition Gazebo 5.2 to 5.3
 
 * If no `<namespace>` is given to the `Thruster` plugin, the namespace now

--- a/include/ignition/gazebo/components/Component.hh
+++ b/include/ignition/gazebo/components/Component.hh
@@ -282,7 +282,7 @@ namespace components
 
     /// \brief Clone the component.
     /// \return A pointer to the component.
-    public: virtual std::unique_ptr<BaseComponent> Clone() = 0;
+    public: virtual std::unique_ptr<BaseComponent> Clone() const = 0;
   };
 
   /// \brief A component type that wraps any data type. The intention is for
@@ -347,7 +347,7 @@ namespace components
     public: bool operator!=(const Component &_component) const;
 
     // Documentation inherited
-    public: std::unique_ptr<BaseComponent> Clone() override;
+    public: std::unique_ptr<BaseComponent> Clone() const override;
 
     // Documentation inherited
     public: ComponentTypeId TypeId() const override;
@@ -416,7 +416,7 @@ namespace components
                             Serializer> &_component) const;
 
     // Documentation inherited
-    public: std::unique_ptr<BaseComponent> Clone() override;
+    public: std::unique_ptr<BaseComponent> Clone() const override;
 
     // Documentation inherited
     public: ComponentTypeId TypeId() const override;
@@ -503,7 +503,7 @@ namespace components
   //////////////////////////////////////////////////
   template <typename DataType, typename Identifier, typename Serializer>
   std::unique_ptr<BaseComponent>
-  Component<DataType, Identifier, Serializer>::Clone()
+  Component<DataType, Identifier, Serializer>::Clone() const
   {
     Component<DataType, Identifier, Serializer> clonedComp(this->Data());
     return std::make_unique<Component<DataType, Identifier, Serializer>>(
@@ -536,7 +536,7 @@ namespace components
   //////////////////////////////////////////////////
   template <typename Identifier, typename Serializer>
   std::unique_ptr<BaseComponent>
-  Component<NoData, Identifier, Serializer>::Clone()
+  Component<NoData, Identifier, Serializer>::Clone() const
   {
     return std::make_unique<Component<NoData, Identifier, Serializer>>();
   }

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -178,7 +178,7 @@ class NoSerialize : public components::BaseComponent
     return 0;
   }
 
-  public: std::unique_ptr<BaseComponent> Clone() override
+  public: std::unique_ptr<BaseComponent> Clone() const override
   {
     return nullptr;
   }


### PR DESCRIPTION
Split from #1249.  Mark `Clone` method as `const`.

This is likely not back-portable as it breaks API.  Any components that implement a custom `Clone` will fail to compile.  There are none in the main `ign-gazebo` codebase, but there is a possibility of external users doing so.

Signed-off-by: Michael Carroll <michael@openrobotics.org>
