### PR TITLE
Make sure pose publisher creates valid pose topics

### DIFF
--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -251,6 +251,7 @@ void PosePublisher::Configure(const Entity &_entity,
     _sdf->Get<bool>("use_pose_vector_msg", this->dataPtr->usePoseV).first;
 
   std::string poseTopic = scopedName(_entity, _ecm) + "/pose";
+  poseTopic = transport::TopicUtils::AsValidTopic(poseTopic);
   std::string staticPoseTopic = poseTopic + "_static";
 
   if (this->dataPtr->usePoseV)


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix


## Summary

Our model names often have spaces in them. This makes sure the ign topic created by the pose publisher system has valid topics.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

