### PR TITLE
Fix running simulation with no world specified on the command line

### DIFF
--- a/include/ignition/gazebo/ServerConfig.hh
+++ b/include/ignition/gazebo/ServerConfig.hh
@@ -172,7 +172,8 @@ namespace ignition
       /// Setting the SDF file will override any value set by `SetSdfString`.
       ///
       /// \param[in] _file Full path to an SDF file.
-      /// \return (reserved for future use)
+      /// \return True if the file was set, false if the file was not set.
+      /// The file will not be set if the provide _file string is empty.
       public: bool SetSdfFile(const std::string &_file);
 
       /// \brief Get the SDF file that has been set. An empty string will be

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -327,6 +327,9 @@ ServerConfig::~ServerConfig() = default;
 //////////////////////////////////////////////////
 bool ServerConfig::SetSdfFile(const std::string &_file)
 {
+  if (_file.empty())
+    return false;
+
   this->dataPtr->source = ServerConfig::SourceType::kSdfFile;
   this->dataPtr->sdfFile = _file;
   this->dataPtr->sdfString = "";


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

Running `ign gazbeo -v 4` terminates on start, when it should run an empty world.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.