### PR TITLE
Fix accessing empty JointPosition component in lift drag plugin

### DIFF
--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -266,9 +266,6 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
         _ecm.Component<components::JointPosition>(this->controlJointEntity);
   }
 
-  if (!controlJointPosition)
-    return;
-
   if (!worldLinVel || !worldAngVel || !worldPose)
     return;
 
@@ -385,7 +382,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
     cl = this->cla * alpha * cosSweepAngle;
 
   // modify cl per control joint value
-  if (controlJointPosition)
+  if (controlJointPosition && !controlJointPosition->Data().empty())
   {
     cl = cl + this->controlJointRadToCL * controlJointPosition->Data()[0];
     /// \todo(anyone): also change cm and cd

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -266,6 +266,9 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
         _ecm.Component<components::JointPosition>(this->controlJointEntity);
   }
 
+  if (!controlJointPosition)
+    return;
+
   if (!worldLinVel || !worldAngVel || !worldPose)
     return;
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Check for empty `JointControl` component before accessing it

## Summary

Ran into a crash  when the step size is not 1ms and a robot with the lift drag system is spawned into the world. The `JointPosition` component vector is accessed without being filled first.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

