### PR TITLE
Component inspector: refactor Pose3d C++ code into a separate class

### DIFF
--- a/src/gui/plugins/component_inspector/CMakeLists.txt
+++ b/src/gui/plugins/component_inspector/CMakeLists.txt
@@ -1,4 +1,8 @@
 gz_add_gui_plugin(ComponentInspector
-  SOURCES ComponentInspector.cc
-  QT_HEADERS ComponentInspector.hh
+  SOURCES
+    ComponentInspector.cc
+    Pose3d.cc
+  QT_HEADERS
+    ComponentInspector.hh
+    Pose3d.hh
 )

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -21,14 +21,16 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
+#include <ignition/transport/Node.hh>
 
 #include <ignition/gazebo/components/Component.hh>
 #include <ignition/gazebo/gui/GuiSystem.hh>
 #include <ignition/gazebo/Types.hh>
 
 #include "ignition/gazebo/components/Physics.hh"
+
+#include "Types.hh"
 
 Q_DECLARE_METATYPE(ignition::gazebo::ComponentTypeId)
 
@@ -64,12 +66,6 @@ namespace gazebo
   /// \param[in] _data Data to set.
   template<>
   void setData(QStandardItem *_item, const std::string &_data);
-
-  /// \brief Specialized to set pose data.
-  /// \param[in] _item Item whose data will be set.
-  /// \param[in] _data Data to set.
-  template<>
-  void setData(QStandardItem *_item, const math::Pose3d &_data);
 
   /// \brief Specialized to set vector data.
   /// \param[in] _item Item whose data will be set.
@@ -205,15 +201,12 @@ namespace gazebo
     // Documentation inherited
     public: void Update(const UpdateInfo &, EntityComponentManager &) override;
 
-    /// \brief Callback in Qt thread when pose changes.
-    /// \param[in] _x X
-    /// \param[in] _y Y
-    /// \param[in] _z Z
-    /// \param[in] _roll Roll
-    /// \param[in] _pitch Pitch
-    /// \param[in] _yaw Yaw
-    public: Q_INVOKABLE void OnPose(double _x, double _y, double _z,
-        double _roll, double _pitch, double _yaw);
+    /// \brief Add a callback that's called whenever there are updates from the
+    /// ECM to the view, for a given component type.
+    /// \param[in] _id The component type id
+    /// \param[in] _cb Function that's called when there are updates.
+    public: void AddUpdateViewCb(ComponentTypeId _id,
+                inspector::UpdateViewCb _cb);
 
     /// \brief Callback in Qt thread when physics' properties change.
     /// \param[in] _stepSize step size
@@ -274,6 +267,14 @@ namespace gazebo
 
     /// \brief Notify that paused has changed.
     signals: void PausedChanged();
+
+    /// \brief Name of world entity
+    /// \return World name
+    public: const std::string &WorldName() const;
+
+    /// \brief Node for communication
+    /// \return Transport node
+    public: transport::Node &TransportNode();
 
     /// \internal
     /// \brief Pointer to private data.

--- a/src/gui/plugins/component_inspector/Pose3d.cc
+++ b/src/gui/plugins/component_inspector/Pose3d.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <string>
+
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/pose.pb.h>
 

