### PR TITLE
Don't mark entities with a ComponentState::NoChange component as modified

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1912,6 +1912,10 @@ void EntityComponentManager::SetChanged(
     auto oneTimeIter = this->dataPtr->oneTimeChangedComponents.find(_type);
     if (oneTimeIter != this->dataPtr->oneTimeChangedComponents.end())
       oneTimeIter->second.erase(_entity);
+
+    // the component state is flagged as no change, so don't mark the
+    // corresponding entity as one with a modified component
+    return;
   }
 
   this->dataPtr->AddModifiedComponent(_entity);

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2238,6 +2238,17 @@ TEST_P(EntityComponentManagerFixture,
   EXPECT_EQ(ComponentState::NoChange,
       manager.ComponentState(e2, c2->TypeId()));
 
+  // Marking a component that isn't changed as unchanged again shouldn't effect
+  // the ecm's changed state
+  manager.RunClearNewlyCreatedEntities();
+  EXPECT_EQ(0, manager.ChangedState().entities_size());
+  manager.SetChanged(e1, c1->TypeId(), ComponentState::NoChange);
+  EXPECT_EQ(ComponentState::NoChange,
+      manager.ComponentState(e1, c1->TypeId()));
+  EXPECT_FALSE(manager.HasOneTimeComponentChanges());
+  EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
+  EXPECT_EQ(0, manager.ChangedState().entities_size());
+
   // Mark as changed
   manager.SetChanged(e1, c1->TypeId(), ComponentState::PeriodicChange);
 


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

# 🦟 Bug fix

## Summary
The implementation of `EntityComponentManager::SetChanged` was always calling `this->dataPtr->AddModifiedComponent` at the end, even if the component state was `NoChange`. If the component hasn't been changed, `this->dataPtr->AddModifiedComponent` shouldn't be called.

I have added a test case to verify that this PR corrects the behavior. Before the changes made in the PR, the test will fail.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.