### PR TITLE
Add <initial_position> param to JointPositionController system

### DIFF
--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -46,13 +46,13 @@ class ignition::gazebo::systems::JointPositionControllerPrivate
   public: transport::Node node;
 
   /// \brief Joint Entity
-  public: Entity jointEntity;
+  public: Entity jointEntity{kNullEntity};
 
   /// \brief Joint name
   public: std::string jointName;
 
   /// \brief Commanded joint position
-  public: double jointPosCmd;
+  public: double jointPosCmd{0.0};
 
   /// \brief mutex to protect joint commands
   public: std::mutex jointCmdMutex;
@@ -170,6 +170,12 @@ void JointPositionController::Configure(const Entity &_entity,
 
   this->dataPtr->posPid.Init(p, i, d, iMax, iMin, cmdMax, cmdMin, cmdOffset);
 
+
+  if (_sdf->HasElement("initial_position"))
+  {
+    this->dataPtr->jointPosCmd = _sdf->Get<double>("initial_position");
+  }
+
   // Subscribe to commands
   std::string topic = transport::TopicUtils::AsValidTopic("/model/" +
       this->dataPtr->model.Name(_ecm) + "/joint/" + this->dataPtr->jointName +
@@ -206,6 +212,8 @@ void JointPositionController::Configure(const Entity &_entity,
   igndbg << "cmd_min: ["    << cmdMin    << "]"            << std::endl;
   igndbg << "cmd_offset: [" << cmdOffset << "]"            << std::endl;
   igndbg << "Topic: ["      << topic     << "]"            << std::endl;
+  igndbg << "initial_position: [" << this->dataPtr->jointPosCmd << "]"
+         << std::endl;
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -81,6 +81,9 @@ namespace systems
   /// `<topic>` If you wish to listen on a non-default topic you may specify it
   /// here, otherwise the controller defaults to listening on
   /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos".
+  ///
+  /// `<initial_position>` Initial position of a joint. Optional parameter.
+  ///  The default value is 0.
   class JointPositionController
       : public System,
         public ISystemConfigure,

--- a/test/integration/joint_position_controller_system.cc
+++ b/test/integration/joint_position_controller_system.cc
@@ -178,9 +178,16 @@ TEST_F(JointPositionControllerTestFixture,
 
   server.AddSystem(testSystem.systemPtr);
 
-  const std::size_t initIters = 10;
+  // joint pos starts at 0
+  const std::size_t initIters = 1;
   server.Run(true, initIters, false);
   EXPECT_NEAR(0, currentPosition.at(0), TOL);
+
+  // joint moves to initial_position at -2.0
+  const std::size_t initPosIters = 1000;
+  server.Run(true, initPosIters, false);
+  double expectedInitialPosition = -2.0;
+  EXPECT_NEAR(expectedInitialPosition, currentPosition.at(0), TOL);
 
   // Publish command and check that the joint position is set
   transport::Node node;

--- a/test/worlds/joint_position_controller_velocity.sdf
+++ b/test/worlds/joint_position_controller_velocity.sdf
@@ -112,6 +112,7 @@
         <joint_name>j1</joint_name>
         <use_velocity_commands>true</use_velocity_commands>
         <cmd_max>1000</cmd_max>
+        <initial_position>-2.0</initial_position>
       </plugin>
     </model>
   </world>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary
Similar to the [<initial_position>](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo6/src/systems/joint_traj_control/JointTrajectoryController.hh#L82) parameter in the `JointTrajectoryController` system, this PR adds an `<initial_position>` parameter to the `JointPositionController` to let users specifies the initial target pos for a joint.

## Test it

Run the `INTEGRATION_joint_position_controller_system` test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

