### PR TITLE
Fix JointStatePublisher topic name for nested models

### DIFF
--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -161,8 +161,10 @@ void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
       {
         topics.push_back(this->topic);
       }
-      topics.push_back(std::string("/world/") + worldName + "/model/"
-        + this->model.Name(_ecm) + "/joint_state");
+      std::string topicStr =
+          topicFromScopedName(this->model.Entity(), _ecm, false) +
+          "/joint_state";
+      topics.push_back(topicStr);
 
       this->topic = validTopic(topics);
       if (this->topic.empty())

--- a/test/integration/joint_state_publisher_system.cc
+++ b/test/integration/joint_state_publisher_system.cc
@@ -151,8 +151,8 @@ TEST_F(JointStatePublisherTest,
 {
   // Start server
   ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive_nested.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "diff_drive_nested.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -165,7 +165,6 @@ TEST_F(JointStatePublisherTest,
   std::function<void(const msgs::Model &)> jointStateCb =
     [&](const msgs::Model &_msg)
     {
-      std::cerr << "asdfasdf" << std::endl;
       bool foundLeftWheelJoint{false},
            foundRightWheelJoint{false},
            foundCasterWheel{false},

--- a/test/integration/joint_state_publisher_system.cc
+++ b/test/integration/joint_state_publisher_system.cc
@@ -144,3 +144,58 @@ TEST_F(JointStatePublisherTest,
   // Make sure the callback was triggered at least once.
   EXPECT_GT(count, 0);
 }
+
+/////////////////////////////////////////////////
+TEST_F(JointStatePublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(NestedJointPublisher))
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_nested.sdf");
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  server.SetUpdatePeriod(0ns);
+
+  int count = 0;
+  // Check that all of joints are published.
+  std::function<void(const msgs::Model &)> jointStateCb =
+    [&](const msgs::Model &_msg)
+    {
+      std::cerr << "asdfasdf" << std::endl;
+      bool foundLeftWheelJoint{false},
+           foundRightWheelJoint{false},
+           foundCasterWheel{false},
+           extra{false};
+
+      for (int i = 0; i < _msg.joint_size(); ++i)
+      {
+        if (_msg.joint(i).name() == "left_wheel_joint")
+          foundLeftWheelJoint = true;
+        else if (_msg.joint(i).name() == "right_wheel_joint")
+          foundRightWheelJoint = true;
+        else if (_msg.joint(i).name() == "caster_wheel")
+          foundCasterWheel = true;
+        else
+          extra = true;
+      }
+      EXPECT_TRUE(foundLeftWheelJoint);
+      EXPECT_TRUE(foundRightWheelJoint);
+      EXPECT_TRUE(foundCasterWheel);
+      EXPECT_FALSE(extra);
+      count++;
+    };
+
+  transport::Node node;
+  node.Subscribe(
+      "/world/diff_drive_nested/model/vehicle/model/vehicle_nested/joint_state",
+      jointStateCb);
+
+  server.Run(true, 10, false);
+
+  // Make sure the callback was triggered at least once.
+  EXPECT_GT(count, 0);
+}

--- a/test/worlds/diff_drive_nested.sdf
+++ b/test/worlds/diff_drive_nested.sdf
@@ -1,0 +1,255 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="diff_drive_nested">
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name='vehicle'>
+      <link name="base_link">
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.01 0.01 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <model name='vehicle_nested'>
+        <pose>0 0 0.325 0 -0 0</pose>
+
+        <link name='chassis'>
+          <pose>-0.151427 -0 0.175 0 -0 0</pose>
+          <inertial>
+            <mass>1.14395</mass>
+            <inertia>
+              <ixx>0.126164</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>0.416519</iyy>
+              <iyz>0</iyz>
+              <izz>0.481014</izz>
+            </inertia>
+          </inertial>
+          <visual name='visual'>
+            <geometry>
+              <box>
+                <size>2.01142 1 0.568726</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0.5 0.5 1.0 1</ambient>
+              <diffuse>0.5 0.5 1.0 1</diffuse>
+              <specular>0.0 0.0 1.0 1</specular>
+            </material>
+          </visual>
+          <collision name='collision'>
+            <geometry>
+              <box>
+                <size>2.01142 1 0.568726</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+
+        <link name='left_wheel'>
+          <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+          <inertial>
+            <mass>2</mass>
+            <inertia>
+              <ixx>0.145833</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>0.145833</iyy>
+              <iyz>0</iyz>
+              <izz>0.125</izz>
+            </inertia>
+          </inertial>
+          <visual name='visual'>
+            <geometry>
+              <sphere>
+                <radius>0.3</radius>
+              </sphere>
+            </geometry>
+            <material>
+              <ambient>0.2 0.2 0.2 1</ambient>
+              <diffuse>0.2 0.2 0.2 1</diffuse>
+              <specular>0.2 0.2 0.2 1</specular>
+            </material>
+          </visual>
+          <collision name='collision'>
+            <geometry>
+              <sphere>
+                <radius>0.3</radius>
+              </sphere>
+            </geometry>
+          </collision>
+        </link>
+
+        <link name='right_wheel'>
+          <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+          <inertial>
+            <mass>2</mass>
+            <inertia>
+              <ixx>0.145833</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>0.145833</iyy>
+              <iyz>0</iyz>
+              <izz>0.125</izz>
+            </inertia>
+          </inertial>
+          <visual name='visual'>
+            <geometry>
+              <sphere>
+                <radius>0.3</radius>
+              </sphere>
+            </geometry>
+            <material>
+              <ambient>0.2 0.2 0.2 1</ambient>
+              <diffuse>0.2 0.2 0.2 1</diffuse>
+              <specular>0.2 0.2 0.2 1</specular>
+            </material>
+          </visual>
+          <collision name='collision'>
+            <geometry>
+              <sphere>
+                <radius>0.3</radius>
+              </sphere>
+            </geometry>
+          </collision>
+        </link>
+
+        <link name='caster'>
+          <pose>-0.957138 -0 -0.125 0 -0 0</pose>
+          <inertial>
+            <mass>1</mass>
+            <inertia>
+              <ixx>0.1</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>0.1</iyy>
+              <iyz>0</iyz>
+              <izz>0.1</izz>
+            </inertia>
+          </inertial>
+          <visual name='visual'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+            <material>
+              <ambient>0.2 0.2 0.2 1</ambient>
+              <diffuse>0.2 0.2 0.2 1</diffuse>
+              <specular>0.2 0.2 0.2 1</specular>
+            </material>
+          </visual>
+          <collision name='collision'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+          </collision>
+        </link>
+
+        <joint name='left_wheel_joint' type='revolute'>
+          <parent>chassis</parent>
+          <child>left_wheel</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+            <limit>
+              <lower>-1.79769e+308</lower>
+              <upper>1.79769e+308</upper>
+            </limit>
+          </axis>
+        </joint>
+
+        <joint name='right_wheel_joint' type='revolute'>
+          <parent>chassis</parent>
+          <child>right_wheel</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+            <limit>
+              <lower>-1.79769e+308</lower>
+              <upper>1.79769e+308</upper>
+            </limit>
+          </axis>
+        </joint>
+
+        <joint name='caster_wheel' type='ball'>
+          <parent>chassis</parent>
+          <child>caster</child>
+        </joint>
+
+        <plugin
+          filename="ignition-gazebo-diff-drive-system"
+          name="ignition::gazebo::systems::DiffDrive">
+          <left_joint>left_wheel_joint</left_joint>
+          <right_joint>right_wheel_joint</right_joint>
+          <wheel_separation>1.25</wheel_separation>
+          <wheel_radius>0.3</wheel_radius>
+          <max_linear_acceleration>1</max_linear_acceleration>
+          <min_linear_acceleration>-1</min_linear_acceleration>
+          <max_angular_acceleration>2</max_angular_acceleration>
+          <min_angular_acceleration>-2</min_angular_acceleration>
+          <max_linear_velocity>0.5</max_linear_velocity>
+          <min_linear_velocity>-0.5</min_linear_velocity>
+          <max_angular_velocity>1</max_angular_velocity>
+          <min_angular_velocity>-1</min_angular_velocity>
+          <!-- no odom_publisher_frequency defaults to 50 Hz -->
+        </plugin>
+
+        <plugin
+          filename="ignition-gazebo-joint-state-publisher-system"
+          name="ignition::gazebo::systems::JointStatePublisher">
+        </plugin>
+      </model>
+
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

The joint-state-publisher system currently assumes it's always attached to the top level model and hence generates an incorrect topic name for nested models. This PR updates it to generate the correct topic name.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
