### PR TITLE
Improve contact sensor / visualization performance

### DIFF
--- a/src/systems/physics/EntityFeatureMap.hh
+++ b/src/systems/physics/EntityFeatureMap.hh
@@ -203,6 +203,20 @@ namespace systems::physics_system
       return nullptr;
     }
 
+    /// \brief Get Gazebo entity that corresponds to the physics entity ID
+    /// \param[in] _id Physics entity ID
+    /// \return If found, returns the corresponding Gazebo entity. Otherwise,
+    /// kNullEntity
+    public: Entity GetByPhysicsId(std::size_t _id) const
+    {
+      auto it = this->entityByPhysId.find(_id);
+      if (it != this->entityByPhysId.end())
+      {
+        return it->second;
+      }
+      return kNullEntity;
+    }
+
     /// \brief Check whether there is a physics entity associated with the given
     /// Gazebo entity
     /// \param[in] _entity Gazebo entity.
@@ -232,6 +246,7 @@ namespace systems::physics_system
       this->entityMap[_entity] = _physicsEntity;
       this->reverseMap[_physicsEntity] = _entity;
       this->physEntityById[_physicsEntity->EntityID()] = _physicsEntity;
+      this->entityByPhysId[_physicsEntity->EntityID()] = _entity;
     }
 
     /// \brief Remove entity from all associated maps
