### PR TITLE
Disables Failing Buoyancy Tests on Win32

### DIFF
--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -402,7 +402,7 @@ TEST_F(BuoyancyTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(GradedBuoyancy))
 
 
 /////////////////////////////////////////////////
-TEST_F(BuoyancyTest, OffsetAndRotationGraded)
+TEST_F(BuoyancyTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OffsetAndRotationGraded))
 {
   TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "worlds", "center_of_volume_graded.sdf"));
@@ -457,7 +457,7 @@ TEST_F(BuoyancyTest, OffsetAndRotationGraded)
 }
 
 /////////////////////////////////////////////////
-TEST_F(BuoyancyTest, OffsetAndRotation)
+TEST_F(BuoyancyTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OffsetAndRotation))
 {
   TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "worlds", "center_of_volume.sdf"));


### PR DESCRIPTION
# 🦟 Bug fix

See https://github.com/ignitionrobotics/ign-gazebo/pull/1307#issuecomment-1051364153

## Summary
Buoyancy tests failing on windows. Disabling them to prevent noise.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