--- a/src/gui/plugins/component_inspector/Pose3d.cc
+++ b/src/gui/plugins/component_inspector/Pose3d.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/msgs/boolean.pb.h>
+#include <ignition/msgs/pose.pb.h>
+
+#include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/components/PoseCmd.hh"
+
+#include "Pose3d.hh"
+#include "ComponentInspector.hh"
+#include "Types.hh"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace inspector;
+
+/////////////////////////////////////////////////
+Pose3d::Pose3d(ComponentInspector *_inspector)
+{
+  _inspector->Context()->setContextProperty("Pose3dImpl", this);
+  this->inspector = _inspector;
+
+  this->inspector->AddUpdateViewCb(components::Pose::typeId,
+      std::bind(&Pose3d::UpdateView, this, std::placeholders::_1,
+      std::placeholders::_2));
+  this->inspector->AddUpdateViewCb(components::WorldPose::typeId,
+      std::bind(&Pose3d::UpdateView, this, std::placeholders::_1,
+      std::placeholders::_2));
+  this->inspector->AddUpdateViewCb(components::WorldPoseCmd::typeId,
+      std::bind(&Pose3d::UpdateView, this, std::placeholders::_1,
+      std::placeholders::_2));
+}
+
+/////////////////////////////////////////////////
+void Pose3d::UpdateView(const EntityComponentManager &_ecm,
+    QStandardItem *_item)
+{
+  if (nullptr == _item)
+    return;
+
+  math::Pose3d pose;
+
+  if (auto poseComp = _ecm.Component<components::Pose>(
+      this->inspector->GetEntity()))
+  {
+    pose = poseComp->Data();
+  }
+  else if (auto worldPoseComp = _ecm.Component<components::WorldPose>(
+      this->inspector->GetEntity()))
+  {
+    pose = worldPoseComp->Data();
+  }
+  else if (auto worldPoseCmdComp = _ecm.Component<components::WorldPoseCmd>(
+      this->inspector->GetEntity()))
+  {
+    pose = worldPoseCmdComp->Data();
+  }
+  else
+  {
+    return;
+  }
+
+  _item->setData(QString("Pose3d"),
+      ComponentsModel::RoleNames().key("dataType"));
+  _item->setData(QList({
+    QVariant(pose.Pos().X()),
+    QVariant(pose.Pos().Y()),
+    QVariant(pose.Pos().Z()),
+    QVariant(pose.Rot().Roll()),
+    QVariant(pose.Rot().Pitch()),
+    QVariant(pose.Rot().Yaw())
+  }), ComponentsModel::RoleNames().key("data"));
+}
+
+/////////////////////////////////////////////////
+void Pose3d::OnPose(double _x, double _y, double _z, double _roll,
+    double _pitch, double _yaw)
+{
+  std::function<void(const msgs::Boolean &, const bool)> cb =
+      [](const msgs::Boolean &, const bool _result)
+  {
+    if (!_result)
+        ignerr << "Error setting pose" << std::endl;
+  };
+
+  msgs::Pose req;
+  req.set_id(this->inspector->GetEntity());
+  msgs::Set(req.mutable_position(), math::Vector3d(_x, _y, _z));
+  msgs::Set(req.mutable_orientation(), math::Quaterniond(_roll, _pitch, _yaw));
+  std::string poseCmdService("/world/" + this->inspector->WorldName()
+      + "/set_pose");
+  this->inspector->TransportNode().Request(poseCmdService, req, cb);
+}

--- a/src/gui/plugins/component_inspector/Pose3d.cc
+++ b/src/gui/plugins/component_inspector/Pose3d.cc
@@ -20,12 +20,7 @@
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/pose.pb.h>
 
-#include "ignition/gazebo/components/Pose.hh"
-#include "ignition/gazebo/components/PoseCmd.hh"
-
 #include "Pose3d.hh"
-#include "ComponentInspector.hh"
-#include "Types.hh"
 
 using namespace ignition;
 using namespace gazebo;
