### PR TITLE
Allow to turn on/off lights

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -623,7 +623,7 @@ sdf::Light ignition::gazebo::convert(const msgs::Light &_in)
     }
   }
   out.SetLightOn(isLightOn);
-  
+
   if (_in.type() == msgs::Light_LightType_POINT)
     out.SetType(sdf::LightType::POINT);
   else if (_in.type() == msgs::Light_LightType_SPOT)

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -569,7 +569,7 @@ msgs::Light ignition::gazebo::convert(const sdf::Light &_in)
   out.set_spot_outer_angle(_in.SpotOuterAngle().Radian());
   out.set_spot_falloff(_in.SpotFalloff());
 
-  // todo(anyone) Use the field isLightOn in light.proto from
+  // todo(ahcorde) Use the field is_light_off in light.proto from
   // Garden on.
   auto header = out.mutable_header()->add_data();
   header->set_key("isLightOn");
@@ -606,7 +606,7 @@ sdf::Light ignition::gazebo::convert(const msgs::Light &_in)
   out.SetSpotOuterAngle(math::Angle(_in.spot_outer_angle()));
   out.SetSpotFalloff(_in.spot_falloff());
 
-  // todo(anyone) Use the field isLightOn in light.proto from
+  // todo(ahcorde) Use the field is_light_off in light.proto from
   // Garden on.
   bool isLightOn = true;
   for (int i = 0; i < _in.header().data_size(); ++i)

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -568,6 +568,14 @@ msgs::Light ignition::gazebo::convert(const sdf::Light &_in)
   out.set_spot_inner_angle(_in.SpotInnerAngle().Radian());
   out.set_spot_outer_angle(_in.SpotOuterAngle().Radian());
   out.set_spot_falloff(_in.SpotFalloff());
+
+  // todo(anyone) Use the field isLightOn in light.proto from
+  // Garden on.
+  auto header = out.mutable_header()->add_data();
+  header->set_key("isLightOn");
+  std::string *value = header->add_value();
+  *value = std::to_string(_in.LightOn());
+
   if (_in.Type() == sdf::LightType::POINT)
     out.set_type(msgs::Light_LightType_POINT);
   else if (_in.Type() == sdf::LightType::SPOT)
@@ -597,6 +605,25 @@ sdf::Light ignition::gazebo::convert(const msgs::Light &_in)
   out.SetSpotInnerAngle(math::Angle(_in.spot_inner_angle()));
   out.SetSpotOuterAngle(math::Angle(_in.spot_outer_angle()));
   out.SetSpotFalloff(_in.spot_falloff());
+
+  // todo(anyone) Use the field isLightOn in light.proto from
+  // Garden on.
+  bool isLightOn = true;
+  for (int i = 0; i < _in.header().data_size(); ++i)
+  {
+    for (int j = 0;
+        j < _in.header().data(i).value_size(); ++j)
+    {
+      if (_in.header().data(i).key() ==
+          "isLightOn")
+      {
+        isLightOn = ignition::math::parseInt(
+          _in.header().data(i).value(0));
+      }
+    }
+  }
+  out.SetLightOn(isLightOn);
+  
   if (_in.type() == msgs::Light_LightType_POINT)
     out.SetType(sdf::LightType::POINT);
   else if (_in.type() == msgs::Light_LightType_SPOT)

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -153,6 +153,21 @@ void ignition::gazebo::setData(QStandardItem *_item, const msgs::Light &_data)
     lightType = 2;
   }
 
+  bool isLightOn = true;
+  for (int i = 0; i < _data.header().data_size(); ++i)
+  {
+    for (int j = 0;
+        j < _data.header().data(i).value_size(); ++j)
+    {
+      if (_data.header().data(i).key() ==
+          "isLightOn")
+      {
+        isLightOn = ignition::math::parseInt(
+          _data.header().data(i).value(0));
+      }
+    }
+  }
+
   _item->setData(QString("Light"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QList({
@@ -176,7 +191,8 @@ void ignition::gazebo::setData(QStandardItem *_item, const msgs::Light &_data)
     QVariant(_data.spot_outer_angle()),
     QVariant(_data.spot_falloff()),
     QVariant(_data.intensity()),
-    QVariant(lightType)
+    QVariant(lightType),
+    QVariant(isLightOn)
   }), ComponentsModel::RoleNames().key("data"));
 }
 
