### PR TITLE
python: release GIL when running server

### DIFF
--- a/examples/scripts/python_api/testFixture.py
+++ b/examples/scripts/python_api/testFixture.py
@@ -23,7 +23,6 @@
 # python3 examples/scripts/python_api/helperFixture.py
 
 import os
-import time
 
 from ignition.common import set_verbosity
 from ignition.gazebo import TestFixture, World, world_entity
@@ -75,10 +74,7 @@ helper.on_pre_update(on_pre_udpate_cb)
 helper.finalize()
 
 server = helper.server()
-server.run(False, 1000, False)
-
-while(server.is_running()):
-    time.sleep(0.1)
+server.run(True, 1000, False)
 
 print('iterations ', iterations)
 print('post_iterations ', post_iterations)

--- a/python/src/ignition/gazebo/Server.cc
+++ b/python/src/ignition/gazebo/Server.cc
@@ -35,6 +35,7 @@ void defineGazeboServer(pybind11::object module)
   .def(pybind11::init<ignition::gazebo::ServerConfig &>())
   .def(
     "run", &ignition::gazebo::Server::Run,
+    pybind11::call_guard<pybind11::gil_scoped_release>(),
     "Run the server. By default this is a non-blocking call, "
     " which means the server runs simulation in a separate thread. Pass "
     " in true to the _blocking argument to run the server in the current "

--- a/python/test/testFixture_TEST.py
+++ b/python/test/testFixture_TEST.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import time
 import unittest
 
 from ignition.common import set_verbosity
@@ -56,10 +55,7 @@ class TestTestFixture(unittest.TestCase):
         helper.finalize()
 
         server = helper.server()
-        server.run(False, 1000, False)
-
-        while(server.is_running()):
-            time.sleep(0.1)
+        server.run(True, 1000, False)
 
         self.assertEqual(1000, pre_iterations)
         self.assertEqual(1000, iterations)

--- a/tutorials/python_interfaces.md
+++ b/tutorials/python_interfaces.md
@@ -37,9 +37,7 @@ helper.finalize()
   - **Step 5**: Run the server
 
 ```python
-server.run(False, 1000, False)
-while(server.is_running()):
-    time.sleep(0.1)
+server.run(True, 1000, False)
 ```
 
 # Run the example


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Since running the server can be a blocking function, we need to release the GIL so that other Python threads can run. This also means we no longer need to poll for the server to finish running by setting the blocking argument to True.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