@@ -38,55 +33,14 @@ Pose3d::Pose3d(ComponentInspector *_inspector)
   this->inspector = _inspector;
 
   this->inspector->AddUpdateViewCb(components::Pose::typeId,
-      std::bind(&Pose3d::UpdateView, this, std::placeholders::_1,
-      std::placeholders::_2));
+      std::bind(&Pose3d::UpdateView<components::Pose>, this,
+      std::placeholders::_1, std::placeholders::_2));
   this->inspector->AddUpdateViewCb(components::WorldPose::typeId,
-      std::bind(&Pose3d::UpdateView, this, std::placeholders::_1,
-      std::placeholders::_2));
+      std::bind(&Pose3d::UpdateView<components::WorldPose>, this,
+      std::placeholders::_1, std::placeholders::_2));
   this->inspector->AddUpdateViewCb(components::WorldPoseCmd::typeId,
-      std::bind(&Pose3d::UpdateView, this, std::placeholders::_1,
-      std::placeholders::_2));
-}
-
-/////////////////////////////////////////////////
-void Pose3d::UpdateView(const EntityComponentManager &_ecm,
-    QStandardItem *_item)
-{
-  if (nullptr == _item)
-    return;
-
-  math::Pose3d pose;
-
-  if (auto poseComp = _ecm.Component<components::Pose>(
-      this->inspector->GetEntity()))
-  {
-    pose = poseComp->Data();
-  }
-  else if (auto worldPoseComp = _ecm.Component<components::WorldPose>(
-      this->inspector->GetEntity()))
-  {
-    pose = worldPoseComp->Data();
-  }
-  else if (auto worldPoseCmdComp = _ecm.Component<components::WorldPoseCmd>(
-      this->inspector->GetEntity()))
-  {
-    pose = worldPoseCmdComp->Data();
-  }
-  else
-  {
-    return;
-  }
-
-  _item->setData(QString("Pose3d"),
-      ComponentsModel::RoleNames().key("dataType"));
-  _item->setData(QList({
-    QVariant(pose.Pos().X()),
-    QVariant(pose.Pos().Y()),
-    QVariant(pose.Pos().Z()),
-    QVariant(pose.Rot().Roll()),
-    QVariant(pose.Rot().Pitch()),
-    QVariant(pose.Rot().Yaw())
-  }), ComponentsModel::RoleNames().key("data"));
+      std::bind(&Pose3d::UpdateView<components::WorldPoseCmd>, this,
+      std::placeholders::_1, std::placeholders::_2));
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/component_inspector/Pose3d.hh
+++ b/src/gui/plugins/component_inspector/Pose3d.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_POSE3D_HH_
+#define IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_POSE3D_HH_
+
+#include <ignition/math/Pose3.hh>
+#include "ignition/gazebo/EntityComponentManager.hh"
+
+#include <QObject>
+#include <QStandardItem>
+
+namespace ignition
+{
+namespace gazebo
+{
+class ComponentInspector;
+namespace inspector
+{
+  /// \brief Handles components that are displayed as a 3D pose:
+  /// * `components::Pose`
+  /// * `components::WorldPose`
+  /// * `components::WorldPoseCmd`
+  class Pose3d : public QObject
+  {
+    Q_OBJECT
+
+    /// \brief Constructor
+    /// \param[in] _inspector The component inspector.
+    public: explicit Pose3d(ComponentInspector *_inspector);
+
+    /// \brief Callback when there are ECM updates.
+    /// \param[in] _ecm Immutable reference to the ECM.
+    /// \param[in] _item Item to update.
+    public: void UpdateView(const EntityComponentManager &_ecm,
+        QStandardItem *_item);
+
+    /// \brief Callback in Qt thread when pose changes.
+    /// \param[in] _x X
+    /// \param[in] _y Y
+    /// \param[in] _z Z
+    /// \param[in] _roll Roll
+    /// \param[in] _pitch Pitch
+    /// \param[in] _yaw Yaw
+    public: Q_INVOKABLE void OnPose(double _x, double _y, double _z,
+        double _roll, double _pitch, double _yaw);
+
+    /// \brief Pointer to the component inspector. This is used to add
+    /// callbacks.
+    private: ComponentInspector *inspector{nullptr};
+  };
+}
+}
+}
+#endif

--- a/src/gui/plugins/component_inspector/Pose3d.hh
+++ b/src/gui/plugins/component_inspector/Pose3d.hh
@@ -18,7 +18,13 @@
 #define IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_POSE3D_HH_
 
 #include <ignition/math/Pose3.hh>
+
+#include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/components/PoseCmd.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
+
+#include "ComponentInspector.hh"
+#include "Types.hh"
 
 #include <QObject>
 #include <QStandardItem>
