### PR TITLE
remove unused `View::Clone` method

### DIFF
--- a/include/ignition/gazebo/detail/BaseView.hh
+++ b/include/ignition/gazebo/detail/BaseView.hh
@@ -188,8 +188,6 @@ class IGNITION_GAZEBO_VISIBLE BaseView
   /// \sa ToAddEntities
   public: void ClearToAddEntities();
 
-  public: virtual std::unique_ptr<BaseView> Clone() const = 0;
-
   // TODO(adlarkin) make this a std::unordered_set for better performance.
   // We need to make sure nothing else depends on the ordered preserved by
   // std::set first

--- a/include/ignition/gazebo/detail/View.hh
+++ b/include/ignition/gazebo/detail/View.hh
@@ -106,8 +106,6 @@ class View : public BaseView
   /// \brief Documentation inherited
   public: void Reset() override;
 
-  public: std::unique_ptr<BaseView> Clone() const override;
-
   /// \brief A map of entities to their component data. Since tuples are defined
   /// at compile time, we need separate containers that have tuples for both
   /// non-const and const component pointers (calls to ECM::Each can have a
@@ -331,13 +329,6 @@ void View<ComponentTypeTs...>::Reset()
   this->invalidData.clear();
   this->invalidConstData.clear();
   this->missingCompTracker.clear();
-}
-
-//////////////////////////////////////////////////
-template<typename ...ComponentTypeTs>
-std::unique_ptr<BaseView> View<ComponentTypeTs...>::Clone() const
-{
-  return std::make_unique<View<ComponentTypeTs...>>(*this);
 }
 }  // namespace detail
 }  // namespace IGNITION_GAZEBO_VERSION_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

## Summary
A method for cloning views was added in #1249, but it turns out that this method actually isn't needed. This PR removes the unused methods.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.