### PR TITLE
Prepare for releasing 6.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo6 VERSION 6.4.0)
+project(ignition-gazebo6 VERSION 6.5.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,79 @@
 
 ### Ignition Gazebo 6.X.X (202X-XX-XX)
 
+### Ignition Gazebo 6.5.0 (202X-XX-XX)
+1. New trajectory follower system
+    * [Pull request #1332](https://github.com/ignitionrobotics/ign-gazebo/pull/1332)
+
+1. Extend ShaderParam system to support textures
+    * [Pull request #1310](https://github.com/ignitionrobotics/ign-gazebo/pull/1310)
+
+1. Adds a `Link::SetLinearVelocity()` method
+    * [Pull request #1323](https://github.com/ignitionrobotics/ign-gazebo/pull/1323)
+
+1. Fix weird indentation in `Link.hh`
+    * [Pull request #1324](https://github.com/ignitionrobotics/ign-gazebo/pull/1324)
+
+1. fix buoyancy test by increasing tol
+    * [Pull request #fix buoyancy test by increasing tol](https://github.com/ignitionrobotics/ign-gazebo/pull/fix buoyancy test by increasing tol)
+
+1. Limit thruster system's input thrust cmd
+    * [Pull request #1318](https://github.com/ignitionrobotics/ign-gazebo/pull/1318)
+
+1. Load and run visual plugin (system) on GUI side
+    * [Pull request #1275](https://github.com/ignitionrobotics/ign-gazebo/pull/1275)
+
+1. Log an error if JointPositionController cannot find the joint. (citadel retarget)
+    * [Pull request #1314](https://github.com/ignitionrobotics/ign-gazebo/pull/1314)
+
+1. Update source install instructions
+    * [Pull request #1311](https://github.com/ignitionrobotics/ign-gazebo/pull/1311)
+
+1. Document the `<topic>` option for JointPositionController.
+    * [Pull request #1309](https://github.com/ignitionrobotics/ign-gazebo/pull/1309)
+
+1. Fix typo in EntityComponentManager
+    * [Pull request #1304](https://github.com/ignitionrobotics/ign-gazebo/pull/1304)
+
+1. Buoyancy: fix center of volume's reference frame
+    * [Pull request #1302](https://github.com/ignitionrobotics/ign-gazebo/pull/1302)
+
+1. Fix graded buoyancy problems
+    * [Pull request #1297](https://github.com/ignitionrobotics/ign-gazebo/pull/1297)
+
+1. Add surface to buoyancy engine. (retarget fortress)
+    * [Pull request #1298](https://github.com/ignitionrobotics/ign-gazebo/pull/1298)
+
+1. Remove EachNew calls from sensor PreUpdates
+    * [Pull request #1281](https://github.com/ignitionrobotics/ign-gazebo/pull/1281)
+
+1. Prevent GzScene3D 💥 if another scene is already loaded
+    * [Pull request #1294](https://github.com/ignitionrobotics/ign-gazebo/pull/1294)
+
+1. Fix various typos on API documentation
+    * [Pull request #1291](https://github.com/ignitionrobotics/ign-gazebo/pull/1291)
+
+1. Optional orientation when spawning entity using spherical coordinates
+    * [Pull request #1263](https://github.com/ignitionrobotics/ign-gazebo/pull/1263)
+
+1. Cleanup update call for non-rendering sensors
+    * [Pull request #1282](https://github.com/ignitionrobotics/ign-gazebo/pull/1282)
+
+1. Documentation Error
+    * [Pull request #1285](https://github.com/ignitionrobotics/ign-gazebo/pull/1285)
+
+1. Min and max parameters for velocity, acceleration, and jerk apply to linear and angular separately.
+    * [Pull request #1229](https://github.com/ignitionrobotics/ign-gazebo/pull/1229)
+
+1. Add project() call to examples
+    * [Pull request #1274](https://github.com/ignitionrobotics/ign-gazebo/pull/1274)
+
+1. Implement /server_control::stop
+    * [Pull request #1240](https://github.com/ignitionrobotics/ign-gazebo/pull/1240)
+
+1. 👩‍🌾 Make depth camera tests more robust (#897)
+    * [Pull request #897) (#1257](https://github.com/ignitionrobotics/ign-gazebo/pull/897) (#1257)
+
 ### Ignition Gazebo 6.4.0 (2021-01-13)
 
 1. Disable more tests on Windows

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,6 @@
 1. Fix weird indentation in `Link.hh`
     * [Pull request #1324](https://github.com/ignitionrobotics/ign-gazebo/pull/1324)
 
-1. fix buoyancy test by increasing tol
-    * [Pull request #fix buoyancy test by increasing tol](https://github.com/ignitionrobotics/ign-gazebo/pull/fix buoyancy test by increasing tol)
-
 1. Limit thruster system's input thrust cmd
     * [Pull request #1318](https://github.com/ignitionrobotics/ign-gazebo/pull/1318)
 
@@ -71,9 +68,6 @@
 
 1. Implement /server_control::stop
     * [Pull request #1240](https://github.com/ignitionrobotics/ign-gazebo/pull/1240)
-
-1. 👩‍🌾 Make depth camera tests more robust (#897)
-    * [Pull request #897) (#1257](https://github.com/ignitionrobotics/ign-gazebo/pull/897) (#1257)
 
 ### Ignition Gazebo 6.4.0 (2021-01-13)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.5.0 release.

Comparison to 6.4.0: https://github.com/ignitionrobotics/ign-gazebo/compare/ignition-gazebo6_6.4.0...prepare_6_5_0

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [x] Bumped version in ign-gazebo6-release 

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.