### PR TITLE
Refactor System functionality into SystemManager

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ set (sources
   ServerPrivate.cc
   SimulationRunner.cc
   SystemLoader.cc
+  SystemManager.cc
   TestFixture.cc
   Util.cc
   World.cc
@@ -86,6 +87,7 @@ set (gtest_sources
   Server_TEST.cc
   SimulationRunner_TEST.cc
   SystemLoader_TEST.cc
+  SystemManager_TEST.cc
   System_TEST.cc
   TestFixture_TEST.cc
   Util_TEST.cc

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -456,10 +456,8 @@ void SimulationRunner::AddSystem(const SystemPluginPtr &_system,
       std::optional<Entity> _entity,
       std::optional<std::shared_ptr<const sdf::Element>> _sdf)
 {
-  auto entity = _entity.has_value() ? _entity.value()
-      : worldEntity(this->entityCompMgr);
-  auto sdf = _sdf.has_value() ? _sdf.value() : this->sdfWorld->Element();
-
+  auto entity = _entity.value_or(worldEntity(this->entityCompMgr));
+  auto sdf = _sdf.value_or(this->sdfWorld->Element());
   this->systemMgr->AddSystem(_system, entity, sdf);
 }
 
@@ -469,10 +467,8 @@ void SimulationRunner::AddSystem(
       std::optional<Entity> _entity,
       std::optional<std::shared_ptr<const sdf::Element>> _sdf)
 {
-  auto entity = _entity.has_value() ? _entity.value()
-      : worldEntity(this->entityCompMgr);
-  auto sdf = _sdf.has_value() ? _sdf.value() : this->sdfWorld->Element();
-
+  auto entity = _entity.value_or(worldEntity(this->entityCompMgr));
+  auto sdf = _sdf.value_or(this->sdfWorld->Element());
   this->systemMgr->AddSystem(_system, entity, sdf);
 }
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -113,7 +113,8 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   }
 
   // Create the system manager
-  this->systemMgr = std::make_unique<SystemManager>(_systemLoader);
+  this->systemMgr = std::make_unique<SystemManager>(_systemLoader,
+      &this->entityCompMgr, &this->eventMgr);
 
   this->pauseConn = this->eventMgr.Connect<events::Pause>(
       std::bind(&SimulationRunner::SetPaused, this, std::placeholders::_1));
@@ -460,7 +461,6 @@ void SimulationRunner::AddSystem(const SystemPluginPtr &_system,
   auto sdf = _sdf.has_value() ? _sdf.value() : this->sdfWorld->Element();
 
   this->systemMgr->AddSystem(_system, entity, sdf);
-  this->systemMgr->ConfigurePendingSystems(this->entityCompMgr, this->eventMgr);
 }
 
 //////////////////////////////////////////////////
@@ -474,7 +474,6 @@ void SimulationRunner::AddSystem(
   auto sdf = _sdf.has_value() ? _sdf.value() : this->sdfWorld->Element();
 
   this->systemMgr->AddSystem(_system, entity, sdf);
-  this->systemMgr->ConfigurePendingSystems(this->entityCompMgr, this->eventMgr);
 }
 
 /////////////////////////////////////////////////
@@ -865,8 +864,6 @@ void SimulationRunner::LoadPlugin(const Entity _entity,
                                   const sdf::ElementPtr &_sdf)
 {
   this->systemMgr->LoadPlugin(_entity, _fname, _name, _sdf);
-  this->systemMgr->ConfigurePendingSystems(
-      this->entityCompMgr, this->eventMgr);
 }
 
 //////////////////////////////////////////////////

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -389,9 +389,6 @@ namespace ignition
       /// server is in the run state.
       private: std::atomic<bool> running{false};
 
-      /// \brief Manager of all systems.
-      private: std::unique_ptr<SystemManager> systemMgr;
-
       /// \brief Manager of all events.
       /// Note: must be before EntityComponentManager
       private: EventManager eventMgr;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -389,13 +389,17 @@ namespace ignition
       /// server is in the run state.
       private: std::atomic<bool> running{false};
 
+      /// \brief Manager of all systems.
+      /// Note: must be before EntityComponentManager
+      /// Note: must be before EventMgr
+      /// Because systems have access to the ECM and Events, they need to be
+      /// cleanly stopped and destructed before destroying the event manager
+      /// and entity component manager.
+      private: std::unique_ptr<SystemManager> systemMgr;
+
       /// \brief Manager of all events.
       /// Note: must be before EntityComponentManager
       private: EventManager eventMgr;
-
-      /// \brief Manager of all systems.
-      /// Note: must be before EntityComponentManager
-      private: std::unique_ptr<SystemManager> systemMgr;
 
       /// \brief Manager of all components.
       private: EntityComponentManager entityCompMgr;

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -89,6 +89,14 @@ namespace ignition
       /// Will be nullptr if the System doesn't implement this interface.
       public: ISystemPostUpdate *postupdate = nullptr;
 
+      /// \brief Cached entity that was used to call `Configure` on the system
+      /// Useful for if a system needs to be reconfigured at runtime
+      public: Entity configureEntity = {kNullEntity};
+
+      /// \brief Cached sdf that was used to call `Configure` on the system
+      /// Useful for if a system needs to be reconfigured at runtime
+      public: std::shared_ptr<const sdf::Element> configureSdf = nullptr;
+
       /// \brief Vector of queries and callbacks
       public: std::vector<EntityQueryCallback> updates;
     };

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_SYSTEMINTERNAL_HH_
+#define IGNITION_GAZEBO_SYSTEMINTERNAL_HH_
+
+#include <chrono>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "ignition/gazebo/config.hh"
+#include "ignition/gazebo/System.hh"
+#include "ignition/gazebo/SystemPluginPtr.hh"
+
+namespace ignition
+{
+  namespace gazebo
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+
+    /// \brief Class to hold systems internally. It supports systems loaded
+    /// from plugins, as well as systems created at runtime.
+    class SystemInternal
+    {
+      /// \brief Constructor
+      /// \param[in] _systemPlugin A system loaded from a plugin.
+      public: explicit SystemInternal(SystemPluginPtr _systemPlugin)
+              : systemPlugin(std::move(_systemPlugin)),
+                system(systemPlugin->QueryInterface<System>()),
+                configure(systemPlugin->QueryInterface<ISystemConfigure>()),
+                preupdate(systemPlugin->QueryInterface<ISystemPreUpdate>()),
+                update(systemPlugin->QueryInterface<ISystemUpdate>()),
+                postupdate(systemPlugin->QueryInterface<ISystemPostUpdate>())
+      {
+      }
+
+      /// \brief Constructor
+      /// \param[in] _system Pointer to a system.
+      public: explicit SystemInternal(const std::shared_ptr<System> &_system)
+              : systemShared(_system),
+                system(_system.get()),
+                configure(dynamic_cast<ISystemConfigure *>(_system.get())),
+                preupdate(dynamic_cast<ISystemPreUpdate *>(_system.get())),
+                update(dynamic_cast<ISystemUpdate *>(_system.get())),
+                postupdate(dynamic_cast<ISystemPostUpdate *>(_system.get()))
+      {
+      }
+
+      /// \brief Plugin object. This manages the lifecycle of the instantiated
+      /// class as well as the shared library.
+      /// This will be null if the system wasn't loaded from a plugin.
+      public: SystemPluginPtr systemPlugin;
+
+      /// \brief Pointer to a system.
+      /// This will be null if the system wasn't loaded from a pointer.
+      public: std::shared_ptr<System> systemShared{nullptr};
+
+      /// \brief Access this system via the `System` interface
+      public: System *system = nullptr;
+
+      /// \brief Access this system via the ISystemConfigure interface
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemConfigure *configure = nullptr;
+
+      /// \brief Access this system via the ISystemPreUpdate interface
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemPreUpdate *preupdate = nullptr;
+
+      /// \brief Access this system via the ISystemUpdate interface
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemUpdate *update = nullptr;
+
+      /// \brief Access this system via the ISystemPostUpdate interface
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemPostUpdate *postupdate = nullptr;
+
+      /// \brief Vector of queries and callbacks
+      public: std::vector<EntityQueryCallback> updates;
+    };
+    }
+  }  // namespace gazebo
+}  // namespace ignition
+#endif  // IGNITION_GAZEBO_SYSTEMINTERNAL_HH_
+

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -54,28 +54,26 @@ void SystemManager::LoadPlugin(const Entity _entity,
 //////////////////////////////////////////////////
 size_t SystemManager::TotalCount() const
 {
-  std::lock_guard<std::mutex> lock(this->systemsMutex);
-  return this->systems.size() + this->pendingSystems.size();
+  return this->ActiveCount() + this->PendingCount();
 }
 
 //////////////////////////////////////////////////
 size_t SystemManager::ActiveCount() const
 {
-  std::lock_guard<std::mutex> lock(this->systemsMutex);
   return this->systems.size();
 }
 
 //////////////////////////////////////////////////
 size_t SystemManager::PendingCount() const
 {
-  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  std::lock_guard<std::mutex> lock(this->pendingSystemsMutex);
   return this->pendingSystems.size();
 }
 
 //////////////////////////////////////////////////
 size_t SystemManager::ActivatePendingSystems()
 {
-  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  std::lock_guard<std::mutex> lock(this->pendingSystemsMutex);
 
   auto count = this->pendingSystems.size();
 
@@ -132,7 +130,7 @@ void SystemManager::AddSystemImpl(
   }
 
   // Update callbacks will be handled later, add to queue
-  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  std::lock_guard<std::mutex> lock(this->pendingSystemsMutex);
   this->pendingSystems.push_back(_system);
 }
 

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "SystemManager.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+//////////////////////////////////////////////////
+SystemManager::SystemManager(const SystemLoaderPtr &_systemLoader)
+  : systemLoader(_systemLoader)
+{
+}
+
+//////////////////////////////////////////////////
+void SystemManager::LoadPlugin(const Entity _entity,
+                               const std::string &_fname,
+                               const std::string &_name,
+                               const sdf::ElementPtr &_sdf)
+{
+  std::optional<SystemPluginPtr> system;
+  {
+    std::lock_guard<std::mutex> lock(this->systemLoaderMutex);
+    system = this->systemLoader->LoadPlugin(_fname, _name, _sdf);
+  }
+
+  // System correctly loaded from library
+  if (system)
+  {
+    this->AddSystem(system.value(), _entity, _sdf);
+    igndbg << "Loaded system [" << _name
+           << "] for entity [" << _entity << "]" << std::endl;
+  }
+}
+
+//////////////////////////////////////////////////
+size_t SystemManager::TotalCount() const
+{
+  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  return this->systems.size() + this->pendingSystems.size();
+}
+
+//////////////////////////////////////////////////
+size_t SystemManager::ActiveCount() const
+{
+  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  return this->systems.size();
+}
+
+//////////////////////////////////////////////////
+size_t SystemManager::PendingCount() const
+{
+  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  return this->pendingSystems.size();
+}
+
+//////////////////////////////////////////////////
+void SystemManager::ConfigurePendingSystems(EntityComponentManager &_ecm,
+                                            EventManager &_eventMgr)
+{
+  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  for (size_t ii = 0; ii < this->pendingSystems.size(); ++ii)
+  {
+    if (this->pendingSystemsConfigured[ii])
+      continue;
+
+    const auto& system = this->pendingSystems[ii];
+
+    if (system.configure)
+    {
+      system.configure->Configure(system.configureEntity,
+                                  system.configureSdf,
+                                  _ecm, _eventMgr);
+      this->pendingSystemsConfigured[ii] = true;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+size_t SystemManager::ActivatePendingSystems()
+{
+  std::lock_guard<std::mutex> lock(this->systemsMutex);
+
+  auto count = this->pendingSystems.size();
+
+  for (const auto& system : this->pendingSystems)
+  {
+    this->systems.push_back(system);
+
+    if (system.configure)
+      this->systemsConfigure.push_back(system.configure);
+
+    if (system.preupdate)
+      this->systemsPreupdate.push_back(system.preupdate);
+
+    if (system.update)
+      this->systemsUpdate.push_back(system.update);
+
+    if (system.postupdate)
+      this->systemsPostupdate.push_back(system.postupdate);
+  }
+
+  this->pendingSystems.clear();
+  this->pendingSystemsConfigured.clear();
+  return count;
+}
+
+//////////////////////////////////////////////////
+void SystemManager::AddSystem(const SystemPluginPtr &_system,
+      Entity _entity,
+      std::shared_ptr<const sdf::Element> _sdf)
+{
+  this->AddSystemImpl(SystemInternal(_system), _entity, _sdf);
+}
+
+//////////////////////////////////////////////////
+void SystemManager::AddSystem(
+      const std::shared_ptr<System> &_system,
+      Entity _entity,
+      std::shared_ptr<const sdf::Element> _sdf)
+{
+  this->AddSystemImpl(SystemInternal(_system), _entity, _sdf);
+}
+
+//////////////////////////////////////////////////
+void SystemManager::AddSystemImpl(
+      SystemInternal _system,
+      Entity _entity,
+      std::shared_ptr<const sdf::Element> _sdf)
+{
+  _system.configureEntity = _entity;
+  _system.configureSdf = _sdf;
+
+  // Update callbacks will be handled later, add to queue
+  std::lock_guard<std::mutex> lock(this->systemsMutex);
+  this->pendingSystems.push_back(_system);
+  this->pendingSystemsConfigured.push_back(false);
+}
+
+//////////////////////////////////////////////////
+const std::vector<ISystemConfigure *>& SystemManager::SystemsConfigure()
+{
+  return this->systemsConfigure;
+}
+
+//////////////////////////////////////////////////
+const std::vector<ISystemPreUpdate *>& SystemManager::SystemsPreUpdate()
+{
+  return this->systemsPreupdate;
+}
+
+//////////////////////////////////////////////////
+const std::vector<ISystemUpdate *>& SystemManager::SystemsUpdate()
+{
+  return this->systemsUpdate;
+}
+
+//////////////////////////////////////////////////
+const std::vector<ISystemPostUpdate *>& SystemManager::SystemsPostUpdate()
+{
+  return this->systemsPostupdate;
+}

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -120,11 +120,8 @@ namespace ignition
       /// \brief Pending systems to be added to systems.
       private: std::vector<SystemInternal> pendingSystems;
 
-      /// \brief Mark if a pending system has been configured
-      private: std::vector<bool> pendingSystemsConfigured;
-
       /// \brief Mutex to protect pendingSystems
-      private: mutable std::mutex systemsMutex;
+      private: mutable std::mutex pendingSystemsMutex;
 
       /// \brief Systems implementing Configure
       private: std::vector<ISystemConfigure *> systemsConfigure;

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -42,7 +42,13 @@ namespace ignition
       /// \brief Constructor
       /// \param[in] _systemLoader A pointer to a SystemLoader to load plugins
       ///  from files
-      public: explicit SystemManager(const SystemLoaderPtr &_systemLoader);
+      /// \param[in] _entityCompMgr Pointer to the entity component manager to
+      ///  be used when configuring new systems
+      /// \param[in] _eventMgr Pointer to the event manager to be used when
+      ///  configuring new systems
+      public: explicit SystemManager(const SystemLoaderPtr &_systemLoader,
+                            EntityComponentManager *_entityCompMgr = nullptr,
+                            EventManager *_eventMgr = nullptr);
 
       /// \brief Load system plugin for a given entity.
       /// \param[in] _entity Entity
@@ -81,12 +87,6 @@ namespace ignition
       /// \brief Get the count of all (pending + active) managed systems
       /// \return The count.
       public: size_t TotalCount() const;
-
-      /// \brief Call the configure call on all pending systems
-      /// \param[in] _ecm The entity component manager to configure with
-      /// \param[in] _evetnMgr The event manager to configure with
-      public: void ConfigurePendingSystems(EntityComponentManager &_ecm,
-                                           EventManager &_eventMgr);
 
       /// \brief Move all "pending" systems to "active" state
       /// \return The number of newly-active systems
@@ -143,6 +143,12 @@ namespace ignition
 
       /// \brief Mutex to protect systemLoader
       private: std::mutex systemLoaderMutex;
+
+      /// \brief Pointer to associated entity component manager
+      private: EntityComponentManager *entityCompMgr;
+
+      /// \brief Pointer to associated event manager
+      private: EventManager *eventMgr;
     };
     }
   }  // namespace gazebo

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_SYSTEMMANAGER_HH_
+#define IGNITION_GAZEBO_SYSTEMMANAGER_HH_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ignition/gazebo/config.hh"
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/SystemLoader.hh"
+#include "ignition/gazebo/Types.hh"
+
+#include "SystemInternal.hh"
+
+namespace ignition
+{
+  namespace gazebo
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+
+    /// \brief Used to load / unload sysetms as well as iterate over them.
+    class SystemManager
+    {
+      /// \brief Constructor
+      /// \param[in] _systemLoader A pointer to a SystemLoader to load plugins
+      ///  from files
+      public: explicit SystemManager(const SystemLoaderPtr &_systemLoader);
+
+      /// \brief Load system plugin for a given entity.
+      /// \param[in] _entity Entity
+      /// \param[in] _fname Filename of the plugin library
+      /// \param[in] _name Name of the plugin
+      /// \param[in] _sdf SDF element (content of plugin tag)
+      public: void LoadPlugin(const Entity _entity,
+                              const std::string &_fname,
+                              const std::string &_name,
+                              const sdf::ElementPtr &_sdf);
+
+      /// \brief Add a system to the manager
+      /// \param[in] _system SystemPluginPtr to be added
+      /// \param[in] _entity Entity that system is attached to.
+      /// \param[in] _sdf Pointer to the SDF of the entity.
+      public: void AddSystem(const SystemPluginPtr &_system,
+                             Entity _entity,
+                             std::shared_ptr<const sdf::Element> _sdf);
+
+      /// \brief Add a system to the manager
+      /// \param[in] _system SystemPluginPtr to be added
+      /// \param[in] _entity Entity that system is attached to.
+      /// \param[in] _sdf Pointer to the SDF of the entity.
+      public: void AddSystem(const std::shared_ptr<System> &_system,
+                             Entity _entity,
+                             std::shared_ptr<const sdf::Element> _sdf);
+
+      /// \brief Get the count of currently active systems.
+      /// \return The active systems count.
+      public: size_t ActiveCount() const;
+
+      /// \brief Get the count of currently pending systems.
+      /// \return The pending systems count.
+      public: size_t PendingCount() const;
+
+      /// \brief Get the count of all (pending + active) managed systems
+      /// \return The count.
+      public: size_t TotalCount() const;
+
+      /// \brief Call the configure call on all pending systems
+      /// \param[in] _ecm The entity component manager to configure with
+      /// \param[in] _evetnMgr The event manager to configure with
+      public: void ConfigurePendingSystems(EntityComponentManager &_ecm,
+                                           EventManager &_eventMgr);
+
+      /// \brief Move all "pending" systems to "active" state
+      /// \return The number of newly-active systems
+      public: size_t ActivatePendingSystems();
+
+      /// \brief Get an vector of all systems implementing "Configure"
+      public: const std::vector<ISystemConfigure *>& SystemsConfigure();
+
+      /// \brief Get an vector of all systems implementing "PreUpdate"
+      public: const std::vector<ISystemPreUpdate *>& SystemsPreUpdate();
+
+      /// \brief Get an vector of all systems implementing "Update"
+      public: const std::vector<ISystemUpdate *>& SystemsUpdate();
+
+      /// \brief Get an vector of all systems implementing "PostUpdate"
+      public: const std::vector<ISystemPostUpdate *>& SystemsPostUpdate();
+
+      /// \brief Implementation for AddSystem functions. This only adds systems
+      /// to a queue, the actual addition is performed by `AddSystemToRunner` at
+      /// the appropriate time.
+      /// \param[in] _system Generic representation of a system.
+      /// \param[in] _entity Entity received from AddSystem.
+      /// \param[in] _sdf SDF received from AddSystem.
+      private: void AddSystemImpl(SystemInternal _system,
+                                  Entity _entity,
+                                  std::shared_ptr<const sdf::Element> _sdf);
+
+      /// \brief All the systems.
+      private: std::vector<SystemInternal> systems;
+
+      /// \brief Pending systems to be added to systems.
+      private: std::vector<SystemInternal> pendingSystems;
+
+      /// \brief Mark if a pending system has been configured
+      private: std::vector<bool> pendingSystemsConfigured;
+
+      /// \brief Mutex to protect pendingSystems
+      private: mutable std::mutex systemsMutex;
+
+      /// \brief Systems implementing Configure
+      private: std::vector<ISystemConfigure *> systemsConfigure;
+
+      /// \brief Systems implementing PreUpdate
+      private: std::vector<ISystemPreUpdate *> systemsPreupdate;
+
+      /// \brief Systems implementing Update
+      private: std::vector<ISystemUpdate *> systemsUpdate;
+
+      /// \brief Systems implementing PostUpdate
+      private: std::vector<ISystemPostUpdate *> systemsPostupdate;
+
+      /// \brief System loader, for loading system plugins.
+      private: SystemLoaderPtr systemLoader;
+
+      /// \brief Mutex to protect systemLoader
+      private: std::mutex systemLoaderMutex;
+    };
+    }
+  }  // namespace gazebo
+}  // namespace ignition
+#endif  // IGNITION_GAZEBO_SYSTEMINTERNAL_HH_

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -37,7 +37,7 @@ namespace ignition
     inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 
     /// \brief Used to load / unload sysetms as well as iterate over them.