@@ -244,6 +259,7 @@ namespace systems::physics_system
       {
         this->reverseMap.erase(it->second);
         this->physEntityById.erase(it->second->EntityID());
+        this->entityByPhysId.erase(it->second->EntityID());
         this->castCache.erase(_entity);
         this->entityMap.erase(it);
         return true;
@@ -261,6 +277,7 @@ namespace systems::physics_system
       {
         this->entityMap.erase(it->second);
         this->physEntityById.erase(it->first->EntityID());
+        this->entityByPhysId.erase(it->first->EntityID());
         this->castCache.erase(it->second);
         this->reverseMap.erase(it);
         return true;
@@ -282,7 +299,8 @@ namespace systems::physics_system
     public: std::size_t TotalMapEntryCount() const
     {
       return this->entityMap.size() + this->reverseMap.size() +
-             this->castCache.size() + this->physEntityById.size();
+             this->castCache.size() + this->physEntityById.size() +
+             this->entityByPhysId.size();
     }
 
     /// \brief Map from Gazebo entity to physics entities with required features
@@ -294,6 +312,9 @@ namespace systems::physics_system
     /// \brief Map of physics entity IDs to the corresponding physics entity
     /// with required features
     private: std::unordered_map<std::size_t, RequiredEntityPtr> physEntityById;
+
+    /// \brief Map of physics entity IDs to Gazebo entity
+    private: std::unordered_map<std::size_t, Entity> entityByPhysId;
 
     /// \brief Cache map from Gazebo entity to physics entities with optional
     /// features

--- a/src/systems/physics/EntityFeatureMap_TEST.cc
+++ b/src/systems/physics/EntityFeatureMap_TEST.cc
@@ -124,17 +124,18 @@ TEST_F(EntityFeatureMapFixture,
 
   testMap.AddEntity(gazeboWorld1Entity, testWorld1);
 
-  // After adding the entity, there should be one entry each in three maps
-  EXPECT_EQ(3u, testMap.TotalMapEntryCount());
+  // After adding the entity, there should be one entry each in four maps
+  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
   EXPECT_EQ(testWorld1, testMap.Get(gazeboWorld1Entity));
   EXPECT_EQ(gazeboWorld1Entity, testMap.Get(testWorld1));
+  EXPECT_EQ(gazeboWorld1Entity, testMap.GetByPhysicsId(testWorld1->EntityID()));
 
   // Cast to optional feature1
   auto testWorld1Feature1 =
       testMap.EntityCast<TestOptionalFeatures1>(gazeboWorld1Entity);
   ASSERT_NE(nullptr, testWorld1Feature1);
   // After the cast, there should be one more entry in the cache map.
-  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(5u, testMap.TotalMapEntryCount());
 
   // Cast to optional feature2
   auto testWorld1Feature2 =
@@ -142,38 +143,43 @@ TEST_F(EntityFeatureMapFixture,
   ASSERT_NE(nullptr, testWorld1Feature2);
   // After the cast, the number of entries should remain the same because we
   // have not added an entity.
-  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(5u, testMap.TotalMapEntryCount());
 
   // Add another entity
   WorldPtrType testWorld2 = this->engine->ConstructEmptyWorld("world2");
   testMap.AddEntity(gazeboWorld2Entity, testWorld2);
-  EXPECT_EQ(7u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(9u, testMap.TotalMapEntryCount());
   EXPECT_EQ(testWorld2, testMap.Get(gazeboWorld2Entity));
   EXPECT_EQ(gazeboWorld2Entity, testMap.Get(testWorld2));
+  EXPECT_EQ(gazeboWorld2Entity, testMap.GetByPhysicsId(testWorld2->EntityID()));
 
   auto testWorld2Feature1 =
       testMap.EntityCast<TestOptionalFeatures1>(testWorld2);
   ASSERT_NE(nullptr, testWorld2Feature1);
   // After the cast, there should be one more entry in the cache map.
-  EXPECT_EQ(8u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(10u, testMap.TotalMapEntryCount());
 
   auto testWorld2Feature2 =
       testMap.EntityCast<TestOptionalFeatures2>(testWorld2);
   ASSERT_NE(nullptr, testWorld2Feature2);
   // After the cast, the number of entries should remain the same because we
   // have not added an entity.
-  EXPECT_EQ(8u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(10u, testMap.TotalMapEntryCount());
 
   // Remove entitites
   testMap.Remove(gazeboWorld1Entity);
   EXPECT_FALSE(testMap.HasEntity(gazeboWorld1Entity));
   EXPECT_EQ(nullptr, testMap.Get(gazeboWorld1Entity));
   EXPECT_EQ(gazebo::kNullEntity, testMap.Get(testWorld1));
-  EXPECT_EQ(4u, testMap.TotalMapEntryCount());
+  EXPECT_EQ(gazebo::kNullEntity,
+      testMap.GetByPhysicsId(testWorld1->EntityID()));
+  EXPECT_EQ(5u, testMap.TotalMapEntryCount());
 
   testMap.Remove(testWorld2);
   EXPECT_FALSE(testMap.HasEntity(gazeboWorld2Entity));
   EXPECT_EQ(nullptr, testMap.Get(gazeboWorld2Entity));
   EXPECT_EQ(gazebo::kNullEntity, testMap.Get(testWorld2));
+  EXPECT_EQ(gazebo::kNullEntity, testMap.GetByPhysicsId(
+      testWorld2->EntityID()));
   EXPECT_EQ(0u, testMap.TotalMapEntryCount());
 }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3227,15 +3227,17 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
   // Note that we are temporarily storing pointers to elements in this
   // ("allContacts") container. Thus, we must make sure it doesn't get destroyed
   // until the end of this function.
-  auto allContacts = worldCollisionFeature->GetContactsFromLastStep();
+  auto allContacts =
+      std::move(worldCollisionFeature->GetContactsFromLastStep());
+
+  std::unordered_map<ShapePtrType, Entity> contactCache;
   for (const auto &contactComposite : allContacts)
   {
     const auto &contact = contactComposite.Get<WorldShapeType::ContactPoint>();
     auto coll1Entity =
-      this->entityCollisionMap.Get(ShapePtrType(contact.collision1));
+      this->entityCollisionMap.GetByPhysicsId(contact.collision1->EntityID());
     auto coll2Entity =
-      this->entityCollisionMap.Get(ShapePtrType(contact.collision2));
-
+      this->entityCollisionMap.GetByPhysicsId(contact.collision2->EntityID());
 
     if (coll1Entity != kNullEntity && coll2Entity != kNullEntity)
     {
@@ -3334,10 +3336,10 @@ void PhysicsPrivate::EnableContactSurfaceCustomization(const Entity &_world)
       Feature::ContactSurfaceParams<Policy> &_params)
       {
         const auto &contact = _contact.Get<ContactPoint>();
-        auto coll1Entity = this->entityCollisionMap.Get(
-          ShapePtrType(contact.collision1));
-        auto coll2Entity = this->entityCollisionMap.Get(
-          ShapePtrType(contact.collision2));
+        auto coll1Entity = this->entityCollisionMap.GetByPhysicsId(
+          contact.collision1->EntityID());
+        auto coll2Entity = this->entityCollisionMap.GetByPhysicsId(
+          contact.collision2->EntityID());
 
         // check if at least one of the entities wants contact surface
         // customization

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3230,7 +3230,6 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
   auto allContacts =
       std::move(worldCollisionFeature->GetContactsFromLastStep());
 
-  std::unordered_map<ShapePtrType, Entity> contactCache;
   for (const auto &contactComposite : allContacts)
   {
     const auto &contact = contactComposite.Get<WorldShapeType::ContactPoint>();


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

This PR improves contact sensor performance by using a new `GetByPhysicsId` function in `EntityFeatureMap` for faster retrieval of gazebo entities from physics ID.

The original call uses the `Get` function that requires casting to `ShapePtrType` which causes a big performance hit when done many times in a for loop. The cast is needed because the two types are actually different. 

With this change, I noticed that for our application with ~70 contact points, the computation time of the [for loop for building the contact map](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo6/src/systems/physics/Physics.cc#L3231-L3245) drops from 2.x ms to 0.02x ms. This gives us ~10% RTF Improvement with a contact sensor in the world.

You can manually test this with shapes.world:

1. Launch shapes.sdf world
2. spawn 5 more **cylinders** into the world using the GUI tool: this gives ~60 contact points.
3. Go to top right 3 dots menu and open the `Visualize Contacts` GUI Plugin

Before this change, the RTF on my machine is roughly 3x%. After this change, it hovers around 8x%

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

