### PR TITLE
Disable PeerTracker.PeerTrackerStale on macOS

### DIFF
--- a/src/network/PeerTracker_TEST.cc
+++ b/src/network/PeerTracker_TEST.cc
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "PeerTracker.hh"
 #include "ignition/gazebo/EventManager.hh"
@@ -143,7 +144,7 @@ TEST(PeerTracker, PeerTracker)
 }
 
 //////////////////////////////////////////////////
-TEST(PeerTracker, PeerTrackerStale)
+TEST(PeerTracker, IGN_UTILS_TEST_DISABLED_ON_MAC(PeerTrackerStale))
 {
   ignition::common::Console::SetVerbosity(4);
   EventManager eventMgr;


### PR DESCRIPTION
# 🦟 Bug fix

Relates to #760 

## Summary
Disabling test since it's flaky.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
