### PR TITLE
Skip serializing nested model with //pose/@relative_to attribute

### DIFF
--- a/examples/worlds/sensors_demo.sdf
+++ b/examples/worlds/sensors_demo.sdf
@@ -380,6 +380,7 @@
             <image>
               <width>320</width>
               <height>240</height>
+              <format>L8</format>
             </image>
             <clip>
               <near>0.1</near>

--- a/include/ignition/gazebo/components/Model.hh
+++ b/include/ignition/gazebo/components/Model.hh
@@ -59,6 +59,10 @@ namespace serializers
           // Skip serializing models with //pose/@relative_to attribute
           // since deserialization will fail. This could be a nested model.
           // see https://github.com/ignitionrobotics/ign-gazebo/issues/1071
+          // Once https://github.com/ignitionrobotics/sdformat/issues/820 is
+          // resolved, there should be an API that returns sdf::Errors objects
+          // instead of printing console msgs so it would be easier to ignore
+          // specific errors in Deserialize.
           static bool warned = false;
           if (!warned)
           {


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Not a bug but suppresses misleading error messages.
Related issue: https://github.com/ignitionrobotics/ign-gazebo/issues/1071

## Summary

Details are described in https://github.com/ignitionrobotics/ign-gazebo/issues/1071. This PR prevents serialization of a model component if it has the `//pose/@relative_to` attribute to avoid flooding the console with error messages when there are multiple models with nested models using this attribute. Since model deserialization with  `//pose/@relative_to` never worked, this should not affect existing behavior. I believe the model serialization / deserialization functionality is mainly used by the component editor.

More info:

Problem is that during ign-gazebo serialization, a nested model is treated as an individual (top level) model ([wrapped by](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo6/include/ignition/gazebo/components/Model.hh#L54) `<sdf>` tag) and serialized to string. However, when ign-gazebo tries to deserialize it, sdformat sees it a top level model so the `//pose/@relative_to` attribute causes `root.LoadSdfString` to fail. It then produces these error messages:

```
Error:   Could not find the 'robot' element in the xml file
         at line 80 in /build/urdfdom-YMMa9X/urdfdom-1.0.0/urdf_parser/src/model.cpp
Error [parser_urdf.cc:3255] Unable to call parseURDF on robot model
Error [parser.cc:820] parse as old deprecated model file failed.
[GUI] [Err] [Model.hh:73] Unable to unserialize sdf::Model
```

I think sdformat is doing its job correctly when it fails to parse the sdf string. Maybe we need a way for ign-gazebo to tell sdformat to skip this check, or have a better serialization / deserialization method for [nested] models.

I also changed the verbosity level for serialization / serialization issue from error to warning.

See https://github.com/ignitionrobotics/ign-gazebo/issues/1071 on how to reproduce the issue.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

