### PR TITLE
[style-fix] Fix weird indentation in `Link.hh`

### DIFF
--- a/include/ignition/gazebo/Link.hh
+++ b/include/ignition/gazebo/Link.hh
@@ -220,13 +220,13 @@ namespace ignition
       public: void EnableVelocityChecks(EntityComponentManager &_ecm,
           bool _enable = true) const;
 
-       /// \brief Get the angular acceleration of the body in the world frame.
-       /// \param[in] _ecm Entity-component manager.
-       /// \return Angular acceleration of the body in the world frame or
-       /// nullopt if acceleration checks aren't enabled.
-       /// \sa EnableAccelerationChecks
-       public: std::optional<math::Vector3d> WorldAngularAcceleration(
-           const EntityComponentManager &_ecm) const;
+      /// \brief Get the angular acceleration of the body in the world frame.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Angular acceleration of the body in the world frame or
+      /// nullopt if acceleration checks aren't enabled.
+      /// \sa EnableAccelerationChecks
+      public: std::optional<math::Vector3d> WorldAngularAcceleration(
+          const EntityComponentManager &_ecm) const;
 
       /// \brief Get the linear acceleration of the body in the world frame.
       /// \param[in] _ecm Entity-component manager.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
There was some weird indentation going on in the `Link.hh` header file. This PR fixes it.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
