### PR TITLE
Prevent hanging when world has only non-world plugins

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -174,7 +174,7 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
 
   // If we have reached this point and no world systems have been loaded, then
   // load a default set of systems.
-  if (this->systemMgr->SystemsByEntity(
+  if (this->systemMgr->TotalByEntity(
       worldEntity(this->entityCompMgr)).empty())
   {
     ignmsg << "No systems loaded from SDF, loading defaults" << std::endl;

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -172,9 +172,10 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   // Load any additional plugins from the Server Configuration
   this->LoadServerPlugins(this->serverConfig.Plugins());
 
-  // If we have reached this point and no systems have been loaded, then load
-  // a default set of systems.
-  if (this->systemMgr->TotalCount() == 0)
+  // If we have reached this point and no world systems have been loaded, then
+  // load a default set of systems.
+  if (this->systemMgr->SystemsByEntity(
+      worldEntity(this->entityCompMgr)).empty())
   {
     ignmsg << "No systems loaded from SDF, loading defaults" << std::endl;
     bool isPlayback = !this->serverConfig.LogPlaybackPath().empty();

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1533,6 +1533,30 @@ TEST_P(SimulationRunnerTest,
 }
 
 /////////////////////////////////////////////////
+TEST_P(SimulationRunnerTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadOnlyModelPlugin) )
+{
+  sdf::Root rootWithout;
+  rootWithout.Load(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "model_plugin_only.sdf"));
+  ASSERT_EQ(1u, rootWithout.WorldCount());
+
+  // ServerConfig will fall back to environment variable
+  auto config = common::joinPaths(PROJECT_SOURCE_PATH,
+    "test", "worlds", "server_valid2.config");
+  ASSERT_EQ(true, common::setenv(gazebo::kServerConfigPathEnv, config));
+  ServerConfig serverConfig;
+
+  // Create simulation runner
+  auto systemLoader = std::make_shared<SystemLoader>();
+  SimulationRunner runner(rootWithout.WorldByIndex(0), systemLoader,
+      serverConfig);
+
+  // 1 model plugin from SDF and 2 world plugins from config
+  ASSERT_EQ(3u, runner.SystemCount());
+}
+
+/////////////////////////////////////////////////
 TEST_P(SimulationRunnerTest, GuiInfo)
 {
   // Load SDF file

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -39,25 +39,28 @@ namespace ignition
     {
       /// \brief Constructor
       /// \param[in] _systemPlugin A system loaded from a plugin.
-      public: explicit SystemInternal(SystemPluginPtr _systemPlugin)
+      public: explicit SystemInternal(SystemPluginPtr _systemPlugin, Entity _entity)
               : systemPlugin(std::move(_systemPlugin)),
                 system(systemPlugin->QueryInterface<System>()),
                 configure(systemPlugin->QueryInterface<ISystemConfigure>()),
                 preupdate(systemPlugin->QueryInterface<ISystemPreUpdate>()),
                 update(systemPlugin->QueryInterface<ISystemUpdate>()),
-                postupdate(systemPlugin->QueryInterface<ISystemPostUpdate>())
+                postupdate(systemPlugin->QueryInterface<ISystemPostUpdate>()),
+                parentEntity(_entity)
       {
       }
 
       /// \brief Constructor
       /// \param[in] _system Pointer to a system.
-      public: explicit SystemInternal(const std::shared_ptr<System> &_system)
+      public: explicit SystemInternal(const std::shared_ptr<System> &_system,
+          Entity _entity)
               : systemShared(_system),
                 system(_system.get()),
                 configure(dynamic_cast<ISystemConfigure *>(_system.get())),
                 preupdate(dynamic_cast<ISystemPreUpdate *>(_system.get())),
                 update(dynamic_cast<ISystemUpdate *>(_system.get())),
-                postupdate(dynamic_cast<ISystemPostUpdate *>(_system.get()))
+                postupdate(dynamic_cast<ISystemPostUpdate *>(_system.get())),
+                parentEntity(_entity)
       {
       }
 
@@ -89,9 +92,9 @@ namespace ignition
       /// Will be nullptr if the System doesn't implement this interface.
       public: ISystemPostUpdate *postupdate = nullptr;
 
-      /// \brief Cached entity that was used to call `Configure` on the system
-      /// Useful for if a system needs to be reconfigured at runtime
-      public: Entity configureEntity = {kNullEntity};
+      /// \brief Entity that the system is attached to. It's passed to the
+      /// system during the `Configure` call.
+      public: Entity parentEntity = {kNullEntity};
 
       /// \brief Cached sdf that was used to call `Configure` on the system
       /// Useful for if a system needs to be reconfigured at runtime

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -40,7 +40,8 @@ namespace ignition
       /// \brief Constructor
       /// \param[in] _systemPlugin A system loaded from a plugin.
       /// \param[in] _entity The entity that this system is attached to.
-      public: explicit SystemInternal(SystemPluginPtr _systemPlugin, Entity _entity)
+      public: explicit SystemInternal(SystemPluginPtr _systemPlugin,
+          Entity _entity)
               : systemPlugin(std::move(_systemPlugin)),
                 system(systemPlugin->QueryInterface<System>()),
                 configure(systemPlugin->QueryInterface<ISystemConfigure>()),
@@ -53,6 +54,7 @@ namespace ignition
 
       /// \brief Constructor
       /// \param[in] _system Pointer to a system.
+      /// \param[in] _entity The entity that this system is attached to.
       public: explicit SystemInternal(const std::shared_ptr<System> &_system,
           Entity _entity)
               : systemShared(_system),

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -39,6 +39,7 @@ namespace ignition
     {
       /// \brief Constructor
       /// \param[in] _systemPlugin A system loaded from a plugin.
+      /// \param[in] _entity The entity that this system is attached to.
       public: explicit SystemInternal(SystemPluginPtr _systemPlugin, Entity _entity)
               : systemPlugin(std::move(_systemPlugin)),
                 system(systemPlugin->QueryInterface<System>()),

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -103,7 +103,7 @@ void SystemManager::AddSystem(const SystemPluginPtr &_system,
       Entity _entity,
       std::shared_ptr<const sdf::Element> _sdf)
 {
-  this->AddSystemImpl(SystemInternal(_system), _entity, _sdf);
+  this->AddSystemImpl(SystemInternal(_system, _entity), _sdf);
 }
 
 //////////////////////////////////////////////////
@@ -112,19 +112,18 @@ void SystemManager::AddSystem(
       Entity _entity,
       std::shared_ptr<const sdf::Element> _sdf)
 {
-  this->AddSystemImpl(SystemInternal(_system), _entity, _sdf);
+  this->AddSystemImpl(SystemInternal(_system, _entity), _sdf);
 }
 
 //////////////////////////////////////////////////
 void SystemManager::AddSystemImpl(
       SystemInternal _system,
-      Entity _entity,
       std::shared_ptr<const sdf::Element> _sdf)
 {
   // Configure the system, if necessary
   if (_system.configure && this->entityCompMgr && this->eventMgr)
   {
-    _system.configure->Configure(_entity, _sdf,
+    _system.configure->Configure(_system.parentEntity, _sdf,
                                  *this->entityCompMgr,
                                  *this->eventMgr);
   }
@@ -156,4 +155,16 @@ const std::vector<ISystemUpdate *>& SystemManager::SystemsUpdate()
 const std::vector<ISystemPostUpdate *>& SystemManager::SystemsPostUpdate()
 {
   return this->systemsPostupdate;
+}
+
+//////////////////////////////////////////////////
+std::vector<SystemInternal> SystemManager::SystemsByEntity(Entity _entity)
+{
+  std::vector<SystemInternal> result;
+  for (auto system : this->systems)
+  {
+    if (system.parentEntity == _entity)
+      result.push_back(system);
+  }
+  return result;
 }

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -158,10 +158,15 @@ const std::vector<ISystemPostUpdate *>& SystemManager::SystemsPostUpdate()
 }
 
 //////////////////////////////////////////////////
-std::vector<SystemInternal> SystemManager::SystemsByEntity(Entity _entity)
+std::vector<SystemInternal> SystemManager::TotalByEntity(Entity _entity)
 {
   std::vector<SystemInternal> result;
   for (auto system : this->systems)
+  {
+    if (system.parentEntity == _entity)
+      result.push_back(system);
+  }
+  for (auto system : this->pendingSystems)
   {
     if (system.parentEntity == _entity)
       result.push_back(system);

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -92,26 +92,32 @@ namespace ignition
       /// \return The number of newly-active systems
       public: size_t ActivatePendingSystems();
 
-      /// \brief Get an vector of all systems implementing "Configure"
+      /// \brief Get an vector of all active systems implementing "Configure"
+      /// \return Vector of systems's configure interfaces.
       public: const std::vector<ISystemConfigure *>& SystemsConfigure();
 
-      /// \brief Get an vector of all systems implementing "PreUpdate"
+      /// \brief Get an vector of all active systems implementing "PreUpdate"
+      /// \return Vector of systems's pre-update interfaces.
       public: const std::vector<ISystemPreUpdate *>& SystemsPreUpdate();
 
-      /// \brief Get an vector of all systems implementing "Update"
+      /// \brief Get an vector of all active systems implementing "Update"
+      /// \return Vector of systems's update interfaces.
       public: const std::vector<ISystemUpdate *>& SystemsUpdate();
 
-      /// \brief Get an vector of all systems implementing "PostUpdate"
+      /// \brief Get an vector of all active systems implementing "PostUpdate"
+      /// \return Vector of systems's post-update interfaces.
       public: const std::vector<ISystemPostUpdate *>& SystemsPostUpdate();
+
+      /// \brief Get an vector of all active systems attached to a given entity.
+      /// \return Vector of systems.
+      public: std::vector<SystemInternal> SystemsByEntity(Entity _entity);
 
       /// \brief Implementation for AddSystem functions. This only adds systems
       /// to a queue, the actual addition is performed by `AddSystemToRunner` at
       /// the appropriate time.
       /// \param[in] _system Generic representation of a system.
-      /// \param[in] _entity Entity received from AddSystem.
       /// \param[in] _sdf SDF received from AddSystem.
       private: void AddSystemImpl(SystemInternal _system,
-                                  Entity _entity,
                                   std::shared_ptr<const sdf::Element> _sdf);
 
       /// \brief All the systems.

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -108,9 +108,9 @@ namespace ignition
       /// \return Vector of systems's post-update interfaces.
       public: const std::vector<ISystemPostUpdate *>& SystemsPostUpdate();
 
-      /// \brief Get an vector of all active systems attached to a given entity.
+      /// \brief Get an vector of all systems attached to a given entity.
       /// \return Vector of systems.
-      public: std::vector<SystemInternal> SystemsByEntity(Entity _entity);
+      public: std::vector<SystemInternal> TotalByEntity(Entity _entity);
 
       /// \brief Implementation for AddSystem functions. This only adds systems
       /// to a queue, the actual addition is performed by `AddSystemToRunner` at

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -106,7 +106,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
-  EXPECT_EQ(0u, systemMgr.SystemsByEntity(configEntity).size());
+  EXPECT_EQ(1u, systemMgr.TotalByEntity(configEntity).size());
 
   systemMgr.ActivatePendingSystems();
   EXPECT_EQ(1u, systemMgr.ActiveCount());
@@ -116,7 +116,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
-  EXPECT_EQ(1u, systemMgr.SystemsByEntity(configEntity).size());
+  EXPECT_EQ(1u, systemMgr.TotalByEntity(configEntity).size());
 
   auto updateSystem = std::make_shared<SystemWithUpdates>();
   Entity updateEntity{456u};
@@ -128,7 +128,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
-  EXPECT_EQ(0u, systemMgr.SystemsByEntity(updateEntity).size());
+  EXPECT_EQ(1u, systemMgr.TotalByEntity(updateEntity).size());
 
   systemMgr.ActivatePendingSystems();
   EXPECT_EQ(2u, systemMgr.ActiveCount());
@@ -138,7 +138,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
-  EXPECT_EQ(1u, systemMgr.SystemsByEntity(updateEntity).size());
+  EXPECT_EQ(1u, systemMgr.TotalByEntity(updateEntity).size());
 }
 
 /////////////////////////////////////////////////

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -93,7 +93,8 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
   auto configSystem = std::make_shared<SystemWithConfigure>();
-  systemMgr.AddSystem(configSystem, kNullEntity, nullptr);
+  Entity configEntity{123u};
+  systemMgr.AddSystem(configSystem, configEntity, nullptr);
 
   // SystemManager without an ECM/EventmManager will mean no config occurs
   EXPECT_EQ(0, configSystem->configured);
@@ -105,6 +106,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsByEntity(configEntity).size());
 
   systemMgr.ActivatePendingSystems();
   EXPECT_EQ(1u, systemMgr.ActiveCount());
@@ -114,9 +116,11 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsByEntity(configEntity).size());
 
   auto updateSystem = std::make_shared<SystemWithUpdates>();
-  systemMgr.AddSystem(updateSystem, kNullEntity, nullptr);
+  Entity updateEntity{456u};
+  systemMgr.AddSystem(updateSystem, updateEntity, nullptr);
   EXPECT_EQ(1u, systemMgr.ActiveCount());
   EXPECT_EQ(1u, systemMgr.PendingCount());
   EXPECT_EQ(2u, systemMgr.TotalCount());
@@ -124,6 +128,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
+  EXPECT_EQ(0u, systemMgr.SystemsByEntity(updateEntity).size());
 
   systemMgr.ActivatePendingSystems();
   EXPECT_EQ(2u, systemMgr.ActiveCount());
@@ -133,6 +138,7 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsByEntity(updateEntity).size());
 }
 
 /////////////////////////////////////////////////

--- a/test/worlds/model_plugin_only.sdf
+++ b/test/worlds/model_plugin_only.sdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="model_plugin_only">
+
+    <light type="directional" name="sun">
+    </light>
+
+    <model name='box'>
+      <link name='link'>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <iyy>0.416519</iyy>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <plugin
+        filename="ignition-gazebo-velocity-control-system"
+        name="ignition::gazebo::systems::VelocityControl">
+        <initial_linear>0.3 0 0</initial_linear>
+        <initial_angular>0 0 -0.1</initial_angular>
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

* Fixes the main issue in https://github.com/ignitionrobotics/ign-gazebo/issues/796

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

When loading a world without any world plugins, we load a predefined set of plugins by default, [see this tutorial](https://ignitionrobotics.org/api/gazebo/6.7/server_config.html). The problem is that if a world has some non-world plugin, such as a model plugin, then we were not loading those default world plugins. Which causes the UI to "hang", because there's no `SceneBroadcaster`, and the simulation not to do anything, because there's no `Physics`.

This PR makes sure that we load the default world plugins even if there are other plugins loaded.

### Try it out

Before this PR, loading the added test world leaves an empty screen. With the PR, the UI shows the model and it moves.

`ign gazebo test/worlds/model_plugin_only.sdf`

### Target branch

I targeted `ign-gazebo6` to take advantage of the new `SystemManager` class introduced in #1340. This bug is also present in Citadel, so I'll think about a way of backporting the fix. I looked into backporting #1340 but it may depend on other non-backportable PRs.

### Implementation detail

I noticed that the `configureEntity` variable wasn't being used. I took a quick look into the "reset" PRs, and didn't see how it was meant to be used. I changed its name for clarity and also I'm making sure it's used now. Let me know if this conflicts with any of the reset work, @mjcarroll @azeey .

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
