### PR TITLE
Fix UNIT_SdfGenerator_TEST

### DIFF
--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -547,7 +547,7 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2/";
+      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

`UNIT_SdfGenerator_TEST` is failing in Edifice in all builds. This should fix the test.

This fixed in Fortress in https://github.com/ignitionrobotics/ign-gazebo/pull/1286

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.