### PR TITLE
Log an error if JointPositionController cannot find the joint. 

### DIFF
--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -236,7 +236,8 @@ void JointPositionController::PreUpdate(
   {
     static bool warned = false;
     if(!warned)
-      ignerr << "Could not find joint with name [" << this->dataPtr->jointName <<";\n";
+      ignerr << "Could not find joint with name ["
+        << this->dataPtr->jointName <<";\n";
     warned = true;
     return;
   }

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -230,8 +230,16 @@ void JointPositionController::PreUpdate(
         this->dataPtr->model.JointByName(_ecm, this->dataPtr->jointName);
   }
 
+  // If the joint is still not found then warn the user, they may have entered
+  // the wrong joint name.
   if (this->dataPtr->jointEntity == kNullEntity)
+  {
+    static bool warned = false;
+    if(!warned)
+      ignerr << "Could not find joint with name [" << this->dataPtr->jointName <<";\n";
+    warned = true;
     return;
+  }
 
   // Nothing left to do if paused.
   if (_info.paused)


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes #<NUMBER>

## Summary
In the event a user enters the wrong name for a certain joint, the JointPositionController system will silently fail. This PR adds a simple error message that tells the user that the joint was not found. Let me know if we should target citadel instead of fortress.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