### PR TITLE
JointStatePublisher publish parent, child and axis data

### DIFF
--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -213,10 +213,14 @@ void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
           if (jointAxis)
           {
             msgs::Set(
-              jointMsg->mutable_axis1()->mutable_xyz(), jointAxis->Data().Xyz());
-            jointMsg->mutable_axis1()->set_limit_upper(jointAxis->Data().Upper());
-            jointMsg->mutable_axis1()->set_limit_lower(jointAxis->Data().Lower());
-            jointMsg->mutable_axis1()->set_damping(jointAxis->Data().Damping());
+              jointMsg->mutable_axis1()->mutable_xyz(),
+              jointAxis->Data().Xyz());
+            jointMsg->mutable_axis1()->set_limit_upper(
+              jointAxis->Data().Upper());
+            jointMsg->mutable_axis1()->set_limit_lower(
+              jointAxis->Data().Lower());
+            jointMsg->mutable_axis1()->set_damping(
+              jointAxis->Data().Damping());
           }
         }
         else if (i == 1)

--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -24,12 +24,15 @@
 
 #include <ignition/plugin/Register.hh>
 
+#include "ignition/gazebo/components/ChildLinkName.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Joint.hh"
+#include "ignition/gazebo/components/JointAxis.hh"
 #include "ignition/gazebo/components/JointForce.hh"
 #include "ignition/gazebo/components/JointPosition.hh"
 #include "ignition/gazebo/components/JointVelocity.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/ParentLinkName.hh"
 #include "ignition/gazebo/components/Pose.hh"
 
 using namespace ignition;
@@ -184,6 +187,18 @@ void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
     if (pose)
       msgs::Set(jointMsg->mutable_pose(), pose->Data());
 
+    auto child = _ecm.Component<components::ChildLinkName>(joint);
+    if (child)
+    {
+      jointMsg->set_child(child->Data());
+    }
+
+    auto parent = _ecm.Component<components::ParentLinkName>(joint);
+    if (parent)
+    {
+      jointMsg->set_parent(parent->Data());
+    }
+
     // Set the joint position
     const auto *jointPositions  =
       _ecm.Component<components::JointPosition>(joint);
@@ -194,6 +209,15 @@ void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
         if (i == 0)
         {
           jointMsg->mutable_axis1()->set_position(jointPositions->Data()[i]);
+          auto jointAxis = _ecm.Component<components::JointAxis>(joint);
+          if (jointAxis)
+          {
+            msgs::Set(
+              jointMsg->mutable_axis1()->mutable_xyz(), jointAxis->Data().Xyz());
+            jointMsg->mutable_axis1()->set_limit_upper(jointAxis->Data().Upper());
+            jointMsg->mutable_axis1()->set_limit_lower(jointAxis->Data().Lower());
+            jointMsg->mutable_axis1()->set_damping(jointAxis->Data().Damping());
+          }
         }
         else if (i == 1)
         {


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

## Summary

JointStatePublisher plugin is not publishing data about child, parent or axis. 

This PR add this data to the message 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
