### PR TITLE
GzSceneManager: Prevent crash 💥 when inserted from menu

### DIFF
--- a/src/gui/plugins/scene_manager/GzSceneManager.cc
+++ b/src/gui/plugins/scene_manager/GzSceneManager.cc
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 
 #include <QQmlProperty>
 

--- a/src/gui/plugins/scene_manager/GzSceneManager.cc
+++ b/src/gui/plugins/scene_manager/GzSceneManager.cc
@@ -18,6 +18,8 @@
 #include <map>
 #include <set>
 
+#include <QQmlProperty>
+
 #include "../../GuiRunner.hh"
 #include "GzSceneManager.hh"
 
@@ -67,6 +69,9 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 
     /// \brief Indicates whether initial visual plugins have been loaded or not.
     public: bool initializedVisualPlugins = false;
+
+    /// \brief Whether the plugin was correctly initialized
+    public: bool initialized{false};
   };
 }
 }
@@ -90,14 +95,30 @@ void GzSceneManager::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Scene Manager";
 
+  static bool done{false};
+  if (done)
+  {
+    std::string msg{"Only one GzSceneManager is supported at a time."};
+    ignerr << msg << std::endl;
+    QQmlProperty::write(this->PluginItem(), "message",
+        QString::fromStdString(msg));
+    return;
+  }
+  done = true;
+
   ignition::gui::App()->findChild<
       ignition::gui::MainWindow *>()->installEventFilter(this);
+
+  this->dataPtr->initialized = true;
 }
 
 //////////////////////////////////////////////////
 void GzSceneManager::Update(const UpdateInfo &_info,
     EntityComponentManager &_ecm)
 {
+  if (!this->dataPtr->initialized)
+    return;
+
   IGN_PROFILE("GzSceneManager::Update");
 
   this->dataPtr->renderUtil.UpdateECM(_info, _ecm);

--- a/src/gui/plugins/scene_manager/GzSceneManager.hh
+++ b/src/gui/plugins/scene_manager/GzSceneManager.hh
@@ -34,6 +34,8 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
   /// This plugin doesn't instantiate a new 3D scene. Instead, it relies on
   /// another plugin being loaded alongside it that will create and paint the
   /// scene to the window, such as `ignition::gui::plugins::Scene3D`.
+  ///
+  /// Only one GzSceneManager can be used at a time.
   class GzSceneManager : public GuiSystem
   {
     Q_OBJECT

--- a/src/gui/plugins/scene_manager/GzSceneManager.qml
+++ b/src/gui/plugins/scene_manager/GzSceneManager.qml
@@ -27,7 +27,7 @@ GridLayout {
   anchors.fill: parent
   anchors.margins: 10
 
-  property string message: 'N/A'
+  property string message: 'This plugin updates a 3D scene based on information coming from the Entity-Component-Manager.'
 
   Label {
     Layout.columnSpan: 1

--- a/src/gui/plugins/scene_manager/GzSceneManager.qml
+++ b/src/gui/plugins/scene_manager/GzSceneManager.qml
@@ -15,14 +15,30 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+GridLayout {
+  columns: 1
+  columnSpacing: 10
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 200
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: 'N/A'
+
+  Label {
+    Layout.columnSpan: 1
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    Layout.columnSpan: 1
+    width: 10
+    Layout.fillHeight: true
+  }
 }


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Currently, when the plugin is inserted from the menu, it causes a crash. With this change, only one `GzSceneManager` is supported at a time. When a new one is inserted, it prints an error to the user explaining that.

![gz_mana](https://user-images.githubusercontent.com/5751272/156668829-dd99e1a9-1469-4fec-8892-dbf136e62cb7.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
