### PR TITLE
Fix typo in EntityComponentManager

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1453,7 +1453,7 @@ void EntityComponentManager::AddEntityToMessage(msgs::SerializedStateMap &_msg,
         // periodic change
         auto periodicIter = this->dataPtr->periodicChangedComponents.find(type);
         if (periodicIter != this->dataPtr->periodicChangedComponents.end() &&
-            periodicIter->second.find(_entity) != oneTimeIter->second.end())
+            periodicIter->second.find(_entity) != periodicIter->second.end())
           noChange = false;
       }
 


### PR DESCRIPTION
This typo appears to be an artifact of some earlier copy-pastes. It sometimes causes the SceneBroadcaster to crash in unoptimized builds.

Signed-off-by: Sicong (Anson) Wang <sicongw@google.com>