### PR TITLE
Fix finding DART on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(ignition-gazebo6 VERSION 6.9.0)
 # Find ignition-cmake
 #============================================================================
 # If you get an error at this line, you need to install ignition-cmake
-find_package(ignition-cmake2 2.8.0 REQUIRED)
+find_package(ignition-cmake2 2.12.0 REQUIRED)
 
 #============================================================================
 # Configure the project

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -128,7 +128,7 @@ ign_build_tests(TYPE INTEGRATION
 # For INTEGRATION_physics_system, we need to check what version of DART is
 # available so that we can disable tests that are unsupported by the particular
 # version of physics engine
-ign_find_package(DART)
+ign_find_package(DART CONFIG)
 if (DART_FOUND)
   # Only adding include directories, no need to link against DART to check version
   target_include_directories(INTEGRATION_physics_system SYSTEM PRIVATE ${DART_INCLUDE_DIRS})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -128,7 +128,7 @@ ign_build_tests(TYPE INTEGRATION
 # For INTEGRATION_physics_system, we need to check what version of DART is
 # available so that we can disable tests that are unsupported by the particular
 # version of physics engine
-ign_find_package(DART QUIET)
+ign_find_package(DART)
 if (DART_FOUND)
   # Only adding include directories, no need to link against DART to check version
   target_include_directories(INTEGRATION_physics_system SYSTEM PRIVATE ${DART_INCLUDE_DIRS})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -128,7 +128,12 @@ ign_build_tests(TYPE INTEGRATION
 # For INTEGRATION_physics_system, we need to check what version of DART is
 # available so that we can disable tests that are unsupported by the particular
 # version of physics engine
+cmake_policy(PUSH)
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 ign_find_package(DART CONFIG)
+cmake_policy(POP)
 if (DART_FOUND)
   # Only adding include directories, no need to link against DART to check version
   target_include_directories(INTEGRATION_physics_system SYSTEM PRIVATE ${DART_INCLUDE_DIRS})


### PR DESCRIPTION
# 🦟 Bug fix

Fixes cmake logic for finding DART for purposes of Physics System test.

## Summary

There are some tests in the physics system that depend on the version of DART available on the system. In particular, Ubuntu 20.04 has DART 6.9.2, so any tests requiring features from 6.10 need to be disabled. This is accomplished by calling `ign_find_package(DART)` in `test/integration/CMakeLists.txt` and checking the available version.

This logic is now working properly on macOS, which has DART 6.12.1 from homebrew-core, but still does not run the tests that require 6.10:

* https://build.osrfoundation.org/view/ign-fortress/job/ignition_gazebo-ci-ign-gazebo6-homebrew-amd64/84/testReport/(root)/PhysicsSystemFixtureWithDart6_10/

~~~
165: [  SKIPPED ] PhysicsSystemFixtureWithDart6_10.JointPositionLimitsCommandComponent
165: [  SKIPPED ] PhysicsSystemFixtureWithDart6_10.JointVelocityLimitsCommandComponent
165: [  SKIPPED ] PhysicsSystemFixtureWithDart6_10.JointEffortLimitsCommandComponent
165/237 Test #165: INTEGRATION_physics_system .............................   Passed    8.87 sec
~~~

This pull request does the following:

* https://github.com/ignitionrobotics/ign-gazebo/commit/c8a463b75283ed6179ba7b8bb44d91dcb27ab931: find DART without `QUIET`. It was failing to find DART the physics library and was using a `FindDart` cmake module for a different package, but `QUIET` was hiding that.
* https://github.com/ignitionrobotics/ign-gazebo/commit/2e4eced5bd87092e27284e31e843e951c570a304: use `CONFIG` keyword to actually find DART correctly on macOS
* https://github.com/ignitionrobotics/ign-gazebo/commit/9f8c3a2ed236ba882040b2801471a010bcca8018: fix a cmake warning that pops up

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
