### PR TITLE
The return type of member function Name() has been changed for Model.hh

### DIFF
--- a/include/ignition/gazebo/Model.hh
+++ b/include/ignition/gazebo/Model.hh
@@ -96,7 +96,7 @@ namespace ignition
       /// \brief Get the model's unscoped name.
       /// \param[in] _ecm Entity-component manager.
       /// \return Model's name.
-      public: std::string Name(const EntityComponentManager &_ecm) const;
+      public: std::optional<std::string> Name(const EntityComponentManager &_ecm) const;
 
       /// \brief Get whether this model is static.
       /// \param[in] _ecm Entity-component manager.

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -78,7 +78,7 @@ bool Model::Valid(const EntityComponentManager &_ecm) const
 }
 
 //////////////////////////////////////////////////
-std::string Model::Name(const EntityComponentManager &_ecm) const
+std::optional<std::string> Model::Name(const EntityComponentManager &_ecm) const
 {
   auto comp = _ecm.Component<components::Name>(this->dataPtr->id);
   if (comp)


### PR DESCRIPTION
Signed-off-by: Aryaman <aryashardul2002@gmail.com>

Fixes #987

## Summary
The return type of the member function Name() in the model header file and the Model.cc has been changed from ```std::string``` to ```std::optional<std::string>``` so that it becomes consistent with other entities.




