### PR TITLE
python: remove semicolons

### DIFF
--- a/examples/scripts/python_api/testFixture.py
+++ b/examples/scripts/python_api/testFixture.py
@@ -48,7 +48,7 @@ def on_pre_udpate_cb(_info, _ecm):
     pre_iterations += 1
     if first_iteration:
         first_iteration = False
-        world_e = world_entity(_ecm);
+        world_e = world_entity(_ecm)
         print('World entity is ', world_e)
         w = World(world_e)
         v = w.gravity(_ecm)

--- a/python/test/testFixture_TEST.py
+++ b/python/test/testFixture_TEST.py
@@ -40,7 +40,7 @@ class TestTestFixture(unittest.TestCase):
         def on_pre_udpate_cb(_info, _ecm):
             global pre_iterations
             pre_iterations += 1
-            world_e = world_entity(_ecm);
+            world_e = world_entity(_ecm)
             self.assertEqual(1, world_e)
             w = World(world_e)
             v = w.gravity(_ecm)


### PR DESCRIPTION
Python doesn't use semicolons (although it does ignore them).
