### PR TITLE
Document the `<topic>` option for JointPositionController.

### DIFF
--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -36,10 +36,12 @@ namespace systems
   ///
   /// A new Ignition Transport topic is created to send target joint positions.
   /// The topic name is
-  /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos"
+  /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos".
   ///
   /// This topic accepts ignition::msgs::Double values representing the target
-  /// position.
+  /// position. If you wish to change the topic on which this plugin listens
+  /// you may use the `<topic>` parameter to specify which topic the plugin
+  /// should listen on.
   ///
   /// ## System Parameters
   ///
@@ -75,6 +77,10 @@ namespace systems
   /// `<use_velocity_commands>` Bypasses the PID and creates a perfect
   /// position. The maximum speed on the joint can be set using the `<cmd_max>`
   /// tag.
+  ///
+  /// `<topic>` If you wish to listen on a non-default topic you may specify it
+  /// here, otherwise the controller defaults to listening on
+  /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos".
   class JointPositionController
       : public System,
         public ISystemConfigure,


### PR DESCRIPTION
I discovered that the `<topic>` parameter has not been documented in the docstring. This mini-PR adds the docs for it.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>