@@ -989,7 +1005,8 @@ void ComponentInspector::OnLight(
   double _attRange, double _attLinear, double _attConstant,
   double _attQuadratic, bool _castShadows, double _directionX,
   double _directionY, double _directionZ, double _innerAngle,
-  double _outerAngle, double _falloff, double _intensity, int _type)
+  double _outerAngle, double _falloff, double _intensity, int _type,
+  bool _isLightOn)
 {
   std::function<void(const ignition::msgs::Boolean &, const bool)> cb =
       [](const ignition::msgs::Boolean &/*_rep*/, const bool _result)
@@ -999,6 +1016,14 @@ void ComponentInspector::OnLight(
   };
 
   ignition::msgs::Light req;
+
+  // todo(anyone) Use the field isLightOn in light.proto from
+  // Garden on.
+  auto header = req.mutable_header()->add_data();
+  header->set_key("isLightOn");
+  std::string *value = header->add_value();
+  *value = std::to_string(_isLightOn);
+
   req.set_name(this->dataPtr->entityName);
   req.set_id(this->dataPtr->entity);
   ignition::msgs::Set(req.mutable_diffuse(),

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -1017,7 +1017,7 @@ void ComponentInspector::OnLight(
 
   ignition::msgs::Light req;
 
-  // todo(anyone) Use the field isLightOn in light.proto from
+  // todo(ahcorde) Use the field is_light_off in light.proto from
   // Garden on.
   auto header = req.mutable_header()->add_data();
   header->set_key("isLightOn");

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -252,6 +252,7 @@ namespace gazebo
     /// \param[in] _falloff Falloff of the spotlight
     /// \param[in] _intensity Intensity of the light
     /// \param[in] _type light type
+    /// \param[in] _isLightOn is light on
     public: Q_INVOKABLE void OnLight(
       double _rSpecular, double _gSpecular, double _bSpecular,
       double _aSpecular, double _rDiffuse, double _gDiffuse,

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -259,7 +259,7 @@ namespace gazebo
       double _attLinear, double _attConstant, double _attQuadratic,
       bool _castShadows, double _directionX, double _directionY,
       double _directionZ, double _innerAngle, double _outerAngle,
-      double _falloff, double _intensity, int _type);
+      double _falloff, double _intensity, int _type, bool _isLightOn);
 
     /// \brief Callback in Qt thread when physics' properties change.
     /// \param[in] _stepSize step size

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -101,12 +101,14 @@ Rectangle {
                    _rDiffuse, _gDiffuse, _bDiffuse, _aDiffuse,
                    _attRange, _attLinear, _attConstant, _attQuadratic,
                    _castShadows, _directionX, _directionY, _directionZ,
-                   _innerAngle, _outerAngle, _falloff, _intensity, _type) {
+                   _innerAngle, _outerAngle, _falloff, _intensity, _type,
+                   _isLightOn) {
     ComponentInspector.OnLight(_rSpecular, _gSpecular, _bSpecular, _aSpecular,
                                _rDiffuse, _gDiffuse, _bDiffuse, _aDiffuse,
                                _attRange, _attLinear, _attConstant, _attQuadratic,
                                _castShadows, _directionX, _directionY, _directionZ,
-                               _innerAngle, _outerAngle, _falloff, _intensity, _type)
+                               _innerAngle, _outerAngle, _falloff, _intensity, _type,
+                               _isLightOn)
   }
 
   /*

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -294,13 +294,6 @@ Rectangle {
             color: "transparent"
             height: 40
             Layout.preferredWidth: isOnText.width + indentation*3
-            Loader {
-              id: isLightOn
-              width: iconWidth
-              height: iconHeight
-              y:10
-              sourceComponent: plotIcon
-            }
             Component.onCompleted: isLightOn.item.componentInfo = "is light on ?"
 
             Text {

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -294,7 +294,6 @@ Rectangle {
             color: "transparent"
             height: 40
             Layout.preferredWidth: isOnText.width + indentation*3
-            Component.onCompleted: isLightOn.item.componentInfo = "is light on ?"
 
             Text {
               id : isOnText
@@ -315,7 +314,7 @@ Rectangle {
               property double numberValue: model.data[21]
               sourceComponent: ignSwitch
               onLoaded: {
-                isLightOnItem = inOnLoader.item
+                isLightOnItem = isOnLoader.item
               }
             }
           }

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -99,6 +99,9 @@ Rectangle {
   // Loaded item for intensity
   property var intensityItem: {}
 
+  // Loaded item for isLightOn
+  property var isLightOnItem: {}
+
   // Send new light data to C++
   function sendLight() {
     // TODO(anyone) There's a loss of precision when these values get to C++
@@ -123,7 +126,8 @@ Rectangle {
       outerAngleItem.value,
       falloffItem.value,
       intensityItem.value,
-      model.data[20]
+      model.data[20],
+      isLightOnItem.checked
     );
   }
 
@@ -284,6 +288,45 @@ Rectangle {
       ColumnLayout {
         id: grid
         width: parent.width
+
+        RowLayout {
+          Rectangle {
+            color: "transparent"
+            height: 40
+            Layout.preferredWidth: isOnText.width + indentation*3
+            Loader {
+              id: isLightOn
+              width: iconWidth
+              height: iconHeight
+              y:10
+              sourceComponent: plotIcon
+            }
+            Component.onCompleted: isLightOn.item.componentInfo = "is light on ?"
+
+            Text {
+              id : isOnText
+              text: ' Turn on/off'
+              leftPadding: 5
+              color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
+              font.pointSize: 12
+              anchors.centerIn: parent
+            }
+          }
+          Item {
+            Layout.fillWidth: true
+            height: 40
+
+            Loader {
+              id: inOnLoader
+              anchors.fill: parent
+              property double numberValue: model.data[21]
+              sourceComponent: ignSwitch
+              onLoaded: {
+                isLightOnItem = inOnLoader.item
+              }
+            }
+          }
+        }
 
         RowLayout {
           Rectangle {

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -310,7 +310,7 @@ Rectangle {
             height: 40
 
             Loader {
-              id: inOnLoader
+              id: isOnLoader
               anchors.fill: parent
               property double numberValue: model.data[21]
               sourceComponent: ignSwitch

--- a/src/gui/plugins/component_inspector/Light.qml
+++ b/src/gui/plugins/component_inspector/Light.qml
@@ -873,7 +873,7 @@ Rectangle {
         }
         RowLayout {
           Text {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             Layout.columnSpan: 6
             text: "      Direction"
             color: "dimgrey"
@@ -882,7 +882,7 @@ Rectangle {
         }
         RowLayout {
           Rectangle {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             color: "transparent"
             height: 40
             Layout.preferredWidth: xDirectionText.width + indentation*3
@@ -896,7 +896,7 @@ Rectangle {
             Component.onCompleted: loaderDirectionX.item.componentInfo = "directionX"
 
             Text {
-              visible: model.data[19] === 1 || model.data[19] === 2
+              visible: model.data[20] === 1 || model.data[20] === 2
               id : xDirectionText
               text: ' X:'
               leftPadding: 5
@@ -906,7 +906,7 @@ Rectangle {
             }
           }
           Item {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             Layout.fillWidth: true
             height: 40
             Layout.columnSpan: 4
@@ -923,7 +923,7 @@ Rectangle {
         }
         RowLayout {
           Rectangle {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             color: "transparent"
             height: 40
             Layout.preferredWidth: yDirectionText.width + indentation*3
@@ -937,7 +937,7 @@ Rectangle {
             Component.onCompleted: loaderDirectionY.item.componentInfo = "directionY"
 
             Text {
-              visible: model.data[19] === 1 || model.data[19] === 2
+              visible: model.data[20] === 1 || model.data[20] === 2
               id : yDirectionText
               text: ' Y:'
               leftPadding: 5
@@ -947,7 +947,7 @@ Rectangle {
             }
           }
           Item {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             Layout.fillWidth: true
             height: 40
             Layout.columnSpan: 4
@@ -964,7 +964,7 @@ Rectangle {
         }
         RowLayout {
           Rectangle {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             color: "transparent"
             height: 40
             Layout.preferredWidth: zDirectionText.width + indentation*3
@@ -978,7 +978,7 @@ Rectangle {
             Component.onCompleted: loaderDirectionZ.item.componentInfo = "directionZ"
 
             Text {
-              visible: model.data[19] === 1 || model.data[19] === 2
+              visible: model.data[20] === 1 || model.data[20] === 2
               id : zDirectionText
               text: ' Z:'
               leftPadding: 5
@@ -988,7 +988,7 @@ Rectangle {
             }
           }
           Item {
-            visible: model.data[19] === 1 || model.data[19] === 2
+            visible: model.data[20] === 1 || model.data[20] === 2
             Layout.fillWidth: true
             height: 40
             Layout.columnSpan: 4
@@ -1005,7 +1005,7 @@ Rectangle {
         }
         RowLayout {
           Text {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             Layout.columnSpan: 6
             text: "      Spot features"
             color: "dimgrey"
@@ -1014,7 +1014,7 @@ Rectangle {
         }
         RowLayout {
           Rectangle {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             color: "transparent"
             height: 40
             Layout.preferredWidth: innerAngleText.width + indentation*3
@@ -1028,7 +1028,7 @@ Rectangle {
             Component.onCompleted: loaderInnerAngle.item.componentInfo = "innerAngle"
 
             Text {
-              visible: model.data[19] === 1
+              visible: model.data[20] === 1
               id : innerAngleText
               text: ' Inner Angle:'
               leftPadding: 5
@@ -1038,7 +1038,7 @@ Rectangle {
             }
           }
           Item {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             Layout.fillWidth: true
             height: 40
             Layout.columnSpan: 4
@@ -1055,7 +1055,7 @@ Rectangle {
         }
         RowLayout {
           Rectangle {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             color: "transparent"
             height: 40
             Layout.preferredWidth: outerAngleText.width + indentation*3
@@ -1069,7 +1069,7 @@ Rectangle {
             Component.onCompleted: loaderOuterAngle.item.componentInfo = "outerAngle"
 
             Text {
-              visible: model.data[19] === 1
+              visible: model.data[20] === 1
               id : outerAngleText
               text: ' Outer angle:'
               leftPadding: 5
@@ -1079,7 +1079,7 @@ Rectangle {
             }
           }
           Item {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             Layout.fillWidth: true
             height: 40
             Layout.columnSpan: 4
@@ -1096,7 +1096,7 @@ Rectangle {
         }
         RowLayout {
           Rectangle {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             color: "transparent"
             height: 40
             Layout.preferredWidth: fallOffText.width + indentation*3
@@ -1110,7 +1110,7 @@ Rectangle {
             Component.onCompleted: loaderFallOff.item.componentInfo = "falloff"
 
             Text {
-              visible: model.data[19] === 1
+              visible: model.data[20] === 1
               id : fallOffText
               text: ' Falloff:'
               leftPadding: 5
@@ -1120,7 +1120,7 @@ Rectangle {
             }
           }
           Item {
-            visible: model.data[19] === 1
+            visible: model.data[20] === 1
             Layout.fillWidth: true
             height: 40
             Layout.columnSpan: 4

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2148,8 +2148,6 @@ void RenderUtilPrivate::UpdateLights(
         }
       }
 
-      // const auto lightOnOff = _entityLightsOn.at(light.first);
-
       if (isLightOn)
       {
         if (!ignition::math::equal(

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2131,6 +2131,12 @@ void RenderUtilPrivate::UpdateLights(
     auto l = std::dynamic_pointer_cast<rendering::Light>(node);
     if (l)
     {
+      if (!ignition::math::equal(
+          l->Intensity(),
+          static_cast<double>(light.second.intensity())))
+      {
+        l->SetIntensity(light.second.intensity());
+      }
       if (light.second.has_diffuse())
       {
         if (l->DiffuseColor() != msgs::Convert(light.second.diffuse()))

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2131,11 +2131,37 @@ void RenderUtilPrivate::UpdateLights(
     auto l = std::dynamic_pointer_cast<rendering::Light>(node);
     if (l)
     {
-      if (!ignition::math::equal(
-          l->Intensity(),
-          static_cast<double>(light.second.intensity())))
+      // todo(anyone) Use the field isLightOn in light.proto from
+      // Garden on.
+      bool isLightOn = true;
+      for (int i = 0; i < light.second.header().data_size(); ++i)
       {
-        l->SetIntensity(light.second.intensity());
+        for (int j = 0;
+            j < light.second.header().data(i).value_size(); ++j)
+        {
+          if (light.second.header().data(i).key() ==
+              "isLightOn")
+          {
+            isLightOn = ignition::math::parseInt(
+              light.second.header().data(i).value(0));
+          }
+        }
+      }
+
+      // const auto lightOnOff = _entityLightsOn.at(light.first);
+
+      if (isLightOn)
+      {
+        if (!ignition::math::equal(
+            l->Intensity(),
+            static_cast<double>(light.second.intensity())))
+        {
+          l->SetIntensity(light.second.intensity());
+        }
+      }
+      else
+      {
+        l->SetIntensity(0);
       }
       if (light.second.has_diffuse())
       {

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2131,7 +2131,7 @@ void RenderUtilPrivate::UpdateLights(
     auto l = std::dynamic_pointer_cast<rendering::Light>(node);
     if (l)
     {
-      // todo(anyone) Use the field isLightOn in light.proto from
+      // todo(ahcorde) Use the field is_light_off in light.proto from
       // Garden on.
       bool isLightOn = true;
       for (int i = 0; i < light.second.header().data_size(); ++i)

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -159,7 +159,7 @@ class LightCommand : public UserCommandBase
   public: std::function<bool(const msgs::Light &, const msgs::Light &)>
           lightEql { [](const msgs::Light &_a, const msgs::Light &_b)
             {
-              // todo(anyone) Use the field isLightOn in light.proto from
+              // todo(ahcorde) Use the field is_light_off in light.proto from
               // Garden on.
               auto getIsLightOn = [](const msgs::Light &_light) -> bool
               {

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -159,7 +159,28 @@ class LightCommand : public UserCommandBase
   public: std::function<bool(const msgs::Light &, const msgs::Light &)>
           lightEql { [](const msgs::Light &_a, const msgs::Light &_b)
             {
+              // todo(anyone) Use the field isLightOn in light.proto from
+              // Garden on.
+              auto getIsLightOn = [](const msgs::Light &_light) -> bool
+              {
+                bool isLightOn = true;
+                for (int i = 0; i < _light.header().data_size(); ++i)
+                {
+                  for (int j = 0;
+                      j < _light.header().data(i).value_size(); ++j)
+                  {
+                    if (_light.header().data(i).key() ==
+                        "isLightOn")
+                    {
+                      isLightOn = ignition::math::parseInt(
+                        _light.header().data(i).value(0));
+                    }
+                  }
+                }
+                return isLightOn;
+               };
              return
+                getIsLightOn(_a) == getIsLightOn(_b) &&
                 _a.type() == _b.type() &&
                 _a.name() == _b.name() &&
                 math::equal(

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -760,6 +760,14 @@ TEST_F(UserCommandsTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Light))
   req.set_attenuation_constant(0.6f);
   req.set_attenuation_quadratic(0.001f);
   req.set_cast_shadows(true);
+
+  // todo(ahcorde) Use the field is_light_off in light.proto from
+  // Garden on.
+  auto header = req.mutable_header()->add_data();
+  header->set_key("isLightOn");
+  std::string *value = header->add_value();
+  *value = std::to_string(true);
+
   EXPECT_TRUE(node.Request(service, req, timeout, res, result));
   EXPECT_TRUE(result);
   EXPECT_TRUE(res.data());


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# New feature

## Summary

Related with this issue https://github.com/ignitionrobotics/ign-gazebo/issues/638

Require: https://github.com/ignitionrobotics/sdformat/pull/851

![lights_onoff](https://user-images.githubusercontent.com/1933907/154226823-9606a2b4-010d-4d9a-83be-a0ce71ed7e75.gif)

The implementation uses a user define field in the message, otherwise we break ABI in ign-msgs. This should be fixed in Garden with a new field in `light.proto`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

