### PR TITLE
Populate GUI plugins that are empty

### DIFF
--- a/examples/worlds/empty_gui.sdf
+++ b/examples/worlds/empty_gui.sdf
@@ -1,0 +1,210 @@
+<?xml version="1.0" ?>
+<!--
+
+This example helps illustrate the interaction of the MinimalScene with other GUI plugins.
+
+1. Load this world
+
+        ign gazebo empty_gui.sdf
+
+    The entire screen will be grey, because there's no scene manager populating it with
+
+2. From the top-right menu, insert the Gz Scene Manager plugin.
+    The ground plane, shapes and sky will show up. But it isn't possible to orbit the
+    camera with the mouse.
+
+3. From the menu, insert the Interactive View Control. It's now possible to orbit the
+    camera.
+
+4. Insert the Select Entities plugin, and now the shapes are highlighted when selected.
+
+5. Insert the Entity Context Menu and pop it out of the sidebar so it floats on top of
+    the 3D scene. Right-click its text and select "Settings". Disable "Show title bar"
+    and set the height to zero.
+    Now right-clicking the shapes opens a menu, but some of the options
+    don't work yet.
+
+6. Insert Camera Tracking, and now the "Move to" and "Follow" options on the context
+    menu work.
+
+7. Insert Visualization Capabilities, and now the View options on the context menu work.
+
+8. Insert both Copy Paste and Spawn, and now the "Copy" and "Paste" options work.
+
+-->
+
+<sdf version="1.7">
+
+  <world name="empty_gui">
+
+    <gui fullscreen="0">
+      <plugin filename="MinimalScene" name="3D View">
+        <ignition-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+      </plugin>
+    </gui>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+      <sky></sky>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.8 0.8 0.8 1</specular>
+      <direction>0.0 0.6 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="cylinder">
+      <pose>0 -1.5 0.5 0 0 0</pose>
+      <link name="cylinder_link">
+        <inertial>
+          <inertia>
+            <ixx>2</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2</iyy>
+            <iyz>0</iyz>
+            <izz>2</izz>
+          </inertia>
+          <mass>2.0</mass>
+        </inertial>
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+
+        <visual name="cylinder_visual">
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <specular>0 1 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="sphere">
+      <pose>0 1.5 0.5 0 0 0</pose>
+      <link name="sphere_link">
+        <inertial>
+          <inertia>
+            <ixx>3</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>3</iyy>
+            <iyz>0</iyz>
+            <izz>3</izz>
+          </inertia>
+          <mass>3.0</mass>
+        </inertial>
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="sphere_visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+ </world>
+</sdf>

--- a/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.cc
+++ b/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.cc
@@ -110,7 +110,7 @@ void EntityContextMenu::LoadConfig(const tinyxml2::XMLElement *)
     this->dataPtr->entityContextMenuHandler);
 
   if (this->title.empty())
-    this->title = "EntityContextMenu";
+    this->title = "Entity Context Menu";
 
   ignition::gui::App()->findChild
     <ignition::gui::MainWindow *>()->installEventFilter(this);

--- a/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.qml
+++ b/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.qml
@@ -15,15 +15,39 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 import RenderWindowOverlay 1.0
 import IgnGazebo 1.0 as IgnGazebo
 