-    class SystemManager
+    class IGNITION_GAZEBO_VISIBLE SystemManager
     {
       /// \brief Constructor
       /// \param[in] _systemLoader A pointer to a SystemLoader to load plugins

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/System.hh"
+#include "ignition/gazebo/SystemLoader.hh"
+#include "ignition/gazebo/Types.hh"
+#include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
+
+#include "SystemManager.hh"
+
+using namespace ignition::gazebo;
+
+/////////////////////////////////////////////////
+class System_WithConfigure:
+  public System,
+  public ISystemConfigure
+{
+  // Documentation inherited
+  public: void Configure(
+                const Entity &,
+                const std::shared_ptr<const sdf::Element> &,
+                EntityComponentManager &,
+                EventManager &) override { configured++; };
+
+  public: int configured = 0;
+};
+
+/////////////////////////////////////////////////
+class System_WithUpdates:
+  public System,
+  public ISystemPreUpdate,
+  public ISystemUpdate,
+  public ISystemPostUpdate
+{
+  // Documentation inherited
+  public: void PreUpdate(const UpdateInfo &,
+                EntityComponentManager &) override {};
+
+  // Documentation inherited
+  public: void Update(const UpdateInfo &,
+                EntityComponentManager &) override {};
+
+  // Documentation inherited
+  public: void PostUpdate(const UpdateInfo &,
+                const EntityComponentManager &) override {};
+};
+
+/////////////////////////////////////////////////
+TEST(SystemManager, Constructor)
+{
+  auto loader = std::make_shared<SystemLoader>();
+  SystemManager systemMgr(loader);
+
+  ASSERT_EQ(0u, systemMgr.ActiveCount());
+  ASSERT_EQ(0u, systemMgr.PendingCount());
+  ASSERT_EQ(0u, systemMgr.TotalCount());
+
+  ASSERT_EQ(0u, systemMgr.SystemsConfigure().size());
+  ASSERT_EQ(0u, systemMgr.SystemsPreUpdate().size());
+  ASSERT_EQ(0u, systemMgr.SystemsUpdate().size());
+  ASSERT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+}
+
+/////////////////////////////////////////////////
+TEST(SystemManager, AddSystem)
+{
+  auto loader = std::make_shared<SystemLoader>();
+  SystemManager systemMgr(loader);
+
+  EXPECT_EQ(0u, systemMgr.ActiveCount());
+  EXPECT_EQ(0u, systemMgr.PendingCount());
+  EXPECT_EQ(0u, systemMgr.TotalCount());
+  EXPECT_EQ(0u, systemMgr.SystemsConfigure().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+
+  auto configSystem = std::make_shared<System_WithConfigure>();
+  systemMgr.AddSystem(configSystem, kNullEntity, nullptr);
+  EXPECT_EQ(0u, systemMgr.ActiveCount());
+  EXPECT_EQ(1u, systemMgr.PendingCount());
+  EXPECT_EQ(1u, systemMgr.TotalCount());
+  EXPECT_EQ(0u, systemMgr.SystemsConfigure().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+
+  systemMgr.ActivatePendingSystems();
+  EXPECT_EQ(1u, systemMgr.ActiveCount());
+  EXPECT_EQ(0u, systemMgr.PendingCount());
+  EXPECT_EQ(1u, systemMgr.TotalCount());
+  EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+
+  auto updateSystem = std::make_shared<System_WithUpdates>();
+  systemMgr.AddSystem(updateSystem, kNullEntity, nullptr);
+  EXPECT_EQ(1u, systemMgr.ActiveCount());
+  EXPECT_EQ(1u, systemMgr.PendingCount());
+  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+
+  systemMgr.ActivatePendingSystems();
+  EXPECT_EQ(2u, systemMgr.ActiveCount());
+  EXPECT_EQ(0u, systemMgr.PendingCount());
+  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
+}

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -28,7 +28,7 @@
 using namespace ignition::gazebo;
 
 /////////////////////////////////////////////////
-class System_WithConfigure:
+class SystemWithConfigure:
   public System,
   public ISystemConfigure
 {
@@ -43,7 +43,7 @@ class System_WithConfigure:
 };
 
 /////////////////////////////////////////////////
-class System_WithUpdates:
+class SystemWithUpdates:
   public System,
   public ISystemPreUpdate,
   public ISystemUpdate,
@@ -79,7 +79,7 @@ TEST(SystemManager, Constructor)
 }
 
 /////////////////////////////////////////////////
-TEST(SystemManager, AddSystem_NoEcm)
+TEST(SystemManager, AddSystemNoEcm)
 {
   auto loader = std::make_shared<SystemLoader>();
   SystemManager systemMgr(loader);
@@ -92,7 +92,7 @@ TEST(SystemManager, AddSystem_NoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
-  auto configSystem = std::make_shared<System_WithConfigure>();
+  auto configSystem = std::make_shared<SystemWithConfigure>();
   systemMgr.AddSystem(configSystem, kNullEntity, nullptr);
 
   // SystemManager without an ECM/EventmManager will mean no config occurs
@@ -115,7 +115,7 @@ TEST(SystemManager, AddSystem_NoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
-  auto updateSystem = std::make_shared<System_WithUpdates>();
+  auto updateSystem = std::make_shared<SystemWithUpdates>();
   systemMgr.AddSystem(updateSystem, kNullEntity, nullptr);
   EXPECT_EQ(1u, systemMgr.ActiveCount());
   EXPECT_EQ(1u, systemMgr.PendingCount());
@@ -136,7 +136,7 @@ TEST(SystemManager, AddSystem_NoEcm)
 }
 
 /////////////////////////////////////////////////
-TEST(SystemManager, AddSystem_Ecm)
+TEST(SystemManager, AddSystemEcm)
 {
   auto loader = std::make_shared<SystemLoader>();
 
@@ -153,7 +153,7 @@ TEST(SystemManager, AddSystem_Ecm)
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
-  auto configSystem = std::make_shared<System_WithConfigure>();
+  auto configSystem = std::make_shared<SystemWithConfigure>();
   systemMgr.AddSystem(configSystem, kNullEntity, nullptr);
 
   // Configure called during AddSystem
@@ -176,7 +176,7 @@ TEST(SystemManager, AddSystem_Ecm)
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
-  auto updateSystem = std::make_shared<System_WithUpdates>();
+  auto updateSystem = std::make_shared<SystemWithUpdates>();
   systemMgr.AddSystem(updateSystem, kNullEntity, nullptr);
   EXPECT_EQ(1u, systemMgr.ActiveCount());
   EXPECT_EQ(1u, systemMgr.PendingCount());

--- a/src/WorldControl.hh
+++ b/src/WorldControl.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_WORLDCONTROL_HH_
+#define IGNITION_GAZEBO_WORLDCONTROL_HH_
+
+namespace ignition
+{
+  namespace gazebo
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+
+    /// \brief Helper struct to control world time. It's used to hold
+    /// input from either msgs::WorldControl or msgs::LogPlaybackControl.
+    struct WorldControl
+    {
+      /// \brief True to pause simulation.
+      // cppcheck-suppress unusedStructMember
+      bool pause{false};  // NOLINT
+
+      /// \biref Run a given number of simulation iterations.
+      // cppcheck-suppress unusedStructMember
+      uint64_t multiStep{0u};  // NOLINT
+
+      /// \brief Reset simulation back to time zero. Rewinding resets sim time,
+      /// real time and iterations.
+      // cppcheck-suppress unusedStructMember
+      bool rewind{false};  // NOLINT
+
+      /// \brief A simulation time in the future to run to and then pause.
+      /// A negative number indicates that this variable it not being used.
+      std::chrono::steady_clock::duration runToSimTime{-1};  // NOLINT
+
+      /// \brief Sim time to jump to. A negative value means don't seek.
+      /// Seeking changes sim time but doesn't affect real time.
+      /// It also resets iterations back to zero.
+      std::chrono::steady_clock::duration seek{-1};
+    };
+    }
+  }  // namespace gazebo
+}  // namespace ignition
+#endif  // IGNITION_GAZEBO_WORLDCONTROL_HH_

--- a/src/WorldControl.hh
+++ b/src/WorldControl.hh
@@ -17,6 +17,11 @@
 #ifndef IGNITION_GAZEBO_WORLDCONTROL_HH_
 #define IGNITION_GAZEBO_WORLDCONTROL_HH_
 
+#include <chrono>
+#include <cstdint>
+
+#include "ignition/gazebo/config.hh"
+
 namespace ignition
 {
   namespace gazebo


### PR DESCRIPTION
SimulationRunner is getting long/crowded, so I'm refactoring out a bit of the System-oriented functionality into it's own `Manager` class as a peer to things like `EventsManager` and `LevelManager`.  This should make it a bit easier to test, as well as reduce the clutter in `SimulationRunner`

Note that this moves the functionality into internal headers, so it should not have an impact on our public API/ABI.