### PR TITLE
Replace deprecated common::SubMesh::MaterialIndex() with GetMaterialIndex()

### DIFF
--- a/src/systems/collada_world_exporter/ColladaWorldExporter.cc
+++ b/src/systems/collada_world_exporter/ColladaWorldExporter.cc
@@ -228,14 +228,20 @@ class ignition::gazebo::systems::ColladaWorldExporterPrivate
           {
             auto subMeshLock = mesh->SubMeshByIndex(k).lock();
             subm = worldMesh.AddSubMesh(*subMeshLock.get());
-            addSubmeshFunc(subMeshLock->MaterialIndex());
+            if (const auto subMeshIdx = subMeshLock->GetMaterialIndex())
+              addSubmeshFunc(static_cast<int>(subMeshIdx.value()));
+            else
+              addSubmeshFunc(-1);
           }
         }
         else
         {
           auto subMeshLock = mesh->SubMeshByName(subMeshName).lock();
           subm = worldMesh.AddSubMesh(*subMeshLock.get());
-          addSubmeshFunc(subMeshLock->MaterialIndex());
+          if (const auto subMeshIdx = subMeshLock->GetMaterialIndex())
+            addSubmeshFunc(static_cast<int>(subMeshIdx.value()));
+          else
+            addSubmeshFunc(-1);
         }
       }
       else


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

# 🦟 Bug fix

## Summary
This PR replaces deprecated calls to `ignition::common::SubMesh::MaterialIndex()` with the new `GetMaterialIndex()` method that was introduced in https://github.com/ignitionrobotics/ign-common/pull/319.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.