-Rectangle {
-  visible: false
-  color: "transparent"
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 370
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: 'Adding a right-click context menu to the 3D scene.<br><br>' +
+      'For proper positioning:<br><ol>' +
+      '<li>Undock the menu</li>' +
+      '<li>Right-click this text, and choose Settings</li>' +
+      '<li>Hide the title bar and set height to zero</li></ol><br><br>' +
+      'These other plugins must also be loaded to enable all functionality:<br><ul>' +
+      '<li>Move To / Follow: Camera tracking</li>' +
+      '<li>Copy / Paste: Copy Paste</li>' +
+      '<li>View: Visualization Capabilities</li>' +
+      '<li>Remove: Gz Scene Manager</li></ul>'
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
+  }
 
   RenderWindowOverlay {
     id: renderWindowOverlay

--- a/src/gui/plugins/scene_manager/GzSceneManager.qml
+++ b/src/gui/plugins/scene_manager/GzSceneManager.qml
@@ -23,7 +23,7 @@ GridLayout {
   columns: 1
   columnSpacing: 10
   Layout.minimumWidth: 350
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 130
   anchors.fill: parent
   anchors.margins: 10
 

--- a/src/gui/plugins/select_entities/SelectEntities.cc
+++ b/src/gui/plugins/select_entities/SelectEntities.cc
@@ -21,6 +21,8 @@
 #include <utility>
 #include <vector>
 
+#include <QQmlProperty>
+
 #include <ignition/common/MouseEvent.hh>
 #include <ignition/gui/Application.hh>
 #include <ignition/gui/GuiEvents.hh>
@@ -474,6 +476,17 @@ void SelectEntities::LoadConfig(const tinyxml2::XMLElement *)
 {
   if (this->title.empty())
     this->title = "Select entities";
+
+  static bool done{false};
+  if (done)
+  {
+    std::string msg{"Only one SelectEntities plugin is supported at a time."};
+    ignerr << msg << std::endl;
+    QQmlProperty::write(this->PluginItem(), "message",
+        QString::fromStdString(msg));
+    return;
+  }
+  done = true;
 
   ignition::gui::App()->findChild<
       ignition::gui::MainWindow *>()->installEventFilter(this);

--- a/src/gui/plugins/select_entities/SelectEntities.qml
+++ b/src/gui/plugins/select_entities/SelectEntities.qml
@@ -15,14 +15,26 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 90
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: 'Adding selection functionality to the 3D scene.'
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
+  }
 }

--- a/src/gui/plugins/spawn/Spawn.cc
+++ b/src/gui/plugins/spawn/Spawn.cc
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <QQmlProperty>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/MeshManager.hh>
@@ -179,6 +180,17 @@ void Spawn::LoadConfig(const tinyxml2::XMLElement *)
 {
   if (this->title.empty())
     this->title = "Spawn";
+
+  static bool done{false};
+  if (done)
+  {
+    std::string msg{"Only one Spawn plugin is supported at a time."};
+    ignerr << msg << std::endl;
+    QQmlProperty::write(this->PluginItem(), "message",
+        QString::fromStdString(msg));
+    return;
+  }
+  done = true;
 
   // World name from window, to construct default topics and services
   auto worldNames = gui::worldNames();

--- a/src/gui/plugins/spawn/Spawn.qml
+++ b/src/gui/plugins/spawn/Spawn.qml
@@ -20,10 +20,14 @@ import QtQuick.Controls 2.2
 import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 110
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: 'Adding spawn functionality to the 3D scene, ' +
+      'via events and drag and drop'
 
   Connections {
     target: Spawn
@@ -44,5 +48,16 @@ Rectangle {
       text: Spawn.errorPopupText
     }
     standardButtons: Dialog.Ok
+  }
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
   }
 }

--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
@@ -30,6 +30,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <QQmlProperty>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/HeightmapData.hh>
@@ -2766,7 +2767,19 @@ void VisualizationCapabilities::Update(const UpdateInfo &,
 void VisualizationCapabilities::LoadConfig(const tinyxml2::XMLElement *)
 {
   if (this->title.empty())
-    this->title = "VisualizationCapabilities";
+    this->title = "Visualization capabilities";
+
+  static bool done{false};
+  if (done)
+  {
+    std::string msg{
+        "Only one Visualization capabilities plugin is supported at a time."};
+    ignerr << msg << std::endl;
+    QQmlProperty::write(this->PluginItem(), "message",
+        QString::fromStdString(msg));
+    return;
+  }
+  done = true;
 
   // view as transparent service
   this->dataPtr->viewTransparentService = "/gui/view/transparent";

--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.qml
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.qml
@@ -15,14 +15,27 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 130
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: 'Adding visualization capabilities to the 3D ' +
+      'scene such as view transparent, joints, CoM, etc.'
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
+  }
 }


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Some GUI plugins in this repository were completely empty when inserted by the user, which can be very confusing. This PR adds some text explaining what each plugin is doing. I also added the `empty_gui.sdf` example to demonstrate how various plugins add functionality to `MinimalScene`. Here's a run of the example:

![empty_gui](https://user-images.githubusercontent.com/5751272/156841548-6c691605-1512-445e-91ce-972ab82e2558.gif)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
