### PR TITLE
Add gazebo Entity id to rendering sensor's user data

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -1776,6 +1776,9 @@ bool SceneManager::AddSensor(Entity _gazeboId, const std::string &_sensorName,
     return false;
   }
 
+  // \todo(anyone) change to uint64_t once UserData supports this type
+  sensor->SetUserData("gazebo-entity", static_cast<int>(_gazeboId));
+
   if (parent)
   {
     sensor->RemoveParent();

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -139,3 +139,9 @@ set_tests_properties(INTEGRATION_tracked_vehicle_system PROPERTIES TIMEOUT 300)
 if(TARGET INTEGRATION_examples_build)
   set_tests_properties(INTEGRATION_examples_build PROPERTIES TIMEOUT 320)
 endif()
+
+if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
+  target_link_libraries(INTEGRATION_sensors_system
+    ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+  )
+endif()

--- a/test/integration/sensors_system.cc
+++ b/test/integration/sensors_system.cc
@@ -18,8 +18,8 @@
 #include <gtest/gtest.h>
 
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 #include <sdf/Model.hh>
 #include <sdf/Root.hh>

--- a/test/integration/sensors_system.cc
+++ b/test/integration/sensors_system.cc
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include <sdf/Model.hh>
 #include <sdf/Root.hh>
@@ -26,6 +27,11 @@
 
 #include <ignition/transport/Node.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
+
+#include <ignition/rendering/Camera.hh>
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
 
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/EventManager.hh"
@@ -37,7 +43,10 @@
 
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/components/World.hh"
+
+#include "ignition/gazebo/rendering/Events.hh"
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
@@ -45,6 +54,45 @@
 using namespace ignition;
 using namespace std::chrono_literals;
 namespace components = ignition::gazebo::components;
+
+std::unordered_set<gazebo::Entity> g_sensorEntityIds;
+rendering::ScenePtr g_scene;
+
+/////////////////////////////////////////////////
+void OnPostRender()
+{
+  if (!g_scene)
+  {
+    g_scene = rendering::sceneFromFirstRenderEngine();
+  }
+  ASSERT_TRUE(g_scene);
+
+  EXPECT_LT(0u, g_scene->SensorCount());
+  for (unsigned int i = 0; i < g_scene->SensorCount(); ++i)
+  {
+    auto sensor = g_scene->SensorByIndex(i);
+    ASSERT_TRUE(sensor);
+    EXPECT_TRUE(sensor->HasUserData("gazebo-entity"));
+    auto variant = sensor->UserData("gazebo-entity");
+
+    // todo(anyone) change int to uint64_t once user data supports it
+    const int *value = std::get_if<int>(&variant);
+    ASSERT_TRUE(value);
+    g_sensorEntityIds.insert(*value);
+  }
+}
+
+/////////////////////////////////////////////////
+void testSensorEntityIds(const gazebo::EntityComponentManager &_ecm,
+    const std::unordered_set<gazebo::Entity> &_ids)
+{
+  EXPECT_FALSE(_ids.empty());
+  for (const auto & id : _ids)
+  {
+    auto sensorComp = _ecm.Component<gazebo::components::Sensor>(id);
+    EXPECT_TRUE(sensorComp);
+  }
+}
 
 //////////////////////////////////////////////////
 class SensorsFixture : public InternalFixture<InternalFixture<::testing::Test>>
@@ -127,6 +175,8 @@ TEST_F(SensorsFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(HandleRemovedEntities))
 
   gazebo::Server server(serverConfig);
 
+  common::ConnectionPtr postRenderConn;
+
   // A pointer to the ecm. This will be valid once we run the mock system
   gazebo::EntityComponentManager *ecm = nullptr;
   this->mockSystem->preUpdateCallback =
@@ -134,12 +184,25 @@ TEST_F(SensorsFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(HandleRemovedEntities))
     {
       ecm = &_ecm;
     };
+  this->mockSystem->configureCallback =
+    [&](const gazebo::Entity &,
+           const std::shared_ptr<const sdf::Element> &,
+           gazebo::EntityComponentManager &,
+           gazebo::EventManager &_eventMgr)
+    {
+      postRenderConn = _eventMgr.Connect<gazebo::events::PostRender>(
+          std::bind(&::OnPostRender));
+    };
 
   server.AddSystem(this->systemPtr);
   server.Run(true, 50, false);
   ASSERT_NE(nullptr, ecm);
 
   testDefaultTopics();
+
+  testSensorEntityIds(*ecm, g_sensorEntityIds);
+  g_sensorEntityIds.clear();
+  g_scene.reset();
 
   // We won't use the event manager but it's required to create an
   // SdfEntityCreator


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Adds the `gazebo::Entity` id to a `rendering::Sensor`'s UserData object. The main use case is so that we can get back the corresponding gazebo `Entity` in the rendering thread when processing sensors.

## Test it
Run the `INTEGRATION_sensors_system` test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
