### PR TITLE
Make WindEffects configurable on a location basis

### DIFF
--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -22,6 +22,7 @@
 #include <ignition/msgs/entity_factory.pb.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sdf/Root.hh>
@@ -113,7 +114,8 @@ namespace {
   }
 
   //////////////////////////////////////////////////
-  math::Intervald LoadIntervald(const sdf::ElementPtr _sdf, const std::string &_prefix)
+  math::Intervald
+  LoadIntervald(const sdf::ElementPtr _sdf, const std::string &_prefix)
   {
     bool leftClosed = false;
     double leftValue = -math::INF_D;

--- a/src/systems/wind_effects/WindEffects.hh
+++ b/src/systems/wind_effects/WindEffects.hh
@@ -33,9 +33,8 @@ namespace systems
   class WindEffectsPrivate;
 
   /// \brief A system that simulates a simple wind model.
-  /// The wind is described as a uniform worldwide model. So it is independent
-  /// from model position for simple computations. Its components are computed
-  /// separately:
+  /// The wind is described as a uniform worldwide model.
+  /// Its components are computed separately:
   /// - Horizontal amplitude:
   ///      Low pass filtering on user input (complementary gain)
   ///      + small local fluctuations
@@ -50,6 +49,12 @@ namespace systems
   ///      Low pass filtering on user input (complementary gain)
   ///      + small local fluctuations
   ///      + noise on value
+  ///
+  /// Forces exerted by the wind on model links are approximated from
+  /// link mass and velocity with respect to wind velocity, and applied
+  /// to the link frame origin. These approximations can be amplified or
+  /// attenuated on a per location basis by specifying a piecewise scalar
+  /// field for a scaling factor.
   ///
   /// The following parameters are used by the system:
   ///
@@ -86,6 +91,40 @@ namespace systems
   /// - `<vertical><noise>`
   /// Parameters for the noise that is added to the vertical wind velocity
   /// magnitude.
+  ///
+  /// - `<force_approximation_scaling_factor>`
+  /// Proportionality constant used for wind force approximations as a
+  /// piecewise, separable scalar field:
+  /// \verbatim
+  ///   <force_approximation_scaling_factor>
+  ///     <when xlt="0"> <!-- Half space where x < 0 -->
+  ///       <k>1</k>
+  ///       <px>0 0 0 1</px>  <!-- p(x) = x -->
+  ///       <qy>0 0 0 1</qy>  <!-- q(y) = 1 -->
+  ///       <rz>0 1 0 1</rz>  <!-- r(z) = z^2 -->
+  ///     </when>
+  ///   </force_approximation_scaling_factor>
+  /// \endverbatim
+  /// When the scaling factor is to be constant in a region, a numerical
+  /// constant may be used in place for the scalar field definition:
+  /// \verbatim
+  ///   <force_approximation_scaling_factor>
+  ///     <!-- First octant -->
+  ///     <when xge="0" yge="0" zge="0">1</when>
+  ///   </force_approximation_scaling_factor>
+  /// \endverbatim
+  /// To use the same constant or scalar field in all space, region
+  /// definition may be dropped:
+  /// \verbatim
+  ///   <force_approximation_scaling_factor>
+  ///     <k>2</k>
+  ///     <px>1 0 1 0</px>  <!-- p(x) = x^3 + x -->
+  ///     <qy>0 1 0 1</qy>  <!-- q(y) = x^2 + 1 -->
+  ///     <rz>1 0 1 0</rz>  <!-- r(z) = z^3 + z -->
+  ///   </force_approximation_scaling_factor>
+  /// \endverbatim
+  /// Regions may not overlap.
+  ///
   class WindEffects final:
     public System,
     public ISystemConfigure,

--- a/test/worlds/sea_storm_effects.sdf
+++ b/test/worlds/sea_storm_effects.sdf
@@ -1,0 +1,192 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="sea_storm_demo">
+    <gravity>0 0 0</gravity>
+
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-wind-effects-system"
+      name="ignition::gazebo::systems::WindEffects">
+      <force_approximation_scaling_factor>
+        <when zle="0">0</when>  <!-- No wind below sea level -->
+        <when zgt="0" zlt="5">0.2</when>  <!-- Transition layer -->
+        <when zge="5">  <!-- Vortex-like winds that worsen with height -->
+          <k>0.5</k>
+          <px>0 0.01 0 0</px>
+          <qy>0 0.01 0 0</qy>
+          <rz>0 0 0.01 0.45</rz>
+        </when>
+      </force_approximation_scaling_factor>
+      <horizontal>
+        <magnitude>
+          <time_for_rise>1</time_for_rise>
+          <sin>
+            <amplitude_percent>0.05</amplitude_percent>
+            <period>60</period>
+          </sin>
+        </magnitude>
+        <direction>
+          <time_for_rise>1</time_for_rise>
+          <sin>
+            <amplitude>5</amplitude>
+            <period>20</period>
+          </sin>
+        </direction>
+      </horizontal>
+    </plugin>
+
+    <wind>
+      <linear_velocity>50 50 0</linear_velocity>
+    </wind>
+
+    <model name="wind_below_surface">
+      <pose>0 0 -5 0 0 0</pose>
+      <enable_wind>true</enable_wind>
+      <link name="box_below_surface">
+        <pose>0 0 1 0 0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.667</iyy>
+            <iyz>0</iyz>
+            <izz>0.667</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>2.0 2.0 2.0</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.0</mu>
+                <mu2>0.0</mu2>
+              </ode>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.0 2.0 2.0</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1.0 0.0 0.0 1</ambient>
+            <diffuse>1.0 0.0 0.0 1</diffuse>
+            <specular>1.0 0.0 0.0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="wind_above_surface">
+      <pose>0 0 1 0 0 0</pose>
+      <link name="box_above_surface">
+        <enable_wind>true</enable_wind>
+        <pose>0 0 1 0 0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.667</iyy>
+            <iyz>0</iyz>
+            <izz>0.667</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>2.0 2.0 2.0</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.0</mu>
+                <mu2>0.0</mu2>
+              </ode>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.0 2.0 2.0</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1.0 0.0 0.0 1</ambient>
+            <diffuse>1.0 0.0 0.0 1</diffuse>
+            <specular>1.0 0.0 0.0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="wind_up_high">
+      <pose>50 50 20 0 0 0</pose>
+      <link name="box_up_high">
+        <enable_wind>true</enable_wind>
+        <pose>0 0 1 0 0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.667</iyy>
+            <iyz>0</iyz>
+            <izz>0.667</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>2.0 2.0 2.0</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.0</mu>
+                <mu2>0.0</mu2>
+              </ode>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.0 2.0 2.0</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1.0 0.0 0.0 1</ambient>
+            <diffuse>1.0 0.0 0.0 1</diffuse>
+            <specular>1.0 0.0 0.0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Closes #1354.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
This patch turns the force approximation scaling factor in the `WindEffects` plugin into a piecewise scalar field, configurable from the SDF file. It can still be configured as a scalar, so it remains backwards compatible.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
An integration test case has been added to the `INTEGRATION_wind_effects`  test suite.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.