@@ -45,8 +51,32 @@ namespace inspector
     /// \brief Callback when there are ECM updates.
     /// \param[in] _ecm Immutable reference to the ECM.
     /// \param[in] _item Item to update.
-    public: void UpdateView(const EntityComponentManager &_ecm,
-        QStandardItem *_item);
+    /// \tparam ComponentType Type of component being updated.
+    public:
+    template<typename ComponentType>
+    void UpdateView(const EntityComponentManager &_ecm,
+        QStandardItem *_item)
+    {
+      if (nullptr == _item)
+        return;
+
+      auto comp = _ecm.Component<ComponentType>(this->inspector->GetEntity());
+      if (nullptr == comp)
+        return;
+
+      auto pose = comp->Data();
+
+      _item->setData(QString("Pose3d"),
+          ComponentsModel::RoleNames().key("dataType"));
+      _item->setData(QList({
+        QVariant(pose.Pos().X()),
+        QVariant(pose.Pos().Y()),
+        QVariant(pose.Pos().Z()),
+        QVariant(pose.Rot().Roll()),
+        QVariant(pose.Rot().Pitch()),
+        QVariant(pose.Rot().Yaw())
+      }), ComponentsModel::RoleNames().key("data"));
+    }
 
     /// \brief Callback in Qt thread when pose changes.
     /// \param[in] _x X

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -65,7 +65,7 @@ Rectangle {
   // Send new pose to C++
   function sendPose() {
     // TODO(anyone) There's a loss of precision when these values get to C++
-    componentInspector.onPose(
+    Pose3dImpl.OnPose(
       xItem.value,
       yItem.value,
       zItem.value,

--- a/src/gui/plugins/component_inspector/Types.hh
+++ b/src/gui/plugins/component_inspector/Types.hh
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_TYPES_HH_
+#define IGNITION_GAZEBO_GUI_COMPONENTINSPECTOR_TYPES_HH_
+
+#include <QStandardItem>
+
+#include <ignition/gazebo/Types.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+namespace inspector
+{
+  /// \brief Function definition that a component can use
+  /// to update its UI elements based on changes from the ECM.
+  ///   * _ecm Immutable reference to the ECM
+  ///   * _item Item to be updated
+  /// \sa ComponentInspector::AddUpdateViewCb
+  using UpdateViewCb = std::function<void(const EntityComponentManager &_ecm,
+      QStandardItem *_item)>;
+}
+}
+}
+#endif
+


### PR DESCRIPTION
# 🎉 New feature

Part of
* #191 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

While working on the system inspector, I thought it would be good to adopt some of the refactoring done for the model editor in #1231 to keep the code organized. That work is happening on the `chapulina/6/system_inspector` branch.

This PR ports the approach used on `ComponentModelEditor`:

* All the logic relative to a given display type is moved to its own class / file. 
* I ported `Pose3d` to the new format as an example. It's a comprehensive example because:
    * It registers a callback to update the view (C++ :arrow_right: QML)
    * It has a C++ `Q_INVOKABLE` function which is called from QML  (QML :arrow_right: C++)
* Some differences from `ComponentModelEditor`
    * Renamed `RegisterComponentCreator` to `AddUpdateViewCb` because I think this reflects better what the function is used for
    * Removed the `Entity` parameter from the callback because it can be attained from the inspector
    * I had to expose the `WorldName` and `TransportNode` so `Pose3d` could use them (this isn't used by the model editor because it doesn't send commands through transport directly)
    * One display type can handle multiple component types (i.e. `inspector::Pose3d` works with `components::Pose`, `components::WorldPose` and `components::WorldPoseCmd`)

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Check that all affected components are behaving as always:

1. `ign gazebo rolling_shapes.sdf`
2. See the model poses update as they roll
3. Edit the poses and see the shapes teleported accordingly
4. See how link poses are correct, and read-only
5. `ign gazebo sensors.sdf`
6. See the `WorldPose` component for the sensor entities

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
