### PR TITLE
Fix trajectory follower: enable WorldPose component

### DIFF
--- a/src/systems/trajectory_follower/TrajectoryFollower.cc
+++ b/src/systems/trajectory_follower/TrajectoryFollower.cc
@@ -324,6 +324,7 @@ void TrajectoryFollower::PreUpdate(
     // We call Load here instead of Configure because we can't be guaranteed
     // that all entities have been created when Configure is called
     this->dataPtr->Load(_ecm, this->dataPtr->sdfConfig);
+    enableComponent<components::WorldPose>(_ecm, this->dataPtr->link.Entity());
     this->dataPtr->initialized = true;
   }
 
@@ -379,6 +380,12 @@ void TrajectoryFollower::PreUpdate(
 
   // Transform from world to local frame.
   auto comPose = this->dataPtr->link.WorldInertialPose(_ecm);
+  if (!comPose.has_value())
+  {
+    ignerr << "Failed to get CoM pose for link ["
+           << this->dataPtr->link.Entity() << "]" << std::endl;
+    return;
+  }
 
   // Transform the force and torque to the world frame.
   // Move commands. The vehicle always move forward (X direction).


### PR DESCRIPTION
# 🦟 Bug fix

* Broken off #1380

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `TrajectoryFollower`'s example world doesn't work out of the box on Garden. The `WorldPose` component needs to be explicitly enabled for it to work. I didn't look into why that's different from Fortress, but most likely some other plugin was enabling that component.

Now the example works:

![trajectory_follower_2](https://user-images.githubusercontent.com/5751272/157738156-91380f53-8723-4880-a67a-bfa1736bfdab.gif)

By the way, this would have been caught more easily on the forward-port if there were a test for the plugin. As mentioned in https://github.com/ignitionrobotics/ign-gazebo/pull/1332#issuecomment-1063374928, we should add one. CC @caguero  @iche033 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
