### PR TITLE
Added xyz and rpy offset to published pose

### DIFF
--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -92,6 +92,9 @@ class ignition::gazebo::systems::OdometryPublisherPrivate
 
   /// \brief Current timestamp.
   public: math::clock::time_point lastUpdateTime;
+
+  /// \brief Allow specifying constant xyz and rpy offsets
+  public: ignition::math::Pose3d offset;
 };
 
 //////////////////////////////////////////////////
@@ -140,6 +143,26 @@ void OdometryPublisher::Configure(const Entity &_entity,
   else
   {
     this->dataPtr->odomFrame = _sdf->Get<std::string>("odom_frame");
+  }
+
+  if (!_sdf->HasElement("xyz_offset"))
+  {
+    this->dataPtr->offset.Pos() = ignition::math::Vector3d(0, 0, 0);
+  }
+  else
+  {
+    this->dataPtr->offset.Pos() = _sdf->Get<ignition::math::Vector3d>("xyz_offset");
+  }
+
+  if (!_sdf->HasElement("rpy_offset"))
+  {
+    this->dataPtr->offset.Rot() =
+      ignition::math::Quaterniond(ignition::math::Vector3d(0, 0, 0));
+  }
+  else
+  {
+    this->dataPtr->offset.Rot() =
+      ignition::math::Quaterniond(_sdf->Get<ignition::math::Vector3d>("rpy_offset"));
   }
 
   this->dataPtr->robotBaseFrame = this->dataPtr->model.Name(_ecm)
@@ -257,7 +280,10 @@ void OdometryPublisherPrivate::UpdateOdometry(
     return;
 
   // Get and set robotBaseFrame to odom transformation.
-  const math::Pose3d pose = worldPose(this->model.Entity(), _ecm);
+  const math::Pose3d rawPose = worldPose(this->model.Entity(), _ecm);
+  math::Pose3d pose;
+  pose.Pos() = rawPose.Pos() + this->offset.Pos();
+  pose.Rot() = this->offset.Rot() * rawPose.Rot();
   msg.mutable_pose()->mutable_position()->set_x(pose.Pos().X());
   msg.mutable_pose()->mutable_position()->set_y(pose.Pos().Y());
   msgs::Set(msg.mutable_pose()->mutable_orientation(), pose.Rot());


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes #<NUMBER>

## Summary
This PR enables the user to specify ``xyz_offset`` and ``rpy_offset`` in the odometry publisher messages, similar to ``xyzOffset`` and ``rpyOffset`` in ``gazebo_ros_p3d`` plugin in ``gazebo_ros_pkgs``

## Test it
TODO : Working on a test case.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
