### PR TITLE
Referring to Fuel assets within a heightmap

### DIFF
--- a/examples/worlds/fuel.sdf
+++ b/examples/worlds/fuel.sdf
@@ -107,5 +107,54 @@
       </link>
     </model>
 
+    <!-- Heightmap referring to assets from another model -->
+    <model name="fortress_heightmap">
+      <static>true</static>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <heightmap>
+              <use_terrain_paging>false</use_terrain_paging>
+              <texture>
+                <diffuse>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/dirt_diffusespecular.png</diffuse>
+                <normal>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
+                <size>10</size>
+              </texture>
+              <texture>
+                <diffuse>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/grass_diffusespecular.png</diffuse>
+                <normal>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
+                <size>10</size>
+              </texture>
+              <texture>
+                <diffuse>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fungus_diffusespecular.png</diffuse>
+                <normal>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
+                <size>10</size>
+              </texture>
+              <blend>
+                <min_height>28</min_height>
+                <fade_dist>6</fade_dist>
+              </blend>
+              <blend>
+                <min_height>35</min_height>
+                <fade_dist>18</fade_dist>
+              </blend>
+              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fortress_heightmap.png</uri>
+              <size>257 257 50</size>
+              <pos>0 0 -28</pos>
+            </heightmap>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <heightmap>
+              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fortress_heightmap.png</uri>
+              <size>257 257 50</size>
+              <pos>0 0 -28</pos>
+            </heightmap>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
   </world>
 </sdf>

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -684,8 +684,8 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
   }
   else if (_geom.Type() == sdf::GeometryType::HEIGHTMAP)
   {
-    auto fullPath = asFullPath(_geom.HeightmapShape()->Uri(),
-        _geom.HeightmapShape()->FilePath());
+    auto fullPath = common::findFile(asFullPath(_geom.HeightmapShape()->Uri(),
+        _geom.HeightmapShape()->FilePath()));
     if (fullPath.empty())
     {
       ignerr << "Heightmap geometry missing URI" << std::endl;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1282,8 +1282,8 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm)
             return true;
           }
 
-          auto fullPath = asFullPath(heightmapSdf->Uri(),
-              heightmapSdf->FilePath());
+          auto fullPath = common::findFile(asFullPath(heightmapSdf->Uri(),
+              heightmapSdf->FilePath()));
           if (fullPath.empty())
           {
             ignerr << "Heightmap geometry missing URI" << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Similar to

* https://github.com/ignitionrobotics/ign-gazebo/pull/575
* https://github.com/ignitionrobotics/ign-gazebo/pull/1055

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Make it possible to directly refer to a Fuel asset for heightmap geometries. Try the example:

`ign gazebo -v 4 fuel.sdf`

![image](https://user-images.githubusercontent.com/5751272/160938879-0997b587-3414-4c13-8a79-619f897edc20.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests - I believe we haven't been testing these not to rely on Fuel assets, but I think we could work something out with a local Fuel cache
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
