### PR TITLE
SceneBroadcaster: Use double for state publish frequency instead of int

### DIFF
--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -225,8 +225,8 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
   /// default update rate of 60Hz. The paused period has a key=true and a
   /// default update rate of 30Hz.
   public: std::map<bool, std::chrono::duration<double, std::ratio<1, 1000>>>
-      statePublishPeriod{{false, std::chrono::milliseconds(1000/60)},
-                         {true,  std::chrono::milliseconds(1000/30)}};
+      statePublishPeriod{{false, std::chrono::duration<double, std::ratio<1, 1000>>(1000/60.0)},
+                         {true,  std::chrono::duration<double, std::ratio<1, 1000>>(1000/30.0)}};
 
   /// \brief Flag used to indicate if the state service was called.
   public: bool stateServiceRequest{false};
@@ -262,16 +262,22 @@ void SceneBroadcaster::Configure(
   this->dataPtr->dyPoseHertz = readHertz.first;
 
   auto stateHertz = _sdf->Get<double>("state_hertz", 60);
-  if (stateHertz.first < 0.0)
+  if (stateHertz.first > 0.0)
   {
-    ignerr << "SceneBroadcaster state_hertz must be non-negative\n";
-  }
-  this->dataPtr->statePublishPeriod[false] =
-      std::chrono::duration<double, std::ratio<1, 1000>>(1000/stateHertz.first);
+    this->dataPtr->statePublishPeriod[false] =
+        std::chrono::duration<double, std::ratio<1, 1000>>(1000 / stateHertz.first);
 
-  // Set the paused update rate to half of the running update rate.
-  this->dataPtr->statePublishPeriod[true] =
-      std::chrono::duration<double, std::ratio<1, 1000>>(1000 / (stateHertz.first * 0.5));
+    // Set the paused update rate to half of the running update rate.
+    this->dataPtr->statePublishPeriod[true] =
+        std::chrono::duration<double, std::ratio<1, 1000>>(1000 / (stateHertz.first * 0.5));
+  }
+  else
+  {
+    using secs_double = std::chrono::duration<double, std::ratio<1>>;
+    ignerr << "SceneBroadcaster state_hertz must be positive, using default (" << 
+        1.0 / secs_double(this->dataPtr->statePublishPeriod[false]).count() <<
+        "Hz)\n";
+  }
 
   // Add to graph
   {

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -176,7 +176,7 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
   public: transport::Node::Publisher dyPosePub;
 
   /// \brief Rate at which to publish dynamic poses
-  public: double dyPoseHertz{60};
+  public: int dyPoseHertz{60};
 
   /// \brief Scene publisher
   public: transport::Node::Publisher scenePub;
@@ -258,11 +258,7 @@ void SceneBroadcaster::Configure(
   this->dataPtr->worldEntity = _entity;
   this->dataPtr->worldName = name->Data();
 
-  auto readHertz = _sdf->Get<double>("dynamic_pose_hertz", 60);
-  if (readHertz.first < 0.0)
-  {
-    ignerr << "SceneBroadcaster dynamic_pose_hertz must be non-negative\n";
-  }
+  auto readHertz = _sdf->Get<int>("dynamic_pose_hertz", 60);
   this->dataPtr->dyPoseHertz = readHertz.first;
 
   auto stateHertz = _sdf->Get<double>("state_hertz", 60);

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -741,6 +741,45 @@ TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RemovedComponent))
   EXPECT_TRUE(hasState);
 }
 
+/////////////////////////////////////////////////
+// Tests https://github.com/ignitionrobotics/ign-gazebo/issues/1414
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DecimalStateHertz))
+{
+  // Start server
+  std::string sdfStr = R"(
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="world with spaces">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+      <state_hertz>0.4</state_hertz>
+    </plugin>
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+  </world>
+</sdf>)";
+  ignition::gazebo::ServerConfig serverConfig;
+  serverConfig.SetSdfString(sdfStr);
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run server
+  server.Run(true, 1, false);
+}
+
 // Run multiple times
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, SceneBroadcasterTest,
     ::testing::Range(1, 2));


### PR DESCRIPTION
…

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #1414 

## Summary
Changed the `state_hertz` publishing frequency data type from `int` to `double`. Previously, worlds with those params set between 0 and 1 would crash due to being rounded to 0 and `state_hertz` being inverted. Note that dynamic_pose_hertz still gets rounded down to 0 as it is represented as `int` in `AdvertiseOptions`, but does not cause a crash.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers