### PR TITLE
Use pose multiplication instead of addition

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -81,7 +81,7 @@ math::Pose3d worldPose(const Entity &_entity,
     if (!parentPose)
       break;
     // transform pose
-    pose = pose + parentPose->Data();
+    pose = parentPose->Data() * pose;
     // keep going up the tree
     p = _ecm.Component<components::ParentEntity>(p->Data());
   }

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1321,7 +1321,7 @@ void RenderUtil::Update()
           trajPose.Rot() = tf.second["actorPose"].Rotation();
         }
 
-        actorVisual->SetLocalPose(trajPose + globalPose);
+        actorVisual->SetLocalPose(globalPose * trajPose);
 
         tf.second.erase("actorPose");
         actorMesh->SetSkeletonLocalTransforms(tf.second);
@@ -3035,7 +3035,7 @@ void RenderUtilPrivate::UpdateAnimation(const std::unordered_map<Entity,
       trajPose.Rot() = poseFrame.Rotation();
     }
 
-    actorVisual->SetLocalPose(trajPose + globalPose);
+    actorVisual->SetLocalPose(globalPose * trajPose);
   }
 }
 

--- a/src/systems/optical_tactile_plugin/Visualization.cc
+++ b/src/systems/optical_tactile_plugin/Visualization.cc
@@ -209,8 +209,8 @@ void OpticalTactilePluginVisualization::AddNormalForceToMarkerMsgs(
   ignition::math::Pose3f normalForcePoseFromSensor(
     normalForcePositionFromSensor, normalForceOrientationFromSensor);
 
-  ignition::math::Pose3f normalForcePoseFromWorld =
-    (normalForcePoseFromSensor + this->depthCameraOffset) + _sensorWorldPose;
+  ignition::math::Pose3f normalForcePoseFromWorld = _sensorWorldPose *
+    this->depthCameraOffset * normalForcePoseFromSensor;
   normalForcePoseFromWorld.Correct();
 
   // Get the start point of the normal force
@@ -222,8 +222,8 @@ void OpticalTactilePluginVisualization::AddNormalForceToMarkerMsgs(
   normalForcePoseFromSensor.Set(normalForcePositionFromSensor +
     _normalForce * this->forceLength, normalForceOrientationFromSensor);
 
-  normalForcePoseFromWorld =
-    (normalForcePoseFromSensor + this->depthCameraOffset) + _sensorWorldPose;
+  normalForcePoseFromWorld = _sensorWorldPose * this->depthCameraOffset *
+    normalForcePoseFromSensor;
   normalForcePoseFromWorld.Correct();
 
   ignition::math::Vector3f endPointFromWorld =


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/ign-math/issues/60

## Summary

The ign-math Pose addition operator is going to be deprecated, so use the multiplication operator instead. It works in the opposite order, matching the behavior of coordinate transform multiplication.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
