### PR TITLE
Populate names of colliding entities in contact points message

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -737,15 +737,11 @@ void Physics::Configure(const Entity &_entity,
   }
 
   // Check if entity names should be populated in contact points.
-  if (_sdf->HasElement("contacts"))
+  auto contactsElement = _sdf->FindElement("contacts");
+  if (contactsElement)
   {
-    auto sdfClone = _sdf->Clone();
-    auto contactsElement = sdfClone->GetElement("contacts");
-    if (contactsElement->HasElement("include_entity_names"))
-    {
-      this->dataPtr->contactsEntityNames = contactsElement->Get<bool>(
-        "include_entity_names");
-    }
+    this->dataPtr->contactsEntityNames = contactsElement->Get<bool>(
+      "include_entity_names");
   }
 
   // Find engine shared library

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3260,10 +3260,10 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
           msgs::Contact *contactMsg = contactsComp.add_contact();
           contactMsg->mutable_collision1()->set_id(_collEntity1);
           contactMsg->mutable_collision1()->set_name(
-	    scopedName(_collEntity1, _ecm, ":", 1));
+            removeParentScope(scopedName(_collEntity1, _ecm, "::", 0), "::"));
           contactMsg->mutable_collision2()->set_id(collEntity2);
           contactMsg->mutable_collision2()->set_name(
-	    scopedName(collEntity2, _ecm, ":", 1));
+            removeParentScope(scopedName(collEntity2, _ecm, "::", 0), "::"));
           for (const auto &contact : contactData)
           {
             auto *position = contactMsg->add_position();

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3259,11 +3259,11 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
         {
           msgs::Contact *contactMsg = contactsComp.add_contact();
           contactMsg->mutable_collision1()->set_id(_collEntity1);
-	  auto _collEntity1Name = _ecm.Component<components::Name>(_collEntity1)->Data();
-          contactMsg->mutable_collision1()->set_name(_collEntity1Name);
+          contactMsg->mutable_collision1()->set_name(
+	    scopedName(_collEntity1, _ecm, ":", 1));
           contactMsg->mutable_collision2()->set_id(collEntity2);
-	  auto collEntity2Name = _ecm.Component<components::Name>(collEntity2)->Data();
-          contactMsg->mutable_collision2()->set_name(collEntity2Name);
+          contactMsg->mutable_collision2()->set_name(
+	    scopedName(collEntity2, _ecm, ":", 1));
           for (const auto &contact : contactData)
           {
             auto *position = contactMsg->add_position();

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -686,6 +686,10 @@ class ignition::gazebo::systems::PhysicsPrivate
   /// through the GUI model editor, so that we can avoid premature creation
   /// of joints. This also lets us suppress some invalid error messages.
   public: std::set<Entity> jointAddedToModel;
+
+  /// \brief Flag to store whether the names of colliding entities should
+  /// be populated in the contact points.
+  public: bool contactsEntityNames = true;
 };
 
 //////////////////////////////////////////////////
@@ -730,6 +734,18 @@ void Physics::Configure(const Entity &_entity,
   {
     engineComp->SetData(pluginLib,
         [](const std::string &_a, const std::string &_b){return _a == _b;});
+  }
+
+  // Check if entity names should be populated in contact points.
+  if (_sdf->HasElement("contacts"))
+  {
+    auto sdfClone = _sdf->Clone();
+    auto contactsElement = sdfClone->GetElement("contacts");
+    if (contactsElement->HasElement("include_entity_names"))
+    {
+      this->dataPtr->contactsEntityNames = contactsElement->Get<bool>(
+        "include_entity_names");
+    }
   }
 
   // Find engine shared library
@@ -3259,11 +3275,14 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
         {
           msgs::Contact *contactMsg = contactsComp.add_contact();
           contactMsg->mutable_collision1()->set_id(_collEntity1);
-          contactMsg->mutable_collision1()->set_name(
-            removeParentScope(scopedName(_collEntity1, _ecm, "::", 0), "::"));
           contactMsg->mutable_collision2()->set_id(collEntity2);
-          contactMsg->mutable_collision2()->set_name(
-            removeParentScope(scopedName(collEntity2, _ecm, "::", 0), "::"));
+          if (this->contactsEntityNames)
+          {
+            contactMsg->mutable_collision1()->set_name(
+              removeParentScope(scopedName(_collEntity1, _ecm, "::", 0), "::"));
+            contactMsg->mutable_collision2()->set_name(
+              removeParentScope(scopedName(collEntity2, _ecm, "::", 0), "::"));
+          }
           for (const auto &contact : contactData)
           {
             auto *position = contactMsg->add_position();

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -741,7 +741,7 @@ void Physics::Configure(const Entity &_entity,
   if (contactsElement)
   {
     this->dataPtr->contactsEntityNames = contactsElement->Get<bool>(
-      "include_entity_names");
+      "include_entity_names", true).first;
   }
 
   // Find engine shared library

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3259,7 +3259,11 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
         {
           msgs::Contact *contactMsg = contactsComp.add_contact();
           contactMsg->mutable_collision1()->set_id(_collEntity1);
+	  auto _collEntity1Name = _ecm.Component<components::Name>(_collEntity1)->Data();
+          contactMsg->mutable_collision1()->set_name(_collEntity1Name);
           contactMsg->mutable_collision2()->set_id(collEntity2);
+	  auto collEntity2Name = _ecm.Component<components::Name>(collEntity2)->Data();
+          contactMsg->mutable_collision2()->set_name(collEntity2Name);
           for (const auto &contact : contactData)
           {
             auto *position = contactMsg->add_position();

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -64,6 +64,19 @@ namespace systems
 
   /// \class Physics Physics.hh ignition/gazebo/systems/Physics.hh
   /// \brief Base class for a System.
+  /// Includes optional parameter : <include_entity_names>. When set
+  /// to false, the name of colliding entities is not populated in
+  /// the contacts. Remains true by default. Usage :
+  /// ```
+  ///  <plugin
+  ///    filename="ignition-gazebo-physics-system"
+  ///    name="ignition::gazebo::systems::Physics">
+  ///    <contacts>
+  ///      <include_entity_names>false</include_entity_names>
+  ///    </contacts>
+  ///  </plugin>
+  ///  ```
+
   class Physics:
     public System,
     public ISystemConfigure,

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -93,12 +93,9 @@ TEST_F(ContactSystemTest,
     for (const auto &contact : lastContacts.contact())
     {
       ASSERT_EQ(1, contact.position_size());
-      bool entityNameFound =
-        contact.collision1().name() ==
-        "contact_model::link::collision_sphere1" ||
-        contact.collision1().name() ==
-        "contact_model::link::collision_sphere2";
-      EXPECT_FALSE(entityNameFound);
+      bool entityNameEmpty =
+        contact.collision1().name() == "";
+      EXPECT_TRUE(entityNameEmpty);
     }
   }
 

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -41,6 +41,82 @@ class ContactSystemTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
+// This test verifies that colliding entity names are populated in
+// the contact points message.
+TEST_F(ContactSystemTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(EnableCollidingEntityNames))
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/contact_with_entity_names.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  using namespace std::chrono_literals;
+  server.SetUpdatePeriod(1ns);
+
+  std::mutex contactMutex;
+  std::vector<msgs::Contacts> contactMsgs;
+
+  auto contactCb = [&](const msgs::Contacts &_msg) -> void
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    contactMsgs.push_back(_msg);
+  };
+
+  // subscribe to contacts topic
+  transport::Node node;
+  // Have to create an lvalue here for Node::Subscribe to work.
+  auto callbackFunc = std::function<void(const msgs::Contacts &)>(contactCb);
+  node.Subscribe("/test_multiple_collisions", callbackFunc);
+
+  // Run server
+  size_t iters = 1000;
+  server.Run(true, iters, false);
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    ASSERT_GE(contactMsgs.size(), 1u);
+  }
+
+  // "contact_model" has one contact sensor, but the sensor uses two collisions
+  // as sensors. Therefore, once the "contact_model" model has fallen and has
+  // stabilized, we expect that each collision will have 1 contact point.
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    const auto &lastContacts = contactMsgs.back();
+    EXPECT_EQ(4, lastContacts.contact_size());
+
+    for (const auto &contact : lastContacts.contact())
+    {
+      ASSERT_EQ(1, contact.position_size());
+      bool entityNameFound =
+        contact.collision1().name() ==
+        "contact_model::link::collision_sphere1" ||
+        contact.collision1().name() ==
+        "contact_model::link::collision_sphere2";
+      EXPECT_TRUE(entityNameFound);
+    }
+  }
+
+  // Remove the colliding boxes and check that contacts are no longer generated.
+  server.RequestRemoveEntity("box1");
+  server.RequestRemoveEntity("box2");
+  // Run once to remove entities
+  server.Run(true, 1, false);
+
+  contactMsgs.clear();
+  server.Run(true, 10, false);
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    EXPECT_EQ(0u, contactMsgs.size());
+  }
+}
+
+/////////////////////////////////////////////////
 // This test verifies that colliding entity names are not populated in
 // the contact points message.
 TEST_F(ContactSystemTest,

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -100,12 +100,12 @@ TEST_F(ContactSystemTest,
       EXPECT_NEAR(0.25, std::abs(contact.position(0).x()), 5e-2);
       EXPECT_NEAR(1, std::abs(contact.position(0).y()), 5e-2);
       EXPECT_NEAR(1, contact.position(0).z(), 5e-2);
-      bool EntityNameFound =
+      bool entityNameFound =
         contact.collision1().name() ==
-	"world:contact_sensor:model:contact_model:link:link:collision:collision_sphere1" ||
-	contact.collision1().name() ==
-	"world:contact_sensor:model:contact_model:link:link:collision:collision_sphere2";
-      EXPECT_TRUE(EntityNameFound);
+        "contact_model::link::collision_sphere1" ||
+        contact.collision1().name() ==
+        "contact_model::link::collision_sphere2";
+      EXPECT_TRUE(entityNameFound);
     }
   }
 

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -100,6 +100,12 @@ TEST_F(ContactSystemTest,
       EXPECT_NEAR(0.25, std::abs(contact.position(0).x()), 5e-2);
       EXPECT_NEAR(1, std::abs(contact.position(0).y()), 5e-2);
       EXPECT_NEAR(1, contact.position(0).z(), 5e-2);
+      bool EntityNameFound =
+        contact.collision1().name() ==
+	"world:contact_sensor:model:contact_model:link:link:collision:collision_sphere1" ||
+	contact.collision1().name() ==
+	"world:contact_sensor:model:contact_model:link:link:collision:collision_sphere2";
+      EXPECT_TRUE(EntityNameFound);
     }
   }
 

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -41,6 +41,82 @@ class ContactSystemTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
+// This test verifies that colliding entity names are not populated in
+// the contact points message.
+TEST_F(ContactSystemTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(DisableCollidingEntityNames))
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/contact_without_entity_names.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  using namespace std::chrono_literals;
+  server.SetUpdatePeriod(1ns);
+
+  std::mutex contactMutex;
+  std::vector<msgs::Contacts> contactMsgs;
+
+  auto contactCb = [&](const msgs::Contacts &_msg) -> void
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    contactMsgs.push_back(_msg);
+  };
+
+  // subscribe to contacts topic
+  transport::Node node;
+  // Have to create an lvalue here for Node::Subscribe to work.
+  auto callbackFunc = std::function<void(const msgs::Contacts &)>(contactCb);
+  node.Subscribe("/test_multiple_collisions", callbackFunc);
+
+  // Run server
+  size_t iters = 1000;
+  server.Run(true, iters, false);
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    ASSERT_GE(contactMsgs.size(), 1u);
+  }
+
+  // "contact_model" has one contact sensor, but the sensor uses two collisions
+  // as sensors. Therefore, once the "contact_model" model has fallen and has
+  // stabilized, we expect that each collision will have 1 contact point.
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    const auto &lastContacts = contactMsgs.back();
+    EXPECT_EQ(4, lastContacts.contact_size());
+
+    for (const auto &contact : lastContacts.contact())
+    {
+      ASSERT_EQ(1, contact.position_size());
+      bool entityNameFound =
+        contact.collision1().name() ==
+        "contact_model::link::collision_sphere1" ||
+        contact.collision1().name() ==
+        "contact_model::link::collision_sphere2";
+      EXPECT_FALSE(entityNameFound);
+    }
+  }
+
+  // Remove the colliding boxes and check that contacts are no longer generated.
+  server.RequestRemoveEntity("box1");
+  server.RequestRemoveEntity("box2");
+  // Run once to remove entities
+  server.Run(true, 1, false);
+
+  contactMsgs.clear();
+  server.Run(true, 10, false);
+  {
+    std::lock_guard<std::mutex> lock(contactMutex);
+    EXPECT_EQ(0u, contactMsgs.size());
+  }
+}
+
+/////////////////////////////////////////////////
 // The test checks that contacts are published by the contact system
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
 TEST_F(ContactSystemTest,

--- a/test/worlds/contact_with_entity_names.sdf
+++ b/test/worlds/contact_with_entity_names.sdf
@@ -8,6 +8,9 @@
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">
+      <contacts>
+        <include_entity_names>true</include_entity_names>
+      </contacts>
     </plugin>
     <plugin
       filename="ignition-gazebo-contact-system"

--- a/test/worlds/contact_without_entity_names.sdf
+++ b/test/worlds/contact_without_entity_names.sdf
@@ -9,7 +9,7 @@
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">
       <contacts>
-        <include_entity_names>true</include_entity_names>
+        <include_entity_names>false</include_entity_names>
       </contacts>
     </plugin>
     <plugin


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
Currently, the contact points message has a ``Enitity`` member whose ``name`` field is not populated and just contains the ``id``. This PR populates the name with the entity's full name, for e.g. ``world:shapes:model:ground_plane:link:link:collision:collision`` so it is clear in the message which pair of entities is colliding.

## Test it
Modified an existing test case to check the full name of a colliding entity (``contact_system.cc`` integration test)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