### PR TITLE
Fix faulty assumption in INTEGRATION_log_system

### DIFF
--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -333,8 +333,7 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogDefaults))
 
   // Test case 1:
   // No path specified on command line. This does not go through
-  // ign.cc, so ignLogDirectory() is not initialized (empty string). Recording
-  // should not take place.
+  // ign.cc, recording should take place in the `.ignition` directory
   {
     // Load SDF
     sdf::Root recordSdfRoot;
@@ -354,8 +353,12 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogDefaults))
     recordServer.Run(true, 200, false);
   }
 
-  // Check ignLogDirectory is empty
-  EXPECT_TRUE(ignLogDirectory().empty());
+  // We should expect to see "auto_default.log"  and "state.tlog"
+  EXPECT_FALSE(ignLogDirectory().empty());
+  EXPECT_TRUE(common::exists(
+        common::joinPaths(ignLogDirectory(), "auto_default.log")));
+  EXPECT_TRUE(common::exists(
+        common::joinPaths(ignLogDirectory(), "state.tlog")));
 
   // Remove artifacts. Recreate new directory
   this->RemoveLogsDir();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

I believe that https://github.com/ignitionrobotics/ign-common/pull/332 uncovered a faulty assumption in the log recorder test.  `ignLogDirectory` should not be empty, it should be initialized to `.ignition` if the console logger is not properly initialized.  This adjusts the assumption to be correct.

I've seen this pop up in CI (https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/8397/testReport/junit/(root)/LogSystemTest/LogDefaults/) and can reproduce locally on the `main` branch.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

