### PR TITLE
Adding ability to pause/resume the trajectory follower behavior.

### DIFF
--- a/examples/worlds/trajectory_follower.sdf
+++ b/examples/worlds/trajectory_follower.sdf
@@ -1,6 +1,16 @@
 <?xml version="1.0" ?>
 <!--
   Ignition Gazebo trajectory follower plugin demo.
+
+  Try sending commands:
+
+    To pause the trajectory follower behavior:
+
+      ign topic -t "/model/box/trajectory_follower/pause" -m ignition.msgs.Boolean -p "data: true"
+
+    To resume the trajectory follower behavior:
+
+      ign topic -t "/model/box/trajectory_follower/pause" -m ignition.msgs.Boolean -p "data: false"
 -->
 <sdf version="1.6">
   <world name="trajectory_follower">

--- a/src/systems/trajectory_follower/TrajectoryFollower.cc
+++ b/src/systems/trajectory_follower/TrajectoryFollower.cc
@@ -29,6 +29,7 @@
 #include <ignition/math/Vector3.hh>
 #include <ignition/plugin/Register.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/transport/TopicUtils.hh>
 #include <sdf/sdf.hh>
 
 #include "ignition/gazebo/components/Pose.hh"
@@ -251,10 +252,17 @@ void TrajectoryFollowerPrivate::Load(const EntityComponentManager &_ecm,
   // Parse the optional <topic> element.
   this->topic = "/model/" + this->model.Name(_ecm) +
     "/trajectory_follower/pause";
+
   if (_sdf->HasElement("topic"))
     this->topic = _sdf->Get<std::string>("topic");
 
+  this->topic = transport::TopicUtils::AsValidTopic(this->topic);
+
   this->node.Subscribe(topic, &TrajectoryFollowerPrivate::OnPause, this);
+
+  ignmsg << "TrajectoryFollower["
+      << this->model.Name() << "] subscribed "
+      << "to pause messages on topic[" << this->topic << "]\n";
 
   // If we have waypoints to visit, read the first one.
   if (!this->localWaypoints.empty())

--- a/src/systems/trajectory_follower/TrajectoryFollower.cc
+++ b/src/systems/trajectory_follower/TrajectoryFollower.cc
@@ -15,6 +15,9 @@
  *
  */
 
+#include <ignition/msgs/boolean.pb.h>
+
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -25,6 +28,7 @@
 #include <ignition/math/Vector2.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/plugin/Register.hh>
+#include <ignition/transport/Node.hh>
 #include <sdf/sdf.hh>
 
 #include "ignition/gazebo/components/Pose.hh"
@@ -45,6 +49,20 @@ class ignition::gazebo::systems::TrajectoryFollowerPrivate
   /// \param[in] _sdf The SDF Element associated with this system plugin.
   public: void Load(const EntityComponentManager &_ecm,
                     const sdf::ElementPtr &_sdf);
+
+  /// \brief Callback to pause/resume the behavior.
+  /// \param[in] _paused True when the intention is to pause the trajectory
+  /// follower behavior or false to continue the trajectory.
+  public: void OnPause(const msgs::Boolean &_paused);
+
+  /// \brief A mutex to protect the paused member.
+  public: std::mutex mutex;
+
+  /// \brief Ignition transport node.
+  public: transport::Node node;
+
+  /// \brief Topic name to pause/resume the trajectory.
+  public: std::string topic;
 
   /// \brief The link entity
   public: ignition::gazebo::Link link;
@@ -87,6 +105,9 @@ class ignition::gazebo::systems::TrajectoryFollowerPrivate
 
   /// \brief Copy of the sdf configuration used for this plugin
   public: sdf::ElementPtr sdfConfig;
+
+  /// \brief Whether the trajectory follower behavior should be paused or not.
+  public: bool paused = false;
 };
 
 //////////////////////////////////////////////////
@@ -227,12 +248,27 @@ void TrajectoryFollowerPrivate::Load(const EntityComponentManager &_ecm,
   if (_sdf->HasElement("bearing_tolerance"))
     this->bearingTolerance = _sdf->Get<double>("bearing_tolerance");
 
+  // Parse the optional <topic> element.
+  this->topic = "/model/" + this->model.Name(_ecm) +
+    "/trajectory_follower/pause";
+  if (_sdf->HasElement("topic"))
+    this->topic = _sdf->Get<std::string>("topic");
+
+  this->node.Subscribe(topic, &TrajectoryFollowerPrivate::OnPause, this);
+
   // If we have waypoints to visit, read the first one.
   if (!this->localWaypoints.empty())
   {
     this->nextGoal =
       {this->localWaypoints.front().X(), this->localWaypoints.front().Y(), 0};
   }
+}
+
+/////////////////////////////////////////////////
+void TrajectoryFollowerPrivate::OnPause(const msgs::Boolean &_paused)
+{
+  std::lock_guard<std::mutex> lock(this->mutex);
+  this->paused = _paused.data();
 }
 
 //////////////////////////////////////////////////
@@ -258,8 +294,11 @@ void TrajectoryFollower::PreUpdate(
 {
   IGN_PROFILE("TrajectoryFollower::PreUpdate");
 
-  if (_info.paused)
-    return;
+  {
+    std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+    if (_info.paused || this->dataPtr->paused)
+      return;
+  }
 
   if (!this->dataPtr->initialized)
   {

--- a/src/systems/trajectory_follower/TrajectoryFollower.cc
+++ b/src/systems/trajectory_follower/TrajectoryFollower.cc
@@ -261,7 +261,7 @@ void TrajectoryFollowerPrivate::Load(const EntityComponentManager &_ecm,
   this->node.Subscribe(topic, &TrajectoryFollowerPrivate::OnPause, this);
 
   ignmsg << "TrajectoryFollower["
-      << this->model.Name() << "] subscribed "
+      << this->model.Name(_ecm) << "] subscribed "
       << "to pause messages on topic[" << this->topic << "]\n";
 
   // If we have waypoints to visit, read the first one.


### PR DESCRIPTION
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>

# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This patch adds the ability to pause/resume the trajectory follower behavior via an Ignition Transport message.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

See the examples notes for testing.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [X] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

